### PR TITLE
Make lsp#complete() synchronous (by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,15 @@ endif
 
 ## auto-complete
 
-`vim-lsp` by default only provides basic omnifunc support for autocomplete.
+`vim-lsp` by default only provides basic omnifunc support for autocomplete. Completion can be made asynchronous by setting `g:lsp_async_completion`. Note that this may cause unexpected behavior in some plugins such as MUcomplete.
+
 If you would like to have more advanced features please use asyncomplete.vim as described below.
 
 ### omnifunc
 
 ```vim
+" let g:lsp_async_completion = 1
+
 autocmd FileType typescript setlocal omnifunc=lsp#complete
 ```
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -558,7 +558,7 @@ endfunction
 
 function! s:find_complete_servers_and_start_pos() abort
     let l:server_names = []
-    for l:server_name in lsp#get_server_names()
+    for l:server_name in lsp#get_whitelisted_servers()
         let l:init_capabilities = lsp#get_server_capabilities(l:server_name)
         if has_key(l:init_capabilities, 'completionProvider')
             " TODO: support triggerCharacters

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -533,9 +533,9 @@ let s:completion_status_pending = 'pending'
 let s:completion = {'status': '', 'matches': []}
 
 function! lsp#complete(findstart, base) abort
-    if a:findstart
-        let l:info = s:find_complete_servers_and_start_pos()
+    let l:info = s:find_complete_servers_and_start_pos()
 
+    if a:findstart
         if len(l:info['server_names']) == 0
             return -1
         endif
@@ -546,8 +546,6 @@ function! lsp#complete(findstart, base) abort
             return l:info['findstart'] - 1
         endif
     else
-        let l:info = s:find_complete_servers_and_start_pos()
-
         if len(l:info['server_names']) == 0
             return []
         endif

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -533,7 +533,7 @@ function! lsp#complete(findstart, base) abort
             return -1
         endif
 
-        return l:info['findstart']
+        return col('.')
     else
         let l:info = s:find_complete_servers_and_start_pos()
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -4,6 +4,7 @@ endif
 let g:lsp_loaded = 1
 
 let g:lsp_auto_enable = get(g:, 'lsp_auto_enable', 1)
+let g:lsp_async_completion = get(g:, 'lsp_async_completion', 0)
 let g:lsp_log_file = get(g:, 'lsp_log_file', '')
 let g:lsp_log_verbose = get(g:, 'lsp_log_verbose', 1)
 let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])


### PR DESCRIPTION
The asynchronous nature of `lsp#complete()` can cause unexpected behavior in some plugins (such as [MUcomplete](https://github.com/lifepillar/vim-mucomplete)). With this PR, completion is made more predictable and the old behavior has to be explicitly enabled.