### PR TITLE
return empty string so the output#preview will not add 0 in cmdline

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -11,6 +11,8 @@ function! lsp#ui#vim#output#preview(data) abort
     setlocal readonly nomodifiable
 
     let &l:filetype = l:ft . '.lsp-hover'
+
+    return ''
 endfunction
 
 function! s:append(data) abort


### PR DESCRIPTION
//cc @hauleth 

This fixes `0` being shown when calling `output#preview`.

Before:
<img width="850" alt="screen shot 2018-01-01 at 2 05 45 pm" src="https://user-images.githubusercontent.com/287744/34471387-f5f7bfe6-eefc-11e7-9bc5-5b39ac9bee18.png">

After:
<img width="851" alt="screen shot 2018-01-01 at 2 06 11 pm" src="https://user-images.githubusercontent.com/287744/34471388-02ff9600-eefd-11e7-8467-f687bbc88d87.png">
