### PR TITLE
fix #130 Command Option about 'typescript-language-server'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ While most of the time it is ok to just set the `name`, `cmd` and `whitelist` th
 if executable('typescript-language-server')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'typescript-language-server',
-        \ 'cmd': {server_info->[&shell, &shellcmdflag, 'typescript-language-server', '--stdio']},
+        \ 'cmd': {server_info->[&shell, &shellcmdflag, 'typescript-language-server --stdio']},
         \ 'root_uri':{server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'tsconfig.json'))},
         \ 'whitelist': ['typescript'],
         \ })

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -197,7 +197,7 @@ The vim |dict| containing information about the server.
 
     Example:
 	'cmd': {server_info->
-	    \ [&shell, &shellcmdflag, 'typescript-language-server', '--stdio']}
+	    \ [&shell, &shellcmdflag, 'typescript-language-server --stdio']}
 
  * whitelist:
     optional


### PR DESCRIPTION
fix documentation about `--stdio` of `typescript-language-server`.