### PR TITLE
Revert "Show matching lines on :LspReferences"

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -13,12 +13,11 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
                 let l:path = lsp#utils#uri_to_path(l:location['uri'])
                 let l:line = l:location['range']['start']['line'] + 1
                 let l:col = l:location['range']['start']['character'] + 1
-                let l:text = bufnr(l:path) ==# -1 ? 'File not loaded' : getbufline(bufnr(l:path), l:line)[0]
                 call add(l:list, {
                     \ 'filename': l:path,
                     \ 'lnum': l:line,
                     \ 'col': l:col,
-                    \ 'text': l:text,
+                    \ 'text': l:path,
                     \ })
             endif
         endfor


### PR DESCRIPTION
Reverts prabirshrestha/vim-lsp#93

@xtal8 Need to revert since this causes other bug https://github.com/prabirshrestha/vim-lsp/issues/97#issuecomment-359254062