### PR TITLE
Fix errors and warnings produced by vint

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -84,7 +84,7 @@ function! lsp#unregister_notifications(name) abort
     " TODO
 endfunction
 
-function s:register_events() abort
+function! s:register_events() abort
     augroup lsp
         autocmd!
         autocmd BufReadPost * call s:on_text_document_did_open()

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -5,11 +5,14 @@ let s:servers = {} " { lsp_id, server_info, init_callbacks, init_result, buffers
 let s:notification_callbacks = [] " { name, callback }
 
 " do nothing, place it here only to avoid the message
-autocmd User lsp_setup silent
-autocmd User lsp_register_server silent
-autocmd User lsp_unregister_server silent
-autocmd User lsp_server_init silent
-autocmd User lsp_server_exit silent
+augroup _lsp_silent_
+    autocmd!
+    autocmd User lsp_setup silent
+    autocmd User lsp_register_server silent
+    autocmd User lsp_unregister_server silent
+    autocmd User lsp_server_init silent
+    autocmd User lsp_server_exit silent
+augroup END
 
 function! lsp#log_verbose(...) abort
     if g:lsp_log_verbose

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -236,7 +236,7 @@ function! s:ensure_start(buf, server_name, cb) abort
     let l:cmd = l:server_info['cmd'](l:server_info)
 
     if empty(l:cmd)
-        let l:msg = s:new_rpc_error('ignore server start since cmd is empty', { 'server_name': a:server_name }))
+        let l:msg = s:new_rpc_error('ignore server start since cmd is empty', { 'server_name': a:server_name })
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -422,14 +422,14 @@ function! s:on_notification(server_name, id, data, event) abort
 
     if lsp#client#is_server_instantiated_notification(a:data)
         if has_key(l:response, 'method')
-            if l:response['method'] == 'textDocument/publishDiagnostics'
+            if l:response['method'] ==# 'textDocument/publishDiagnostics'
                 call lsp#ui#vim#handle_text_document_publish_diagnostics(a:server_name, a:data)
             endif
         endif
     else
         let l:request = a:data['request']
         let l:method = l:request['method']
-        if l:method == 'initialize'
+        if l:method ==# 'initialize'
             call s:handle_initialize(a:server_name, a:data)
         endif
     endif
@@ -480,7 +480,7 @@ function! lsp#get_whitelisted_servers(...) abort
 
         if has_key(l:server_info, 'blacklist')
             for l:filetype in l:server_info['blacklist']
-                if l:filetype == l:buffer_filetype || l:filetype == '*'
+                if l:filetype ==? l:buffer_filetype || l:filetype ==# '*'
                     let l:blacklisted = 1
                     break
                 endif
@@ -493,7 +493,7 @@ function! lsp#get_whitelisted_servers(...) abort
 
         if has_key(l:server_info, 'whitelist')
             for l:filetype in l:server_info['whitelist']
-                if l:filetype == l:buffer_filetype || l:filetype == '*'
+                if l:filetype ==? l:buffer_filetype || l:filetype ==# '*'
                     let l:active_servers += [l:server_name]
                     break
                 endif

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -22,7 +22,7 @@ function! s:create_context(client_id, opts) abort
     return l:ctx
 endfunction
 
-function s:dispose_context(client_id) abort
+function! s:dispose_context(client_id) abort
     if a:client_id > 0
         if has_key(s:clients, a:client_id)
             unlet s:clients[a:client_id]
@@ -261,7 +261,7 @@ function! lsp#client#is_error(notification) abort
     return s:lsp_is_error(a:notification)
 endfunction
 
-function! lsp#client#is_server_instantiated_notification(notification)
+function! lsp#client#is_server_instantiated_notification(notification) abort
     return s:is_server_instantiated_notification(a:notification)
 endfunction
 

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -224,7 +224,7 @@ function! s:lsp_send(id, opts, type) abort " opts = { method, params?, on_notifi
 endfunction
 
 function! s:lsp_get_last_request_id(id) abort
-    return s:lsp_clients[a:id]['request_sequence']
+    return s:clients[a:id]['request_sequence']
 endfunction
 
 function! s:lsp_is_error(notification) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -58,6 +58,7 @@ function! lsp#omni#complete(findstart, base) abort
             let s:completion['matches'] = filter(s:completion['matches'], {_, match -> match['word'] =~ '^' . a:base})
             let s:completion['status'] = ''
             return s:completion['matches']
+        endif
     endif
 endfunction
 

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -146,7 +146,7 @@ function! s:get_visual_selection_pos() abort
     if len(lines) == 0
         return [0, 0, 0, 0]
     endif
-    let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
+    let lines[-1] = lines[-1][: column_end - (&selection ==# 'inclusive' ? 1 : 2)]
     let lines[0] = lines[0][column_start - 1:]
     return [line_start, column_start, line_end, len(lines[-1])]
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -136,7 +136,7 @@ function! lsp#ui#vim#document_format() abort
     echom 'Formatting document ...'
 endfunction
 
-function! s:get_visual_selection_pos()
+function! s:get_visual_selection_pos() abort
     " https://groups.google.com/d/msg/vim_dev/oCUQzO3y8XE/vfIMJiHCHtEJ
     " https://stackoverflow.com/a/6271254
     " getpos("'>'") doesn't give the right column so need to do extra processing

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -128,10 +128,10 @@ function! s:is_file_uri(uri) abort
 endfunction
 
 
-function! s:get_symbol_text_from_kind(kind)
+function! s:get_symbol_text_from_kind(kind) abort
     return has_key(s:symbol_kinds, a:kind) ? s:symbol_kinds[a:kind] : 'unknown symbol ' . a:kind
 endfunction
 
-function! s:get_diagnostic_severity_text(severity)
+function! s:get_diagnostic_severity_text(severity) abort
     return s:diagnostic_severity[a:severity]
 endfunction


### PR DESCRIPTION
I checked the the codebase with the vint vimscript linter. The errors and relevant warnings are fixed in these commits, roughly ordered by severity.

1. The first commit fixes plain errors (caused by typos probably).
2. The second commit ensures function signatures are correct.
3. The third commit changes occurences of `==` to either `==#` or `==?` depending on context. Read more about why this is important [here](http://learnvimscriptthehardway.stevelosh.com/chapters/22.html).
4. The fourth commit wraps the `silent` autocommands in a group and resets them when the file is sourced. While not strictly necessary, this is more prudent and silences the warnings.