### PR TITLE
Use word instead of WORD for renaming hint (Fix #175)

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -113,7 +113,7 @@ function! lsp#ui#vim#rename() abort
         return
     endif
 
-    let l:new_name = input('new name: ', expand('<cWORD>'))
+    let l:new_name = input('new name: ', expand('<cword>'))
 
     if empty(l:new_name)
         echo '... Renaming aborted ...'


### PR DESCRIPTION
Fix #175 