### PR TITLE
WIP: full language server manager implementation

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1,4 +1,8 @@
 let s:enabled = 0
+let s:already_setup = 0
+
+" do nothing, place it here only to avoid the message
+autocmd User lsp_setup silent
 
 function! lsp#log(...) abort
     if !empty(g:lsp_log_file)
@@ -9,6 +13,11 @@ endfunction
 function! lsp#enable() abort
     if s:enabled
         return
+    endif
+    if !s:already_setup
+        call lsp#log('lsp-core', 'lsp_setup')
+        doautocmd User lsp_setup
+        let s:already_setup = 1
     endif
     let s:enabled = 1
     call lsp#log('lsp-core', 'enabling')

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -204,6 +204,7 @@ function! lsp#initialize(name, ...) abort
 endfunction
 
 function! s:on_stderr(id, data, event) abort
+    call lsp#log('lsp-core', 'on_stderr', a:id, a:data)
 endfunction
 
 function! s:on_exit(id, data, event) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1,0 +1,39 @@
+let s:enabled = 0
+
+function! lsp#log(...) abort
+    if !empty(g:lsp_log_file)
+        call writefile([json_encode(a:000)], g:lsp_log_file, 'a')
+    endif
+endfunction
+
+function! lsp#enable() abort
+    if s:enabled
+        return
+    endif
+    let s:enabled = 1
+    call lsp#log('lsp-core', 'enabling')
+    call s:register_events()
+    call lsp#log('lsp-core', 'enabled')
+endfunction
+
+function! lsp#disable() abort
+    if !s:enabled
+        return
+    endif
+    let s:enabled = 0
+    call lsp#log('lsp-core', 'disabled')
+endfunction
+
+function! s:register_events() abort
+    call lsp#log('lsp-core', 'registering events')
+    augroup lsp
+        autocmd! * <buffer>
+        autocmd BufReadPost * call s:on_text_document_did_open()
+    augroup END
+    call s:on_text_document_did_open()
+    call lsp#log('lsp-core', 'registered events')
+endfunction
+
+function! s:on_text_document_did_open() abort
+    call lsp#log('lsp-core', 's:on_text_document_did_open()')
+endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -29,6 +29,8 @@ function! s:register_events() abort
     augroup lsp
         autocmd! * <buffer>
         autocmd BufReadPost * call s:on_text_document_did_open()
+        autocmd BufWritePost * call s:on_text_document_did_save()
+        autocmd TextChangedI * call s:on_text_document_did_change()
     augroup END
     call s:on_text_document_did_open()
     call lsp#log('lsp-core', 'registered events')
@@ -36,4 +38,12 @@ endfunction
 
 function! s:on_text_document_did_open() abort
     call lsp#log('lsp-core', 's:on_text_document_did_open()')
+endfunction
+
+function! s:on_text_document_did_save() abort
+    call lsp#log('lsp-core', 's:on_text_document_did_save()')
+endfunction
+
+function! s:on_text_document_did_change() abort
+    call lsp#log('lsp-core', 's:on_text_document_did_change()')
 endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1,10 +1,6 @@
 let s:enabled = 0
 let s:already_setup = 0
-let s:servers = {} " {
-                   "   'tsc': {
-                   "      \ 'name': 'tsc',
-                   "   \ }
-                   " \ }
+let s:servers = {} " { server_name: server_info }
 
 " do nothing, place it here only to avoid the message
 autocmd User lsp_setup silent
@@ -40,7 +36,7 @@ function! lsp#disable() abort
 endfunction
 
 " @params
-" info = {
+" server_info = {
 "    'name': 'tsc',             required
 "    'whitelist': [],           optional
 "    'blacklist': [],           optional
@@ -54,14 +50,14 @@ endfunction
 " au User lsp_setup call lsp#register_server({
 "   \ 'name': 'tsc',
 "   \ })
-function! lsp#register_server(info) abort
-    call lsp#log('lsp-core', 'registering server', a:info['name'])
-    if has_key(s:servers, a:info['name'])
-        call lsp#log('lsp-core', 'server already registered', a:info['name'])
+function! lsp#register_server(server_info) abort
+    call lsp#log('lsp-core', 'registering server', a:server_info['name'])
+    if has_key(s:servers, a:server_info['name'])
+        call lsp#log('lsp-core', 'server already registered', a:server_info['name'])
         return -1
     endif
-    let s:servers[a:info['name']] = a:info
-    call lsp#log('lsp-core', 'registered server', a:info['name'])
+    let s:servers[a:server_info['name']] = a:server_info
+    call lsp#log('lsp-core', 'registered server', a:server_info['name'])
     return 1
 endfunction
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -203,7 +203,7 @@ function! lsp#initialize(name, ...) abort
     if len(a:000) == 0
         let l:options = {}
     else
-        let l:options = a:0
+        let l:options = a:1
     endif
     if has_key(l:options, 'root_uri')
         let l:root_uri = type(l:options['root_uri']) == type('') ? l:options['root_uri'] : l:options['root_uri'](l:server_info)
