### PR TITLE
Percent-decode uri from language server to fix issue #106

### DIFF
--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -2,7 +2,7 @@ function! lsp#utils#is_remote_uri(uri) abort
     return a:uri =~# '^\w\+::' || a:uri =~# '^\w\+://'
 endfunction
 
-function! lsp#utils#decode_uri(uri) abort
+function! s:decode_uri(uri) abort
     let ret = a:uri
     let ret = substitute(ret, '+', ' ', 'g')
     let ret = substitute(ret, '%\(\x\x\)', '\=printf("%c", str2nr(submatch(1), 16))', 'g')
@@ -29,11 +29,11 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#uri_to_path(uri) abort
-        return lsp#utils#decode_uri(substitute(a:uri[len('file:///'):], '/', '\\', 'g'))
+        return s:decode_uri(substitute(a:uri[len('file:///'):], '/', '\\', 'g'))
     endfunction
 else
     function! lsp#utils#uri_to_path(uri) abort
-        return lsp#utils#decode_uri(a:uri[len('file://'):])
+        return s:decode_uri(a:uri[len('file://'):])
     endfunction
 endif
 

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -2,6 +2,13 @@ function! lsp#utils#is_remote_uri(uri) abort
     return a:uri =~# '^\w\+::' || a:uri =~# '^\w\+://'
 endfunction
 
+function! lsp#utils#decode_uri(uri) abort
+    let ret = a:uri
+    let ret = substitute(ret, '+', ' ', 'g')
+    let ret = substitute(ret, '%\(\x\x\)', '\=printf("%c", str2nr(submatch(1), 16))', 'g')
+    return ret
+endfunction
+
 if has('win32') || has('win64')
     function! lsp#utils#path_to_uri(path) abort
         if empty(a:path)
@@ -22,11 +29,11 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#uri_to_path(uri) abort
-        return substitute(a:uri[len('file:///'):], '/', '\\', 'g')
+        return lsp#utils#decode_uri(substitute(a:uri[len('file:///'):], '/', '\\', 'g'))
     endfunction
 else
     function! lsp#utils#uri_to_path(uri) abort
-        return a:uri[len('file://'):]
+        return lsp#utils#decode_uri(a:uri[len('file://'):])
     endfunction
 endif
 

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -29,7 +29,7 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#uri_to_path(uri) abort
-        return s:decode_uri(substitute(a:uri[len('file:///'):], '/', '\\', 'g'))
+        return substitute(s:decode_uri(a:uri[len('file:///'):]), '/', '\\', 'g')
     endfunction
 else
     function! lsp#utils#uri_to_path(uri) abort

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -9,12 +9,38 @@ function! s:decode_uri(uri) abort
     return substitute(l:ret, '%\(\x\x\)', '\=printf("%c", str2nr(submatch(1), 16))', 'g')
 endfunction
 
+function! s:urlencode_char(c) abort
+  return printf('%%%02X', char2nr(a:c))
+endfunction
+
+function! s:get_prefix(path) abort
+  return matchstr(a:path, '\(^\w\+::\|^\w\+://\)')
+endfunction
+
+function! s:encode_uri(path, default_prefix) abort
+  let l:prefix = s:get_prefix(a:path)
+  let l:path = a:path[len(l:prefix):]
+  if len(l:prefix) == 0
+      let l:prefix = a:default_prefix
+  endif
+  let l:result = ''
+  for i in range(len(l:path))
+    " Don't encode '/' here, `path` is expected to be a valid path.
+    if l:path[i] =~# '^[a-zA-Z0-9_.~/-]$'
+      let l:result .= l:path[i]
+    else
+      let l:result .= s:urlencode_char(l:path[i])
+    endif
+  endfor
+  return l:prefix . l:result
+endfunction
+
 if has('win32') || has('win64')
     function! lsp#utils#path_to_uri(path) abort
         if empty(a:path)
             return a:path
         else
-            return lsp#utils#is_remote_uri(a:path) ? a:path : 'file:///' . substitute(a:path, '\', '/', 'g')
+            return s:encode_uri(substitute(a:path, '\', '/', 'g'), 'file:///')
         endif
     endfunction
 else
@@ -22,7 +48,7 @@ else
         if empty(a:path)
             return a:path
         else
-            return lsp#utils#is_remote_uri(a:path) ? a:path : 'file://' . a:path
+            return s:encode_uri(a:path, 'file://')
         endif
     endfunction
 endif

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -2,6 +2,8 @@ function! lsp#utils#is_remote_uri(uri) abort
     return a:uri =~# '^\w\+::' || a:uri =~# '^\w\+://'
 endfunction
 
+" Decode uri function is taken from vital framework: https://github.com/vim-jp/vital.vim
+" For it's license (NYSL), see http://www.kmonos.net/nysl/index.en.html
 function! s:decode_uri(uri) abort
     let ret = a:uri
     let ret = substitute(ret, '+', ' ', 'g')

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -5,10 +5,8 @@ endfunction
 " Decode uri function is taken from vital framework: https://github.com/vim-jp/vital.vim
 " For it's license (NYSL), see http://www.kmonos.net/nysl/index.en.html
 function! s:decode_uri(uri) abort
-    let ret = a:uri
-    let ret = substitute(ret, '+', ' ', 'g')
-    let ret = substitute(ret, '%\(\x\x\)', '\=printf("%c", str2nr(submatch(1), 16))', 'g')
-    return ret
+    let l:ret = substitute(a:uri, '+', ' ', 'g')
+    return substitute(l:ret, '%\(\x\x\)', '\=printf("%c", str2nr(submatch(1), 16))', 'g')
 endfunction
 
 if has('win32') || has('win64')


### PR DESCRIPTION
This fixes the issue #106 with jump to c++ standard library headers with cquery language server. I'm not sure if the opposite should be done - when we convert path to uri, should it be uri-encoded or not, so I skipped it for now. I tried this fix with c++ cquery, rust rls and python pyls, looks like they all work as expected, though I'm not sure that any of them except cquery do uri encoding, or if it is even required for them, cause there paths doesn't contain special characters ('+' in c++ case). I used an implementation of decode function from [vital.vim](https://github.com/vim-jp/vital.vim).