### PR TITLE
Add position to jumplist before :LspDefinition

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -308,6 +308,9 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
         if empty(a:ctx['list'])
             echom 'No ' . a:type .' found'
         else
+            if a:type ==# 'definition'
+              normal! m'
+            endif
             if len(a:ctx['list']) == 1 && a:ctx['jump_if_one']
                 let l:loc = a:ctx['list'][0]
                 if lsp#utils#path_to_uri(expand('%:p')) == lsp#utils#path_to_uri(l:loc['filename'])

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -309,7 +309,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
             echom 'No ' . a:type .' found'
         else
             if a:type ==# 'definition'
-              normal! m'
+                normal! m'
             endif
             if len(a:ctx['list']) == 1 && a:ctx['jump_if_one']
                 let l:loc = a:ctx['list'][0]


### PR DESCRIPTION
Currently when we jump with :LspDefinition there's no easy
way to go back. With this change we can move back easily
with `<c-o>` or  `''`.