### PR TITLE
Append newline to get_text_document_text output.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -590,10 +590,17 @@ function! lsp#get_whitelisted_servers(...) abort
     return l:active_servers
 endfunction
 
+function! s:requires_eol_at_eof(buf) abort
+    let l:file_ends_with_eol = getbufvar(a:buf, '&eol')
+    let l:vim_will_save_with_eol = !getbufvar(a:buf, '&binary') &&
+                \ getbufvar(a:buf, '&fixeol')
+    return l:file_ends_with_eol || l:vim_will_save_with_eol
+endfunction
+
 function! s:get_text_document_text(buf) abort
     let l:buf_fileformat = getbufvar(a:buf, '&fileformat')
-    let l:line_ending = {'unix': "\n", 'dos': "\r\n", 'mac': "\r"}[l:buf_fileformat]
-    return join(getbufline(a:buf, 1, '$'), l:line_ending)
+    let l:eol = {'unix': "\n", 'dos': "\r\n", 'mac': "\r"}[l:buf_fileformat]
+    return join(getbufline(a:buf, 1, '$'), l:eol).(s:requires_eol_at_eof(a:buf) ? l:eol : '')
 endfunction
 
 function! s:get_text_document(buf, buffer_info) abort


### PR DESCRIPTION
vim appends newlines to each line in a file when saved. This PR addresses an issue where a newline character is not found at the end of the get_text_document_text output, which is a violation of some language server linters, such as pyls.

This PR determines the proper newline characters based on the buffer's fileformat and then joins the result of the getbufline call using the determined newline characters and appends a newline to the end.