### PR TITLE
Add `not_supported` in scope for get_hover_under_cursor

### DIFF
--- a/autoload/lsp/ui/vim/hover.vim
+++ b/autoload/lsp/ui/vim/hover.vim
@@ -1,3 +1,7 @@
+function! s:not_supported(what) abort
+    return lsp#utils#error(a:what.' not supported for '.&filetype)
+endfunction
+
 function! lsp#ui#vim#hover#get_hover_under_cursor() abort
     let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_hover_provider(v:val)')
 


### PR DESCRIPTION
Currently calling hover on a filetype without support throws an error, stating
that 'Unknown function: <SNR>274_not_supported'. This adds the `not_supported` 
function into the scripts' scope.