### PR TITLE
rename lsp#lspClient to lsp#client

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -185,31 +185,31 @@ endfunction
 
 " public apis {{{
 
-let lsp#lspClient#text_document_sync_kind_none = s:lsp_text_document_sync_kind_none
-let lsp#lspClient#text_document_sync_kind_full = s:lsp_text_document_sync_kind_full
-let lsp#lspClient#text_document_sync_kind_incremental = s:lsp_text_document_sync_kind_incremental
+let lsp#client#text_document_sync_kind_none = s:lsp_text_document_sync_kind_none
+let lsp#client#text_document_sync_kind_full = s:lsp_text_document_sync_kind_full
+let lsp#client#text_document_sync_kind_incremental = s:lsp_text_document_sync_kind_incremental
 
-function! lsp#lspClient#start(opts) abort
+function! lsp#client#start(opts) abort
     return s:lsp_start(a:opts)
 endfunction
 
-function! lsp#lspClient#stop(client_id) abort
+function! lsp#client#stop(client_id) abort
     return s:lsp_stop(a:client_id)
 endfunction
 
-function! lsp#lspClient#send(client_id, opts) abort
+function! lsp#client#send(client_id, opts) abort
     return s:lsp_send_request(a:client_id, a:opts)
 endfunction
 
-function! lsp#lspClient#get_last_request_id(client_id) abort
+function! lsp#client#get_last_request_id(client_id) abort
     return s:lsp_get_last_request_id(a:client_id)
 endfunction
 
-function! lsp#lspClient#is_error(notification) abort
+function! lsp#client#is_error(notification) abort
     return s:lsp_is_error(a:notification)
 endfunction
 
-function! lsp#lspClient#is_server_instantiated_notification(notification)
+function! lsp#client#is_server_instantiated_notification(notification)
     return s:is_server_instantiated_notification(a:notification)
 endfunction
 

--- a/example.vim
+++ b/example.vim
@@ -88,13 +88,13 @@ function! s:start_lsp() abort
     if s:lsp_id <= 0
         let l:tsconfig_json_path = s:find_nearest_file(bufnr('%'), 'tsconfig.json')
         if !empty(l:tsconfig_json_path)
-            let s:lsp_id = lsp#lspClient#start({
+            let s:lsp_id = lsp#client#start({
                 \ 'cmd': s:cmd,
                 \ 'on_stderr': function('s:on_stderr'),
                 \ 'on_exit': function('s:on_exit'),
                 \ })
             if s:lsp_id > 0
-                let s:lsp_last_request_id = lsp#lspClient#send(s:lsp_id, {
+                let s:lsp_last_request_id = lsp#client#send(s:lsp_id, {
                     \ 'method': 'initialize',
                     \ 'params': {
                     \   'capabilities': {},
@@ -122,13 +122,13 @@ function! s:on_exit(id, status, event) abort
 endfunction
 
 function! s:on_initialize(id, data, event) abort
-    if lsp#lspClient#is_error(a:data.response)
+    if lsp#client#is_error(a:data.response)
         let s:lsp_init_response = {}
     else
         let s:lsp_init_capabilities = a:data.response.result.capabilities
         if s:lsp_last_request_id > 0
             " javascript-typescript-langserver doesn't support this method so don't call it
-            " let s:lsp_last_request_id = lsp#lspClient#send(s:lsp_id, {
+            " let s:lsp_last_request_id = lsp#client#send(s:lsp_id, {
             "     \ 'method': 'textDocument/didOpen',
             "     \ 'params': {
             "     \   'textDocument': s:get_text_document(),
@@ -144,7 +144,7 @@ function! s:goto_definition() abort
         echom 'Go to definition not supported by the language server'
         return
     endif
-    let s:lsp_last_request_id = lsp#lspClient#send(s:lsp_id, {
+    let s:lsp_last_request_id = lsp#client#send(s:lsp_id, {
         \ 'method': 'textDocument/definition',
         \ 'params': {
         \   'textDocument': s:get_text_document_identifier(),
@@ -155,7 +155,7 @@ function! s:goto_definition() abort
 endfunction
 
 function! s:on_goto_definition(id, data, event) abort
-    if lsp#lspClient#is_error(a:data.response)
+    if lsp#client#is_error(a:data.response)
         echom 'error occurred going to definition'. json_encode(a:data)
         return
     endif
@@ -180,7 +180,7 @@ function! s:find_references() abort
         echom 'FindReferences not supported by the language server'
         return
     endif
-    let s:lsp_last_request_id = lsp#lspClient#send(s:lsp_id, {
+    let s:lsp_last_request_id = lsp#client#send(s:lsp_id, {
         \ 'method': 'textDocument/references',
         \ 'params': s:get_reference_params(),
         \ 'on_notification': function('s:on_find_references')
@@ -188,7 +188,7 @@ function! s:find_references() abort
 endfunction
 
 function! s:on_find_references(id, data, event) abort
-    if lsp#lspClient#is_error(a:data.response)
+    if lsp#client#is_error(a:data.response)
         echom 'error occurred finding references'. json_encode(a:data)
         return
     endif


### PR DESCRIPTION
this is a breaking change for those who are depending directly in `vim-lsp` repository. address #6