### PR TITLE
Support common practice of omitting the double slash in file urls.

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -133,7 +133,7 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
 endfunction
 
 function! s:is_file_uri(uri) abort
-    return stridx(a:uri, 'file:///') == 0
+    return stridx(a:uri, 'file:') == 0
 endfunction
 
 function! s:get_symbol_text_from_kind(kind) abort

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -70,7 +70,7 @@ if has('win32') || has('win64')
     endfunction
 else
     function! lsp#utils#uri_to_path(uri) abort
-        return s:decode_uri(a:uri[len('file://'):])
+        return s:decode_uri(substitute(a:uri, '\v^file:/*', '/', 'g'))
     endfunction
 endif
 


### PR DESCRIPTION
This makes the goto definition of javacs[1] work.

[1] Java language support for Visual Studio Code using javac
(https://github.com/georgewfraser/vscode-javac)

See Also:

- The // after the file: is part of the general syntax of URLs. (The double
slash // should always appear in a file URL according to the specification,
but in practice many Web browsers allow it to be omitted).
(https://en.wikipedia.org/wiki/File_URI_scheme#Meaning_of_slash_character)

- redundant syntax such as two slashes before an empty authority
(https://docs.oracle.com/javase/7/docs/api/java/net/URI.html)