### PR TITLE
Document diagnostics customizations

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -11,10 +11,12 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     endif
     let s:diagnostics[l:uri][a:server_name] = a:data
 
+    call lsp#ui#vim#diagnostics#document_diagnostics(0)
     call lsp#ui#vim#signs#set(a:server_name, a:data)
 endfunction
 
-function! lsp#ui#vim#diagnostics#document_diagnostics() abort
+function! lsp#ui#vim#diagnostics#document_diagnostics(...) abort
+    let l:open_results = get(a:, 1, 1)
     let l:uri = lsp#utils#get_buffer_uri()
 
     let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
@@ -38,7 +40,7 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
 
     if empty(l:result)
         call lsp#utils#error('No diagnostics results found')
-    else
+    elseif l:open_results
         echo 'Retrieved diagnostics results'
         if g:lsp_diagnostics_use_loclist
           botright lopen

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -28,7 +28,11 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
         let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
     endfor
 
-    call setqflist(l:result)
+    if g:lsp_diagnostics_use_loclist
+      call setloclist(0, l:result)
+    else
+      call setqflist(l:result)
+    endif
 
     " autocmd FileType qf setlocal wrap
 
@@ -36,7 +40,11 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
         call lsp#utils#error('No diagnostics results found')
     else
         echo 'Retrieved diagnostics results'
-        botright copen
+        if g:lsp_diagnostics_use_loclist
+          botright lopen
+        else
+          botright copen
+        endif
     endif
 endfunction
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -12,6 +12,7 @@ CONTENTS                                                  *vim-lsp-contents*
     Options			|vim-lsp-options|
       g:lsp_auto_enable           |g:lsp_auto_enable|
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
+      g:lsp_diagnostics_use_loclist    |g:lsp_diagnostics_use_loclist|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -119,6 +120,17 @@ g:lsp_preview_keep_focus                         *g:lsp_preview_keep_focus*
 	let g:lsp_preview_keep_focus = 0
 
     * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
+
+g:lsp_diagnostics_use_loclist               *g:lsp_diagnostics_use_loclist*
+    Type: |Number|
+    Default: `0`
+
+    Indicates whether the |location-list| should be used instead of |quickfix|
+    to display document diagnostics.
+
+    Example:
+	" Use location-list instead of quickfix
+	let g:lsp_diagnostics_use_loclist = 1
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -15,6 +15,7 @@ let g:lsp_signs_information = get(g:, 'lsp_signs_information', {})
 let g:lsp_signs_hint = get(g:, 'lsp_signs_hint', {})
 let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
+let g:lsp_diagnostics_use_loclist = get(g:, 'lsp_diagnostics_use_loclist', 0)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 


### PR DESCRIPTION
This PR mainly introduces two things:

1. `g:lsp_diagnostics_use_loclist` option, so that users can use the location-list instead of the quickfix to display document diagnostics (I think it should be the default, but did not feel like introducing a breaking change)
2. Does not open the loclist/quickfix when diagnostics information is received, unless the user has explicitly invoked `LspDocumentDiagnostics`