### PR TITLE
initial support for diagnostics signs

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -35,6 +35,9 @@ function! lsp#enable() abort
         let s:already_setup = 1
     endif
     let s:enabled = 1
+    if g:lsp_signs_enabled
+        call lsp#ui#vim#signs#enable()
+    endif
     call s:register_events()
 endfunction
 
@@ -42,6 +45,7 @@ function! lsp#disable() abort
     if !s:enabled
         return
     endif
+    call lsp#ui#vim#signs#disable()
     call s:unregister_events()
     let s:enabled = 0
 endfunction
@@ -439,7 +443,7 @@ function! s:on_notification(server_name, id, data, event) abort
     if lsp#client#is_server_instantiated_notification(a:data)
         if has_key(l:response, 'method')
             if l:response['method'] ==# 'textDocument/publishDiagnostics'
-                call lsp#ui#vim#handle_text_document_publish_diagnostics(a:server_name, a:data)
+                call lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(a:server_name, a:data)
             endif
         endif
     else

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -1,5 +1,4 @@
 let s:last_req_id = 0
-let s:diagnostics = {} " { uri: { 'server_name': response } }
 
 function! s:error_msg(msg) abort
     echohl ErrorMsg
@@ -239,42 +238,6 @@ function! lsp#ui#vim#document_symbol() abort
     endfor
 
     echom 'Retrieving document symbols ...'
