### PR TITLE
Silence error from Dart language server

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -40,7 +40,7 @@ function! lsp#capabilities#get_text_document_save_registration_options(server_na
     let l:capabilities = lsp#get_server_capabilities(a:server_name)
     if !empty(l:capabilities) && has_key(l:capabilities, 'textDocumentSync')
         if type(l:capabilities['textDocumentSync']) == type({})
-            if  has_key(l:capabilities['textDocumentSync'], 'save')
+            if has_key(l:capabilities['textDocumentSync'], 'save') && type(l:capabilities['textDocumentSync']['save']) == type({})
                 return [1, {
                     \ 'includeText': has_key(l:capabilities['textDocumentSync']['save'], 'includeText') ? l:capabilities['textDocumentSync']['save']['includeText'] : 0,
                     \ }]


### PR DESCRIPTION
Hi!

I'm using vim-lsp with [dart_language_server](https://github.com/natebosch/dart_language_server).  On every save of a file, I'm getting a VimL exception:

```
Error detected while processing function <SNR>98_on_text_document_did_save[4]..<SNR>98_ensure_flush[1]..lsp#utils#step#start[1]..<SNR>120_next[9]..<lambda>19[1]..<SNR>98_ensure_start[15]..<SNR>120_callback[1]..<SNR>120_next[9]..<lambda>20[1]..<SNR>98_ensure_init[6]..<SNR>120_callback[1]..<SNR>120_next[9]..<lambda>21[1]..<SNR>98_ensure_open[16]..<SNR>120_callback[1]..<SNR>120_next[9]..<lambda>22[1]..<SNR>98_ensure_changed[33]..<SNR>120_callback[1]..<SNR>120_next[9]..<lambda>23[1]..<lambda>18[1]..<SNR>98_call_did_save[8]..lsp#capabilities#get_text_document_save_registration_options:
line    6:
E715: Dictionary required
```

Dump of `l:capabilities`:

```
{'executeCommandProvider': v:null, 'hoverProvider': v:true, 'workspaceSymbolProvider': v:false, 'referencesProvider': v:true, 'signatureHelpProvider': v:null, 'codeActionProvider': v:true, 'textDocumentSync': {'save': v:false, 'willSaveWaitUntil': v:false, 'willSave': v:false, 'change': 2, 'openClose': v:true}, 'codeLensProvider': v:false, 'documentHighlightsProvider': v:false, 'documentLinkProvider': v:null, 'documentOnTypeFormattingProvider': v:false, 'definitionProvider': v:true, 'documentRangeFormattingProvider': v:false, 'documentFormattingProvider': v:false, 'documentSymbolProvider': v:false, 'renameProvider': v:true, 'completionProvider': {'resolveProvider': v:false, 'triggerCharacters': ['.']}}
```

as you can see, the `save` property of `textDocumentSync` is `v:false` and vim-lsp expects a dictionary.  I'm a bit confused because [language-server-protocol specs](https://github.com/Microsoft/language-server-protocol/blob/b70345dcb66bbd9c1acb2a644d5a0ed4af21898d/versions/protocol-2-x.md) give yet another version: `textDocumentSync` is defined as TypeScript nullable `number` there (i.e. not a dictionary).  So which version is correct?

EDIT: There's an [extended specification of the protocol](https://microsoft.github.io/language-server-protocol/specification) that defines `testDocumentSync` as `textDocumentSync?: TextDocumentSyncOptions | number;`.  So it looks like the dart language server is out of date.