@@ -221,6 +221,7 @@ function! lsp#initialize(name, ...) abort
         \   'capabilities': {},
         \   'root_uri': l:root_uri,
         \ },
+        \ 'on_notification': function('s:on_notification_wrapper', [a:name, l:options])
         \ })
 endfunction
 
@@ -323,3 +324,9 @@ else
         return 'file://' . a:path
     endfunction
 endif
+
+function! s:on_notification_wrapper(name, options, id, data, event) abort
+    if has_key(a:options, 'callback')
+        call a:options['callback'](a:name, a:data)
+    endif
+endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -151,6 +151,27 @@ function! lsp#start_server(name, ...) abort
     endif
 endfunction
 
+" @returns
+"   -2: server not running
+"   -1: server not registered
+"    1: server force stopped
+function! lsp#exit(name) abort
+    if !has_key(s:servers, a:name)
+        call lsp#log('lsp-core', 'server not registered', a:name)
+        return -1
+    endif
+    let l:server = s:servers[a:name]
+    " for now always force exit
+    if has_key(l:server, 'lsp_id')
+        call lsp#log('lsp-core', 'force exit', a:name, l:server['lsp_id'])
+        call lsp#client#stop(l:server['lsp_id'])
+        return 1
+    else
+        call lsp#log('lsp-core', 'server not running', a:name)
+        return -2
+    endif
+endfunction
+
 " @params
 "   name: name of the server                                        " required
 "   options: {                                                      " optional

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -44,17 +44,23 @@ endfunction
 "
 " @return
 "   -1: Server already registered
+"   -2: Protocol version not specified
 "    1: Server registered successfully
 "
 " @example
 " au User lsp_setup call lsp#register_server({
 "   \ 'name': 'tsc',
+"   \ 'protocol_version': '2.0',
 "   \ })
 function! lsp#register_server(server_info) abort
     call lsp#log('lsp-core', 'registering server', a:server_info['name'])
     if has_key(s:servers, a:server_info['name'])
         call lsp#log('lsp-core', 'server already registered', a:server_info['name'])
         return -1
+    endif
+    if !has_key(a:server_info, 'protocol_version')
+        call lsp#log('lsp-core', 'protocol_version not specified', a:server_info['name'])
+        return -2
     endif
     let s:servers[a:server_info['name']['server_info']] = a:server_info
     call lsp#log('lsp-core', 'registered server', a:server_info['name'])

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -14,13 +14,13 @@ function! lsp#enable() abort
     if s:enabled
         return
     endif
+    call lsp#log('lsp-core', 'enabling')
     if !s:already_setup
         call lsp#log('lsp-core', 'lsp_setup')
         doautocmd User lsp_setup
         let s:already_setup = 1
     endif
     let s:enabled = 1
-    call lsp#log('lsp-core', 'enabling')
     call s:register_events()
     call lsp#log('lsp-core', 'enabled')
 endfunction
@@ -29,6 +29,7 @@ function! lsp#disable() abort
     if !s:enabled
         return
     endif
+    call s:unregister_events()
     let s:enabled = 0
     call lsp#log('lsp-core', 'disabled')
 endfunction
@@ -36,13 +37,22 @@ endfunction
 function! s:register_events() abort
     call lsp#log('lsp-core', 'registering events')
     augroup lsp
-        autocmd! * <buffer>
+        autocmd!
         autocmd BufReadPost * call s:on_text_document_did_open()
         autocmd BufWritePost * call s:on_text_document_did_save()
         autocmd TextChangedI * call s:on_text_document_did_change()
     augroup END
-    call s:on_text_document_did_open()
     call lsp#log('lsp-core', 'registered events')
+    call lsp#log('lsp-core', 'calling s:on_text_document_did_open() from s:register_events()')
+    call s:on_text_document_did_open()
+endfunction
+
+function! s:unregister_events() abort
+    call lsp#log('lsp-core', 'unregistering events')
+    augroup lsp
+        autocmd!
+    augroup END
+    call lsp#log('lsp-core', 'unregistered events')
 endfunction
 
 function! s:on_text_document_did_open() abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1,5 +1,10 @@
 let s:enabled = 0
 let s:already_setup = 0
+let s:servers = {} " {
+                   "   'tsc': {
+                   "      \ 'name': 'tsc',
+                   "   \ }
+                   " \ }
 
 " do nothing, place it here only to avoid the message
 autocmd User lsp_setup silent
@@ -32,6 +37,32 @@ function! lsp#disable() abort
     call s:unregister_events()
     let s:enabled = 0
     call lsp#log('lsp-core', 'disabled')
