### PR TITLE
Add preview options for hover function

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -136,6 +136,7 @@ function! s:register_events() abort
         autocmd BufWritePost * call s:on_text_document_did_save()
         autocmd BufWinLeave * call s:on_text_document_did_close()
         autocmd InsertLeave * call s:on_text_document_did_change()
+        autocmd TextChanged * call s:on_text_document_did_change()
         autocmd CursorMoved * call s:on_cursor_moved()
     augroup END
     call s:on_text_document_did_open()

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -4,11 +4,15 @@ function! lsp#ui#vim#output#preview(data) abort
 
     let l:current_window_id = win_getid()
 
-    execute &previewheight.'new'
+    execute g:lsp_preview_position.' '.&previewheight.'new'
 
     let l:ft = s:append(a:data)
     " Delete first empty line
     0delete
+
+    if g:lsp_preview_auto_resize
+      execute 'resize ' . line('$')
+    endif
 
     setlocal readonly nomodifiable
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -12,6 +12,8 @@ CONTENTS                                                  *vim-lsp-contents*
     Options			|vim-lsp-options|
       g:lsp_auto_enable           |g:lsp_auto_enable|
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
+      g:lsp_preview_position      |g:lsp_preview_position|
+      g:lsp_preview_auto_resize   |g:lsp_preview_auto_resize|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -118,6 +120,20 @@ g:lsp_preview_keep_focus                         *g:lsp_preview_keep_focus*
 	let g:lsp_preview_keep_focus = 0
 
     * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
+
+g:lsp_preview_position                             *g:lsp_preview_position*
+    Type: |String|
+    Default: `above`
+
+    Indicates the position of the |preview-window| when a |preview-window| is
+    opened by vim-lsp. It can be `above` or `below`.
+
+g:lsp_preview_auto_resize                       *g:lsp_preview_auto_resize*
+    Type: |Number|
+    Default: `0`
+
+    Indicates if the |preview-window| should be automatically resized to fit
+    its content when it is opened by vim-lsp.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*
@@ -312,6 +328,10 @@ Gets the hover information and displays it in the |preview-window|.
  * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
  * To control the default focus of |preview-window| for |LspHover|
    configure |g:lsp_preview_keep_focus|.
+ * To control the default position of |preview-window| for |LspHover|
+   configure |g:lsp_preview_position|.
+ * To control the auto-resizing of the |preview-window| for |LspHover|
+   configure |g:lsp_preview_auto_resize|.
 
 
 LspNextError						     *LspNextError*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -17,6 +17,8 @@ let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
+let g:lsp_preview_position = get(g:, 'lsp_preview_position', 'above')
+let g:lsp_preview_auto_resize = get(g:, 'lsp_preview_auto_resize', 0)
 
 if g:lsp_auto_enable
     au VimEnter * call lsp#enable()


### PR DESCRIPTION
I added 2 options to improve the preview for the hover function:
- lsp_preview_position: to change the position (above or below)
- lsp_preview_auto_resize: to automatically resize the preview to its content

Ideas taken from https://github.com/natebosch/vim-lsc