-endfunction
-
-function! lsp#ui#vim#handle_text_document_publish_diagnostics(server_name, data) abort
-    if lsp#client#is_error(a:data['response'])
-        return
-    endif
-    let l:uri = a:data['response']['params']['uri']
-    if !has_key(s:diagnostics, l:uri)
-        let s:diagnostics[l:uri] = {}
-    endif
-    let s:diagnostics[l:uri][a:server_name] = a:data
-endfunction
-
-function! lsp#ui#vim#document_diagnostics() abort
-    let l:uri = lsp#utils#get_buffer_uri()
-    if !has_key(s:diagnostics, l:uri)
-        call s:error_msg('No diagnostics results')
-        return
-    endif
-
-    let l:diagnostics = s:diagnostics[l:uri]
-    let l:result = []
-    for [l:server_name, l:data] in items(l:diagnostics)
-        let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
-    endfor
-
-    call setqflist(l:result)
-
-    " autocmd FileType qf setlocal wrap
-
-    if empty(l:result)
-        call s:error_msg('No diagnostics results found')
-    else
-        echom 'Retrieved diagnostics results'
-        botright copen
-    endif
 endfunction
 
 function! s:handle_symbol(server, last_req_id, type, data) abort

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -1,0 +1,39 @@
+let s:diagnostics = {} " { uri: { 'server_name': response } }
+
+function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server_name, data) abort
+    if lsp#client#is_error(a:data['response'])
+        return
+    endif
+    let l:uri = a:data['response']['params']['uri']
+    if !has_key(s:diagnostics, l:uri)
+        let s:diagnostics[l:uri] = {}
+    endif
+    let s:diagnostics[l:uri][a:server_name] = a:data
+
+    call lsp#ui#vim#signs#set(a:server_name, a:data)
+endfunction
+
+function! lsp#ui#vim#diagnostics#document_diagnostics() abort
+    let l:uri = lsp#utils#get_buffer_uri()
+    if !has_key(s:diagnostics, l:uri)
+        call s:error_msg('No diagnostics results')
+        return
+    endif
+
+    let l:diagnostics = s:diagnostics[l:uri]
+    let l:result = []
+    for [l:server_name, l:data] in items(l:diagnostics)
+        let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
+    endfor
+
+    call setqflist(l:result)
+
+    " autocmd FileType qf setlocal wrap
+
+    if empty(l:result)
+        call s:error_msg('No diagnostics results found')
+    else
+        echom 'Retrieved diagnostics results'
+        botright copen
+    endif
+endfunction

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -1,0 +1,121 @@
+" TODO: handle !has('signs')
+" TODO: handle signs clearing when server exits
+let s:enabled = 0
+let s:signs_defined = 0
+let s:signs = {} " { server_name: { path: {} } }
+let s:severity_sign_names_mapping = {
+    \ 1: 'LspError',
+    \ 2: 'LspWarning',
+    \ 3: 'LspInformation',
+    \ 4: 'LspHint',
+    \ }
+function! lsp#ui#vim#signs#enable() abort
+    if !s:enabled
+        call s:define_signs()
+        call s:register_events()
+        let s:enabled = 1
+        call lsp#log('vim-lsp signs enabled')
+    endif
+endfunction
+
+function! s:define_signs() abort
+    if !s:signs_defined
+        " TODO: support customization of signs
+        sign define LspError text=E> texthl=Error
+        sign define LspWarning text=W> texthl=Todo
+        sign define LspInformation text=I> texthl=Normal
+        sign define LspHint text=H> texthl=Normal
+        let s:signs_defined = 1
+    endif
+endfunction
+
+function! s:register_events() abort
+    augroup lsp_ui_vim_signs
+        autocmd!
+        autocmd CursorMoved * call s:on_cursor_moved()
+    augroup END
+endfunction
+
+function! lsp#ui#vim#signs#disable() abort
+    if s:enabled
+        call s:undefine_signs()
+        let s:enabled = 0
+        call lsp#log('vim-lsp signs disabled')
+    endif
+endfunction
+
+function! s:undefine_signs() abort
+    if s:signs_defined
+        sign undefine LspError
+        sign undefine LspWarning
+        sign undefine LspInformation
+        sign undefine LspHint
+        let s:signs_defined = 0
+    endif
+endfunction
+
+function! s:unregister_events() abort
+    augroup lsp_ui_vim_signs
+        autocmd!
+    augroup END
+endfunction
+
+function! lsp#ui#vim#signs#set(server_name, data) abort
+    " will always replace existing set
+    if !s:enabled
+        return
+    endif
+
+    if lsp#client#is_error(a:data['response'])
+        return
+    endif
+
+    let l:uri = a:data['response']['params']['uri']
+    let l:diagnostics = a:data['response']['params']['diagnostics']
+
+    let l:path = lsp#utils#uri_to_path(l:uri)
+    if !has_key(s:signs, a:server_name)
+        let s:signs[a:server_name] = {}
+    endif
+
+    if !has_key(s:signs[a:server_name], l:path)
+        let s:signs[a:server_name][l:path] = []
+    endif
+
+    call s:clear_signs(a:server_name, l:path)
+    call s:place_signs(a:server_name, l:path, l:diagnostics)
+endfunction
+
+function! s:clear_signs(server_name, path) abort
+    " TODO clear
+    if !has_key(s:signs[a:server_name], a:path)
+        return
+    endif
+
+    for l:id in s:signs[a:server_name][a:path]
+        execute ":sign unplace " . l:id . " file=" . a:path
+    endfor
+
+    let s:signs[a:server_name][a:path] = []
+endfunction
+
+function! s:place_signs(server_name, path, diagnostics) abort
+    if !empty(a:diagnostics)
+        for l:item in a:diagnostics
+            let l:line = l:item['range']['start']['line'] + 1
+
+            let l:name = 'LspError'
+            if has_key(l:item, 'severity') && !empty(l:item['severity'])
+                let l:name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
+                execute ":sign place " . g:lsp_next_sign_id . " name=" . l:name . " line=" . l:line . " file=" . a:path
+                call add(s:signs[a:server_name][a:path], g:lsp_next_sign_id)
+                call lsp#log('add signs')
+                let g:lsp_next_sign_id += 1
+            endif
+        endfor
+    endif
+endfunction
+
+function! s:on_cursor_moved() abort
+    " TODO: show error message using echo
+endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -8,6 +8,8 @@ let g:lsp_async_completion = get(g:, 'lsp_async_completion', 0)
 let g:lsp_log_file = get(g:, 'lsp_log_file', '')
 let g:lsp_log_verbose = get(g:, 'lsp_log_verbose', 1)
 let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])
+let g:lsp_signs_enabled = get(g:, 'lsp_signs_enabled', 0)
+let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 
 if g:lsp_auto_enable
     au VimEnter * call lsp#enable()
@@ -15,7 +17,7 @@ endif
 
 command! LspDefinition call lsp#ui#vim#definition()
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
-command! LspDocumentDiagnostics call lsp#ui#vim#document_diagnostics()
+command! LspDocumentDiagnostics call lsp#ui#vim#diagnostics#document_diagnostics()
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover()
 command! LspReferences call lsp#ui#vim#references()
 command! LspRename call lsp#ui#vim#rename()


### PR DESCRIPTION
Based on work by @tsufeki in https://github.com/tsufeki/vim-lsp/tree/diagnostic-signs.

* Moved diagnostics to own file based on https://github.com/prabirshrestha/vim-lsp/issues/77
* Added signs.vim to deal with signs
* Currently disabled by default since this is WIP. To enable it use `let g:lsp_signs_enabled = 1`
* Need to support `s:on_cursor_moved()` to make this on by default and useful.