### PR TITLE
Bugfix: fix lsp#utils#path_to_uri for windows

### DIFF
--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -40,7 +40,9 @@ if has('win32') || has('win64')
         if empty(a:path)
             return a:path
         else
-            return s:encode_uri(substitute(a:path, '\', '/', 'g'), 'file:///')
+            " TODO: figure out if encode_uri is needed
+            "return s:encode_uri(substitute(a:path, '\', '/', 'g'), 'file:///')
+            return 'file:///'.substitute(a:path, '\', '/', 'g')
         endif
     endfunction
 else


### PR DESCRIPTION
On windows, the path for the current buffer is created incorrectly.
When we path the a:path through s:encode_uri, it garbles the c:/
part of the path and uri encodes it.

In order to fix this bug, I changed the function to prepend 'file:///'
to the front of the path that has slashes switched to forward slashes.

Right now, there's a TODO based on a question I have. Do we need s:encode_uri when we build up the path? if it is needed, we might need to only encode the path after the drive letter (c:\).