### PR TITLE
Fix an error when the response does not correspond to a request

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -111,6 +111,8 @@ function! s:on_stdout(id, data, event) abort
                 endif
                 if has_key(l:ctx['requests'], l:response['id'])
                     unlet l:ctx['requests'][l:response['id']]
+                else
+                    call lsp#log('cannot find the request corresponding to response: ', l:response)
                 endif
             else
                 " it is a notification

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -109,7 +109,9 @@ function! s:on_stdout(id, data, event) abort
                     endtry
                     unlet l:ctx['on_notifications'][l:response['id']]
                 endif
-                unlet l:ctx['requests'][l:response['id']]
+                if has_key(l:ctx['requests'], l:response['id'])
+                    unlet l:ctx['requests'][l:response['id']]
+                endif
             else
                 " it is a notification
                 if has_key(l:ctx['opts'], 'on_notification')


### PR DESCRIPTION
If the response id is not found in the requests, then the plugin hits an error with message:
> E716: Key not present in Dictionary: 1

One such example is when the server sends some message about "Failed to index [some source]".
This patch adds a check which protects against this situation.