### PR TITLE
Send proper params on lsp#ui#vim#references

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -44,7 +44,7 @@ function! lsp#ui#vim#references() abort
             \ 'params': {
             \   'textDocument': lsp#get_text_document_identifier(),
             \   'position': lsp#get_position(),
-            \   'includeDeclaration': v:false,
+            \   'context': {'includeDeclaration': v:false},
             \ },
             \ 'on_notification': function('s:handle_location', [l:ctx, l:server, 'references']),
             \ })


### PR DESCRIPTION
As far as I understood from the [protocol](https://github.com/Microsoft/language-server-protocol/blob/master/versions/protocol-2-x.md#textDocument_references) we are sending the wrong parameters in lsp#ui#vim#references

This commit fixes it