### PR TITLE
Reduce flickering during sign update

### DIFF
--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -25,7 +25,6 @@ function! s:define_signs() abort
         sign define LspWarning text=W> texthl=Todo
         sign define LspInformation text=I> texthl=Normal
         sign define LspHint text=H> texthl=Normal
-        sign define LspDummy
         let s:signs_defined = 1
     endif
 endfunction
@@ -44,7 +43,6 @@ function! s:undefine_signs() abort
         sign undefine LspWarning
         sign undefine LspInformation
         sign undefine LspHint
-        sign undefine LspDummy
         let s:signs_defined = 0
     endif
 endfunction
@@ -71,26 +69,8 @@ function! lsp#ui#vim#signs#set(server_name, data) abort
         let s:signs[a:server_name][l:path] = []
     endif
 
-    let l:dummy_placed = 0
-    if !empty(l:diagnostics)
-        call s:place_dummy_sign(l:path)
-        let l:dummy_placed = 1
-    endif
-
     call s:clear_signs(a:server_name, l:path)
     call s:place_signs(a:server_name, l:path, l:diagnostics)
-
-    if l:dummy_placed
-        call s:clear_dummy_sign(l:path)
-    endif
-endfunction
-
-function! s:place_dummy_sign(path) abort
-    execute ":sign place " . g:lsp_dummy_sign_id . " name=LspDummy line=9999 file=" . a:path
-endfunction
-
-function! s:clear_dummy_sign(path) abort
-    execute ":sign unplace " . g:lsp_dummy_sign_id . " file=" . a:path
 endfunction
 
 function! s:clear_signs(server_name, path) abort

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -25,6 +25,7 @@ function! s:define_signs() abort
         sign define LspWarning text=W> texthl=Todo
         sign define LspInformation text=I> texthl=Normal
         sign define LspHint text=H> texthl=Normal
+        sign define LspDummy
         let s:signs_defined = 1
     endif
 endfunction
@@ -43,6 +44,7 @@ function! s:undefine_signs() abort
         sign undefine LspWarning
         sign undefine LspInformation
         sign undefine LspHint
+        sign undefine LspDummy
         let s:signs_defined = 0
     endif
 endfunction
@@ -69,8 +71,26 @@ function! lsp#ui#vim#signs#set(server_name, data) abort
         let s:signs[a:server_name][l:path] = []
     endif
 
+    let l:dummy_placed = 0
+    if !empty(l:diagnostics)
+        call s:place_dummy_sign(l:path)
+        let l:dummy_placed = 1
+    endif
+
     call s:clear_signs(a:server_name, l:path)
     call s:place_signs(a:server_name, l:path, l:diagnostics)
+
+    if l:dummy_placed
+        call s:clear_dummy_sign(l:path)
+    endif
+endfunction
+
+function! s:place_dummy_sign(path) abort
+    execute ":sign place " . g:lsp_dummy_sign_id . " name=LspDummy line=9999 file=" . a:path
+endfunction
+
+function! s:clear_dummy_sign(path) abort
+    execute ":sign unplace " . g:lsp_dummy_sign_id . " file=" . a:path
 endfunction
 
 function! s:clear_signs(server_name, path) abort

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -114,11 +114,12 @@ function! s:place_signs(server_name, path, diagnostics) abort
             let l:name = 'LspError'
             if has_key(l:item, 'severity') && !empty(l:item['severity'])
                 let l:name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
-                execute ":sign place " . g:lsp_next_sign_id . " name=" . l:name . " line=" . l:line . " file=" . a:path
-                call add(s:signs[a:server_name][a:path], g:lsp_next_sign_id)
-                call lsp#log('add signs')
-                let g:lsp_next_sign_id += 1
             endif
+
+            execute ":sign place " . g:lsp_next_sign_id . " name=" . l:name . " line=" . l:line . " file=" . a:path
+            call add(s:signs[a:server_name][a:path], g:lsp_next_sign_id)
+            call lsp#log('add signs')
+            let g:lsp_next_sign_id += 1
         endfor
     endif
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -11,7 +11,8 @@ let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])
 let g:lsp_signs_enabled = get(g:, 'lsp_signs_enabled', 0)
 let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
-let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
+let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 7000)
+let g:lsp_dummy_sign_id = get(g:, 'lsp_dummy_sign_id', 6999)
 
 if g:lsp_auto_enable
     au VimEnter * call lsp#enable()

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -11,8 +11,7 @@ let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])
 let g:lsp_signs_enabled = get(g:, 'lsp_signs_enabled', 0)
 let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
-let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 7000)
-let g:lsp_dummy_sign_id = get(g:, 'lsp_dummy_sign_id', 6999)
+let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 
 if g:lsp_auto_enable
     au VimEnter * call lsp#enable()


### PR DESCRIPTION
Set `&signcolumn` during update to reduce flickering.

I also fixed adding sign for diagnostic without severity: in the LS protocol severity is optional.
  