### PR TITLE
Return v:null to suppress warning

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -57,7 +57,8 @@ function! lsp#omni#complete(findstart, base) abort
         call s:send_completion_request(l:info)
 
         if g:lsp_async_completion
-            return []
+            redraw
+            return v:none
         else
             while s:completion['status'] is# s:completion_status_pending && !complete_check()
                 sleep 10m


### PR DESCRIPTION
See https://github.com/vim/vim/pull/3789

Now we can suppress warning "Pattern not found" for asynchronous completion.

https://github.com/vim/vim/commit/cee9bc2e3dc5c16a9d2a8d0e23aa0d5fdefa3a4a

