### PR TITLE
Fix :LspRename

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -413,7 +413,8 @@ endfunction
 
 function! s:apply_text_edits(uri, text_edits) abort
     let l:path = lsp#utils#uri_to_path(a:uri)
-    let l:cmd = 'edit ' . l:path
+    let l:buffer = bufnr(l:path)
+    let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:path
     for l:text_edit in a:text_edits
         let l:start_line = l:text_edit['range']['start']['line'] + 1
         let l:start_character = l:text_edit['range']['start']['character'] + 1


### PR DESCRIPTION
When buffer is modified renaming fails.
Use :buffer instead of :edit for listed buffers.