### PR TITLE
Add support for keeping focus to the current window with :LspHover

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -2,6 +2,8 @@ function! lsp#ui#vim#output#preview(data) abort
     " Close any previously opened preview window
     pclose
 
+    let l:current_window_id = win_getid()
+
     execute &previewheight.'new'
 
     let l:ft = s:append(a:data)
@@ -11,6 +13,11 @@ function! lsp#ui#vim#output#preview(data) abort
     setlocal readonly nomodifiable
 
     let &l:filetype = l:ft . '.lsp-hover'
+
+    if g:lsp_preview_keep_focus
+      " restore focus to the previous window
+      call win_gotoid(l:current_window_id)
+    endif
 
     return ''
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -12,6 +12,7 @@ let g:lsp_signs_enabled = get(g:, 'lsp_signs_enabled', 0)
 let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
+let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 0)
 
 if g:lsp_auto_enable
     au VimEnter * call lsp#enable()


### PR DESCRIPTION
This PR allows to stay in the current window with `:LspHover` if `g:lsp_preview_keep_focus` is `1`.
`g:lsp_preview_keep_focus` is `0` by default to avoid breaking changes of the behavior.