### PR TITLE
Add an initialization hook to send workspace/didChangeNotification

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -376,19 +376,18 @@ endfunction
 function! s:ensure_conf(buf, server_name, cb) abort
     let l:server = s:servers[a:server_name]
     let l:server_info = l:server['server_info']
-    if has_key(l:server_info, 'workspace_conf')
-        let l:workspace_conf = l:server_info['workspace_conf']
+    if has_key(l:server_info, 'workspace_config')
+        let l:workspace_config = l:server_info['workspace_config']
         call s:send_notification(a:server_name, {
             \ 'method': 'workspace/didChangeConfiguration',
             \ 'params': {
-            \   'settings': l:workspace_conf,
+            \   'settings': l:workspace_config,
             \ }
             \ })
     endif
     let l:msg = s:new_rpc_success('configuration sent', { 'server_name': a:server_name })
     call lsp#log(l:msg)
     call a:cb(l:msg)
-
 endfunction
 
 function! s:ensure_changed(buf, server_name, cb) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -259,6 +259,7 @@ function! s:ensure_flush(buf, server_name, cb) abort
     call lsp#utils#step#start([
         \ {s->s:ensure_start(a:buf, a:server_name, s.callback)},
         \ {s->s:is_step_error(s) ? s:throw_step_error(s) : s:ensure_init(a:buf, a:server_name, s.callback)},
+        \ {s->s:is_step_error(s) ? s:throw_step_error(s) : s:ensure_conf(a:buf, a:server_name, s.callback)},
         \ {s->s:is_step_error(s) ? s:throw_step_error(s) : s:ensure_open(a:buf, a:server_name, s.callback)},
         \ {s->s:is_step_error(s) ? s:throw_step_error(s) : s:ensure_changed(a:buf, a:server_name, s.callback)},
         \ {s->a:cb(s.result[0])}
@@ -370,6 +371,24 @@ function! s:ensure_init(buf, server_name, cb) abort
         \   'initializationOptions': l:initialization_options,
         \ },
         \ })
+endfunction
+
+function! s:ensure_conf(buf, server_name, cb) abort
+    let l:server = s:servers[a:server_name]
+    let l:server_info = l:server['server_info']
+    if has_key(l:server_info, 'workspace_conf')
+        let l:workspace_conf = l:server_info['workspace_conf']
+        call s:send_notification(a:server_name, {
+            \ 'method': 'workspace/didChangeConfiguration',
+            \ 'params': {
+            \   'settings': l:workspace_conf,
+            \ }
+            \ })
+    endif
+    let l:msg = s:new_rpc_success('configuration sent', { 'server_name': a:server_name })
+    call lsp#log(l:msg)
+    call a:cb(l:msg)
+
 endfunction
 
 function! s:ensure_changed(buf, server_name, cb) abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -146,6 +146,7 @@ one parameter which is a vim |dict| and is refered to as |vim-lsp-server-info|
 		\ 'whitelist': ['filetype to whitelist'],
 		\ 'blacklist': ['filetype to blacklist'],
 		\ 'config': {},
+		\ 'workspace_conf': {'param': {'enabled': v:true}},
 		\ })
 	endif
 
@@ -165,6 +166,7 @@ The vim |dict| containing information about the server.
 	'whitelist': ['filetype'],
 	'blacklist': ['filetype'],
 	'config': {},
+	'workspace_conf': {},
     }
 
  * name:
@@ -244,6 +246,16 @@ The vim |dict| containing information about the server.
 	    endfunction
 
 	    'cmd': function('s:myserver_cmd')
+
+  * workspace_conf:
+    optional vim |dict|
+    Used to pass workspace configuration to the server after
+    initialization. Configuration settings are language-server specific.
+
+    Example:
+	'workspace_conf': {'pyls': {'plugins': \
+		{'pydocstyle': {'enabled': v:true}}}}
+
 
 lsp#stop_server                                        *vim-lsp-stop_server*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -146,7 +146,7 @@ one parameter which is a vim |dict| and is refered to as |vim-lsp-server-info|
 		\ 'whitelist': ['filetype to whitelist'],
 		\ 'blacklist': ['filetype to blacklist'],
 		\ 'config': {},
-		\ 'workspace_conf': {'param': {'enabled': v:true}},
+		\ 'workspace_config': {'param': {'enabled': v:true}},
 		\ })
 	endif
 
@@ -166,7 +166,7 @@ The vim |dict| containing information about the server.
 	'whitelist': ['filetype'],
 	'blacklist': ['filetype'],
 	'config': {},
-	'workspace_conf': {},
+	'workspace_config': {},
     }
 
  * name:
@@ -247,13 +247,13 @@ The vim |dict| containing information about the server.
 
 	    'cmd': function('s:myserver_cmd')
 
-  * workspace_conf:
+  * workspace_config:
     optional vim |dict|
     Used to pass workspace configuration to the server after
     initialization. Configuration settings are language-server specific.
 
     Example:
-	'workspace_conf': {'pyls': {'plugins': \
+	'workspace_config': {'pyls': {'plugins': \
 		{'pydocstyle': {'enabled': v:true}}}}
 
 


### PR DESCRIPTION
According [https://github.com/palantir/python-language-server/issues/312](https://github.com/palantir/python-language-server/issues/312), the pydocstyle linter is disabled by default. In order to enable this linter, the LSP client is expected to send a workspace/didConfigurationChange notification to the server.

This pull request adds the ability to specify a workspace configuration that is sent to the server after the server is initialized. 