+endfunction
+
+" @params
+" info = {
+"    'name': 'tsc',             required
+"    'whitelist': [],           optional
+"    'blacklist': [],           optional
+" }
+"
+" @return
+"   -1: Server already registered
+"    1: Server registered successfully
+"
+" @example
+" au User lsp_setup call lsp#register_server({
+"   \ 'name': 'tsc',
+"   \ })
+function! lsp#register_server(info) abort
+    call lsp#log('lsp-core', 'registering server', a:info['name'])
+    if has_key(s:servers, a:info['name'])
+        call lsp#log('lsp-core', 'server already registered', a:info['name'])
+        return -1
+    endif
+    let s:servers[a:info['name']] = a:info
+    call lsp#log('lsp-core', 'registered server', a:info['name'])
+    return 1
 endfunction
 
 function! s:register_events() abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1,6 +1,6 @@
 let s:enabled = 0
 let s:already_setup = 0
-let s:servers = {} " { server_name: server_info }
+let s:servers = {} " { server_name: { server_info } }
 
 " do nothing, place it here only to avoid the message
 autocmd User lsp_setup silent
@@ -56,7 +56,7 @@ function! lsp#register_server(server_info) abort
         call lsp#log('lsp-core', 'server already registered', a:server_info['name'])
         return -1
     endif
-    let s:servers[a:server_info['name']] = a:server_info
+    let s:servers[a:server_info['name']['server_info']] = a:server_info
     call lsp#log('lsp-core', 'registered server', a:server_info['name'])
     return 1
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -2,3 +2,10 @@ if exists('g:lsp_loaded')
     finish
 endif
 let g:lsp_loaded = 1
+
+let g:lsp_auto_enable = get(g:, 'lsp_auto_enable', 1)
+let g:lsp_log_file = get(g:, 'lsp_log_file', '')
+
+if g:lsp_auto_enable
+    au VimEnter * call lsp#enable()
+endif

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -1,0 +1,4 @@
+if exists('g:lsp_loaded')
+    finish
+endif
+let g:lsp_loaded = 1


### PR DESCRIPTION
Do not merge. This is WIP.

After few months of break from LSP and working on [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim), it is time to give LSP a try again. Hopefully this time we have more servers that works on Linux, Mac and Windows and would not be disappointing like last year.
Privately I have re-implemented LSP (manager not client) multiple times but I have only made the first one open source which is what is seen in `example.vim`. Throughout this process I have actually learned a lot about lsp and differences in different server implementations as well as os differences.

Here are some of the goals I have. (There are some missing features but I would like to get something usable that I can use it daily instead of trying to be a full featured LSP plugin first and never actually using it)

- [x] `lsp#enable()` and `lsp#disable()`
- [x] `lsp#log(...)` with `g:lsp_log_file`
- [x] `autocmd lsp_setup` for lazy setup
- [ ] `lsp#utils#find_nearest_parent_directory(path, directoryname)`
- [ ] `lsp#utils#find_nearest_parent_file(path, filename)`
- [x] Register lsp servers `lsp#register_server`. Need to support multiple servers for same file types.
- [x] Implement `lsp#start_server('name', options)`.
- [x] implement cleanup for lsp server when exits unexpectedly i.e., handle `on_exit` for lsp servers.
- [x] implement `s:parse_major_version(version)`
- [x] implement `s:path_to_uri()` which works on windows with shell slash enabled and disabled as well as *nix
- [x] implement `s:get_default_root_uri()` - use cwd if `root_uri` not specified when starting or registering the server
- [x] log `on_stderr`
- [x] implement `lsp#exit(name)`
- [x] implement `lsp#initialize(name, options)` - initialize request and initialized notification
- [ ] window/logMessage
- [ ] textDocument/didOpen
- [ ] textDocument/didChange
- [ ] textDocument/willSave
- [ ] textDocument/didSave
- [ ] textDocument/didClose
- [ ] textDocument/hover
- [ ] textDocument/definition
- [ ] textDocument/references
- [ ] workspace/symbol
- [ ] support LSP 2.0 and 3.0 or any new future version.
- [ ] `let g:lsp_enable_default_mappings = 0`
- [ ] expose callback apis so users can use it on their favorite interfaces like `CtrlP`, `Unite` or `Denite` as well as normal commands to it defaults to vim loclist.

Here are other nice to have that is of lower priority and will most likely be in different PRs. The goal is to actually get the MVP and dog-food it and see how practical it is rather than just having bunch of features.

- [ ] textDocument/completion - This will be provided as [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim) source
- [ ] Implement automatic lsp server start. Most likely need to be smarter, for example: typescript server should most likely only start if it finds `tsconfig.json`
- [ ] sign column for validation, warning and errors
- [ ] textDocument/rename
- [ ] window/showMessage
- [ ] telemetry/event
- [ ] `lsp#unregister_server`.
- [ ] Port `lsp#client` to lua. The goal is not to port everything to lua, only the heavy parsing of the lsp protocol. This means if lua is supported it will use lua else fallback to vim script. Neovim recently merged lua changes so this would be interesting to see how it progresses. If the vimscript implementation is slow then I have no choice but to convert everything to lua and might only support neovim remote plugins then.