### PR TITLE
support for showing diagnostics under cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Plug 'prabirshrestha/asyncomplete-lsp.vim'
 |`:LspRename`| Rename symbol |
 |`:LspWorkspaceSymbol`| Search/Show workspace symbol |
 
+### Diagnostics
+
+```
+let g:lsp_signs_enabled = 1         " enable signs
+let lsp_diagnostics_echo_cursor = 1 " enable echo under cursor when in normal mode
+```
+
 ## Debugging
 
 In order to enable file logging set `g:lsp_log_file`.

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -98,6 +98,7 @@ function! s:register_events() abort
         autocmd BufWritePost * call s:on_text_document_did_save()
         autocmd BufWinLeave * call s:on_text_document_did_close()
         autocmd InsertLeave * call s:on_text_document_did_change()
+        autocmd CursorMoved * call s:on_cursor_moved()
     augroup END
     call s:on_text_document_did_open()
 endfunction
@@ -130,6 +131,10 @@ function! s:on_text_document_did_change() abort
     for l:server_name in lsp#get_whitelisted_servers()
         call s:ensure_flush(bufnr('%'), l:server_name, function('s:Noop'))
     endfor
+endfunction
+
+function! s:on_cursor_moved() abort
+    call lsp#ui#vim#diagnostics#echo#cursor_moved()
 endfunction
 
 function! s:call_did_save(buf, server_name, result, cb) abort

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -43,3 +43,38 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
         botright copen
     endif
 endfunction
+
+function! lsp#ui#vim#diagnostics#get_diagnostics_under_cursor() abort
+    let l:uri = lsp#utils#get_buffer_uri()
+    if !has_key(s:diagnostics, l:uri)
+        return
+    endif
+
+    let l:diagnostics = s:diagnostics[l:uri]
+
+    let l:line = line('.')
+    let l:col = col('.')
+
+    let l:closeset_diagnostics = {}
+    let l:closeset_distance = -1
+
+    for [l:server_name, l:data] in items(l:diagnostics)
+        for l:diagnostic in l:data['response']['params']['diagnostics']
+            let l:range = l:diagnostic['range']
+            let l:start_line = l:range['start']['line'] + 1
+            let l:start_col = l:range['start']['character'] + 1
+            let l:end_line = l:range['end']['line'] + 1
+            let l:end_character = l:range['end']['character'] + 1
+
+            if l:line == l:start_line
+                let l:distance = abs(l:start_col - l:col)
+                if l:closeset_distance < 0 || l:distance < l:closeset_distance
+                    let l:closeset_diagnostics = l:diagnostic
+                    let l:closeset_distance = l:distance
+                endif
+            endif
+        endfor
+    endfor
+
+    return l:closeset_diagnostics
+endfunction

--- a/autoload/lsp/ui/vim/diagnostics/echo.vim
+++ b/autoload/lsp/ui/vim/diagnostics/echo.vim
@@ -1,0 +1,36 @@
+function! lsp#ui#vim#diagnostics#echo#cursor_moved()
+    if !g:lsp_diagnostics_echo_cursor
+        return
+    endif
+
+    if mode() isnot# 'n'
+        " dont' show echo only in normal mode
+        return
+    endif
+
+    call s:stop_cursor_moved_timer()
+
+    let l:current_pos = getcurpos()[0:2]
+
+    " use timer to avoid recalculation
+    if !exists('s:last_pos') || l:current_pos != s:last_pos
+        let s:last_pos = l:current_pos
+        let s:cursor_moved_timer = timer_start(g:lsp_diagnostics_echo_delay, function('s:echo_diagnostics_under_cursor'))
+    endif
+endfunction
+
+function! s:echo_diagnostics_under_cursor(...) abort
+    let l:diagnostic = lsp#ui#vim#diagnostics#get_diagnostics_under_cursor()
+    if !empty(l:diagnostic) && has_key(l:diagnostic, 'message')
+        echo 'LSP: '. l:diagnostic['message']
+    else
+        echo ''
+    endif
+endfunction
+
+function! s:stop_cursor_moved_timer() abort
+    if exists('s:cursor_moved_timer')
+        call timer_stop(s:cursor_moved_timer)
+        unlet s:cursor_moved_timer
+    endif
+endfunction

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -9,10 +9,10 @@ let s:severity_sign_names_mapping = {
     \ 3: 'LspInformation',
     \ 4: 'LspHint',
     \ }
+
 function! lsp#ui#vim#signs#enable() abort
     if !s:enabled
         call s:define_signs()
-        call s:register_events()
         let s:enabled = 1
         call lsp#log('vim-lsp signs enabled')
     endif
@@ -27,13 +27,6 @@ function! s:define_signs() abort
         sign define LspHint text=H> texthl=Normal
         let s:signs_defined = 1
     endif
-endfunction
-
-function! s:register_events() abort
-    augroup lsp_ui_vim_signs
-        autocmd!
-        autocmd CursorMoved * call s:on_cursor_moved()
-    augroup END
 endfunction
 
 function! lsp#ui#vim#signs#disable() abort
@@ -52,12 +45,6 @@ function! s:undefine_signs() abort
         sign undefine LspHint
         let s:signs_defined = 0
     endif
-endfunction
-
-function! s:unregister_events() abort
-    augroup lsp_ui_vim_signs
-        autocmd!
-    augroup END
 endfunction
 
 function! lsp#ui#vim#signs#set(server_name, data) abort
@@ -114,8 +101,4 @@ function! s:place_signs(server_name, path, diagnostics) abort
             endif
         endfor
     endif
-endfunction
-
-function! s:on_cursor_moved() abort
-    " TODO: show error message using echo
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -9,6 +9,8 @@ let g:lsp_log_file = get(g:, 'lsp_log_file', '')
 let g:lsp_log_verbose = get(g:, 'lsp_log_verbose', 1)
 let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])
 let g:lsp_signs_enabled = get(g:, 'lsp_signs_enabled', 0)
+let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
+let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 
 if g:lsp_auto_enable


### PR DESCRIPTION
Currently disabled by default and can be enabled by using `let lsp_diagnostics_echo_cursor = 1`.
It is useful when used with signcolumns enabled `let lsp_signs_enabled = 1` without using `:LspDocumentDiagnostics`.

<img width="774" alt="screen shot 2018-01-06 at 6 41 06 pm" src="https://user-images.githubusercontent.com/287744/34645984-370a231c-f311-11e7-811d-ed96ec435dc1.png">
