### PR TITLE
Use <cWORD> as a default value of rename

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -89,7 +89,7 @@ function! lsp#ui#vim#rename() abort
         return
     endif
 
-    let l:new_name = input('new name>')
+    let l:new_name = input('new name: ', expand('<cWORD>'))
 
     if empty(l:new_name)
         echo '... Renaming aborted ...'


### PR DESCRIPTION
In general, `<cWORD>` should be an initial value of rename.