### PR TITLE
make echo message oneline

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics/echo.vim
+++ b/autoload/lsp/ui/vim/diagnostics/echo.vim
@@ -22,7 +22,7 @@ endfunction
 function! s:echo_diagnostics_under_cursor(...) abort
     let l:diagnostic = lsp#ui#vim#diagnostics#get_diagnostics_under_cursor()
     if !empty(l:diagnostic) && has_key(l:diagnostic, 'message')
-        echo 'LSP: '. l:diagnostic['message']
+        echo 'LSP: '. substitute(l:diagnostic['message'], '\n\+', ' ', 'g')
     else
         echo ''
     endif


### PR DESCRIPTION
Some LSP implementations returns diagnostic messages including `\n`, so `echo_diagnostics_under_cursor` shakes my Vim's window.  This PR suppresses this.