### PR TITLE
Use fileformat to determine appropriate newline characters for didChange messages.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -591,7 +591,9 @@ function! lsp#get_whitelisted_servers(...) abort
 endfunction
 
 function! s:get_text_document_text(buf) abort
-    return join(getbufline(a:buf, 1, '$'), "\n")
+    let l:buf_fileformat = getbufvar(a:buf, '&fileformat')
+    let l:line_ending = {'unix': "\n", 'dos': "\r\n", 'mac': "\r"}[l:buf_fileformat]
+    return join(getbufline(a:buf, 1, '$'), l:line_ending)
 endfunction
 
 function! s:get_text_document(buf, buffer_info) abort


### PR DESCRIPTION
This PR will use the buffer's `fileformat` option to determine what newline characters to use when sending buffer contents to a language server. This addresses #43 .