### PR TITLE
rewrite LSP response parser (s:_on_lsp_stdout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ endfunction
 function! s:on_notification(id, data, event)
     if lsp#lspClient#is_error(a:data.response)
         echom 'lsp('.a:id.'):notification:notification error receieved for '.a:data.request.method
+    elseif lsp#lspClient#is_server_instantiated_notification(a:data)
+        " request key will not be present in a:data
+        " make sure to check before accessing a:data.request in order to prevent unhandled errors
+        echom 'lsp('.a:id.'):notification:notification success receieved for '.json_encode(a:data.response)
     else
         echom 'lsp('.a:id.'):notification:notification success receieved for '.a:data.request.method
     endif
@@ -44,7 +48,7 @@ if g:lsp_id > 0
         \ 'method': 'initialize',
         \ 'params': {
             \ 'capabilities': {},
-            \ 'rootPath': 'file://D:/go/src/github.com/nsf/gocode'
+            \ 'rootPath': 'file:///D:/go/src/github.com/nsf/gocode'
         \ },
         \ 'on_notification': function('s:on_notification1')
    \ })


### PR DESCRIPTION
* it now supports variable number of headers where at least one (Content-Length) is required. Current parser used to always expect Content-Length followed by Content-Type. This means it can't parse response messages from https://github.com/sourcegraph/javascript-typescript-langserver since it only contains Content-Length. The implementation should now adhere to the spec.
* added `lsp#lspClient#is_server_instantiated_notification`
* listen to notifications instantiated by server (`javascript-typescript-langserver` sends custom notifications message `fs/readDir`, `fs/readFile`. In old parser there was no way to get these messages. Now it is possible to get these messages. This means if you now try to access `a:data.request` in `on_notification` unhandleded error will be thrown since `request` key will not be present in `a:data`
```viml
function! s:on_notification(id, data, event)
    if lsp#lspClient#is_error(a:data.response)
        echom 'lsp('.a:id.'):notification:notification error receieved for '.a:data.request.method
    elseif lsp#lspClient#is_server_instantiated_notification(a:data)
        echom 'lsp('.a:id.'):notification:server instantiated notification received '.a:data.response
    else
        echom 'lsp('.a:id.'):notification:notification success receieved for '.a:data.request.method
    endif
endfunction
```
* added `s:trim` which is used to trim header key and values
* changed internal representation of `s:lsp_clients.on_notifications.stdout` (Public api consumers of vim-lsp shouldn't be affected by this)