### PR TITLE
Format

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -609,7 +609,7 @@ function! s:generate_sub_cmd_replace(text_edit) abort
     let l:start_character = a:text_edit['range']['start']['character']
     let l:end_line = a:text_edit['range']['end']['line']
     let l:end_character = a:text_edit['range']['end']['character']
-    let l:new_text = a:text_edit['newText']
+    let l:new_text = substitute(a:text_edit['newText'], '\n$', '', '')
 
     let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
     let l:sub_cmd .= s:generate_move_cmd(l:start_line, l:start_character) " move to the first position

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -486,6 +486,7 @@ function! s:apply_text_edits(uri, text_edits) abort
             let l:was_paste = &paste
             let l:was_selection = &selection
             let l:was_virtualedit = &virtualedit
+            let l:was_pos = getpos('.')
 
             set paste
             set selection=exclusive
@@ -496,6 +497,7 @@ function! s:apply_text_edits(uri, text_edits) abort
             let &paste = l:was_paste
             let &selection = l:was_selection
             let &virtualedit = l:was_virtualedit
+            call setpos('.', l:was_pos)
         endtry
 
         let l:i = l:merged_text_edit['end_index']

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -489,7 +489,7 @@ function! s:apply_text_edits(uri, text_edits) abort
             let l:was_pos = getpos('.')
 
             set paste
-            set selection=exclusive
+            set selection=inclusive
             set virtualedit=onemore
 
             execute l:cmd

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -486,7 +486,7 @@ function! s:apply_text_edits(uri, text_edits) abort
             let l:was_paste = &paste
             let l:was_selection = &selection
             let l:was_virtualedit = &virtualedit
-            let l:was_pos = getpos('.')
+            let l:was_view = winsaveview()
 
             set paste
             set selection=inclusive
@@ -497,7 +497,7 @@ function! s:apply_text_edits(uri, text_edits) abort
             let &paste = l:was_paste
             let &selection = l:was_selection
             let &virtualedit = l:was_virtualedit
-            call setpos('.', l:was_pos)
+            call winrestview(l:was_view)
         endtry
 
         let l:i = l:merged_text_edit['end_index']

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -472,7 +472,7 @@ function! s:apply_text_edits(uri, text_edits) abort
     " Example:
     " Initial text:  "abcdef"
     " Edits:
-    " ((0,0), (0, 1), "") - remove first character 'a'
+    " ((0, 0), (0, 1), "") - remove first character 'a'
     " ((0, 4), (0, 5), "") - remove fifth character 'e'
     " ((0, 2), (0, 3), "") - remove third character 'c'
     let l:text_edits = sort(deepcopy(a:text_edits), '<SID>sort_text_edit_desc')

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -19,6 +19,8 @@ function! lsp#ui#vim#output#preview(data) abort
       call win_gotoid(l:current_window_id)
     endif
 
+    echo ''
+
     return ''
 endfunction
 
@@ -30,17 +32,17 @@ function! s:append(data) abort
 
         return 'markdown'
     elseif type(a:data) == type('')
-        put =a:data
+        silent put =a:data
 
         return 'markdown'
     elseif type(a:data) == type({}) && has_key(a:data, 'language')
-        put ='```'.a:data.language
-        put =a:data.value
-        put ='```'
+        silent put ='```'.a:data.language
+        silent put =a:data.value
+        silent put ='```'
 
         return 'markdown'
     elseif type(a:data) == type({}) && has_key(a:data, 'kind')
-        put =a:data.value
+        silent put =a:data.value
 
         return a:data.kind == 'plaintext' ? 'text' : a:data.kind
     endif


### PR DESCRIPTION
Some fixes for LspDocumentFormat

* Save/restore cursor position
* Graceful message
* Remove extra \n
* Fixed bug that last `}` remaining after LspDocumentFormat