### PR TITLE
Add lsp_location_update autocmd

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -12,6 +12,7 @@ augroup _lsp_silent_
     autocmd User lsp_unregister_server silent
     autocmd User lsp_server_init silent
     autocmd User lsp_server_exit silent
+    autocmd User lsp_location_update silent
 augroup END
 
 function! lsp#log_verbose(...) abort

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -351,7 +351,10 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
             else
                 call setqflist(a:ctx['list'])
                 echo 'Retrieved ' . a:type
-                botright copen
+                if g:lsp_quickfix_auto_open == 1
+                    botright copen
+                endif
+                doautocmd User lsp_location_update
             endif
         endif
     endif

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -18,6 +18,7 @@ let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
+let g:lsp_quickfix_auto_open = get(g:, 'lsp_quickfix_auto_open', 1)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable


### PR DESCRIPTION
Thanks for provide very cool plugin.

This PR is supporting any listing vim plugins by autocmd.

I seen #211. It's nice contribution. But I use denite.nvim rather than fzf.

I think, vim-lsp should de-coupling to other plugins or support event extensibility.

### usecase
```viml
let g:lsp_quickfix_auto_open = 0

au User lsp_setup call lsp#register_server(...)
au User lsp_location_update call MyLspLocationUpdate()
function! MyLspLocationUpdate()
  Denite quickfix " or other listing plugins.
endfunction
```