### PR TITLE
Fix :LspDefinition on Windows

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -310,11 +310,9 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
         else
             if len(a:ctx['list']) == 1 && a:ctx['jump_if_one']
                 let l:loc = a:ctx['list'][0]
-                if lsp#utils#path_to_uri(expand('%:p')) == lsp#utils#path_to_uri(l:loc['filename'])
-                    call cursor(l:loc['lnum'], l:loc['col'])
-                else
-                    execute 'edit +call\ cursor('.l:loc['lnum'].','.l:loc['col'].') '.l:loc['filename']
-                endif
+                let l:buffer = bufnr(l:loc['filename'])
+                let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:loc['filename']
+                execute l:cmd . ' | call cursor('.l:loc['lnum'].','.l:loc['col'].')'
             else
                 call setqflist(a:ctx['list'])
                 echom 'Retrieved ' . a:type


### PR DESCRIPTION
Vim and servers sometimes use different case for paths. `bufnr()` will ignore case when used on Windows.


For example when using `typescript-language-server` on Windows.
```
lsp#utils#path_to_uri(expand('%:p'))
file:///C:/Users/Marko/Desktop/test/a.js
lsp#utils#path_to_uri(l:loc['filename'])
file:///c:/Users/Marko/Desktop/test/a.js
```
Notice how `c` is in different case.

Therefore, `lsp#utils#path_to_uri(expand('%:p')) == lsp#utils#path_to_uri(l:loc['filename'])`
will always be false (if `ignorecase` is off) and `:edit` will always be used. If buffer is modified `:edit` and, consequently, `:LspDefinition` will fail.

