### PR TITLE
Show details (type info, etc.) in completion menu

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -164,9 +164,14 @@ function! lsp#omni#get_vim_completion_item(item) abort
     let l:menu = lsp#omni#get_kind_text(a:item)
     let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
 
-    if has_key(a:item, 'detail') 
-      let l:completion['info'] .= a:item['detail'] . ' '
-    endif 
+    if has_key(a:item, 'detail') && !empty(a:item['detail'])
+        if empty(l:menu)
+            let l:completion['menu'] = a:item['detail']
+        else
+            let l:completion['menu'] = '[' . l:menu . '] ' . a:item['detail']
+        endif
+        let l:completion['info'] .= a:item['detail'] . ' '
+    endif
 
     if has_key(a:item, 'documentation')
         if type(a:item['documentation']) == type('')


### PR DESCRIPTION
This solves the main complaint in prabirshrestha/asyncomplete-lsp.vim#12. It is especially useful for languages which support function overloading (like C++ and Java), since the current behavior of vim-lsp results in many duplicate completion candidates for these languages.
![Python Language Server](https://user-images.githubusercontent.com/5321759/50573272-f9b98b00-0de1-11e9-9eee-3a926d3db5e4.png)
![cquery](https://user-images.githubusercontent.com/5321759/50573354-6719eb80-0de3-11e9-9549-53f2c5822378.png)
