### PR TITLE
make contentChanges smaller in DidChangeTextDocumentParams 

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1,0 +1,34 @@
+The vim-lsp source code bundle part of third party's code following which carry
+their own copyright notices and license terms:
+
+* vim-lsc - https://github.com/natebosch/vim-lsc
+    * autoload/lsc/diff.vim
+    ====================================================================
+
+    Copyright 2017 vim-lsc authors
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+    ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ if executable('typescript-language-server')
 endif
 ```
 
+vim-lsp support incremental changes of Language Server Protocol.
+
 ## auto-complete
 
 Refer to docs on configuring omnifunc or [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ if executable('typescript-language-server')
 endif
 ```
 
-vim-lsp support incremental changes of Language Server Protocol.
+vim-lsp supports incremental changes of Language Server Protocol.
 
 ## auto-complete
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -426,7 +426,6 @@ function! s:ensure_conf(buf, server_name, cb) abort
 endfunction
 
 function! s:text_changes(server_name, buf) abort
-	echomsg a:server_name
   let l:sync_kind = lsp#capabilities#get_text_document_change_sync_kind(a:server_name)
 
   " When syncKind is None, return null for contentChanges.

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -409,7 +409,7 @@ function! s:text_changes(buf) abort
     let s:file_content[a:buf] = l:new_content
   else
     let l:new_content = getbufline(a:buf, 1, '$')
-    let l:changes = {'text': l:new_content}
+    let l:changes = {'text': join(l:new_content, "\n")}
     let s:file_content[a:buf] = l:new_content
   endif
   return [l:changes]

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -4,6 +4,17 @@ let s:servers = {} " { lsp_id, server_info, init_callbacks, init_result, buffers
 
 let s:notification_callbacks = [] " { name, callback }
 
+" This hold previous content for each language servers to make
+" DidChangeTextDocumentParams. The key is buffer numbers:
+"    {
+"      1: {
+"        "golsp": [ "first-line", "next-line", ... ],
+"        "bingo": [ "first-line", "next-line", ... ]
+"      },
+"      2: {
+"        "pyls": [ "first-line", "next-line", ... ]
+"      }
+"    }
 let s:file_content = {}
 
 " do nothing, place it here only to avoid the message
@@ -221,14 +232,14 @@ function! s:on_text_document_did_close() abort
     call lsp#log('s:on_text_document_did_close()', l:buf)
 endfunction
 
-function! lsp#get_last_file_content(server_name, buf) abort
+function! s:get_last_file_content(server_name, buf) abort
     if has_key(s:file_content, a:buf) && has_key(s:file_content[a:buf], a:server_name)
         return s:file_content[a:buf][a:server_name]
     endif
     return []
 endfunction
 
-function! lsp#update_file_content(server_name, buf, new) abort
+function! s:update_file_content(server_name, buf, new) abort
     if !has_key(s:file_content, a:buf)
         let s:file_content[a:buf] = {}
     endif
@@ -237,9 +248,7 @@ endfunction
 
 function! s:on_buf_wipeout(buf) abort
     if has_key(s:file_content, a:buf)
-        for l:server_name in lsp#get_whitelisted_servers()
-            call remove(s:file_content[a:buf], l:server_name)
-        endfor
+        call remove(s:file_content, a:buf)
     endif
 endfunction
 
@@ -436,16 +445,16 @@ function! s:text_changes(server_name, buf) abort
   " When syncKind is Incremental and previous content is saved.
   if l:sync_kind == 2 && has_key(s:file_content, a:buf)
     " compute diff
-    let l:old_content = lsp#get_last_file_content(a:server_name, a:buf)
+    let l:old_content = s:get_last_file_content(a:server_name, a:buf)
     let l:new_content = getbufline(a:buf, 1, '$')
     let l:changes = lsp#utils#diff#compute(l:old_content, l:new_content)
-    call lsp#update_file_content(a:server_name, a:buf, l:new_content)
+    call s:update_file_content(a:server_name, a:buf, l:new_content)
     return [l:changes]
   endif
 
   let l:new_content = getbufline(a:buf, 1, '$')
   let l:changes = {'text': join(l:new_content, "\n")}
-  call lsp#update_file_content(a:server_name, a:buf, l:new_content)
+  call s:update_file_content(a:server_name, a:buf, l:new_content)
   return [l:changes]
 endfunction
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -216,7 +216,9 @@ endfunction
 function! s:on_text_document_did_close() abort
     let l:buf = bufnr('%')
     call lsp#log('s:on_text_document_did_close()', l:buf)
-    call remove(s:file_content, l:buf)
+    if has_key(s:file_content, l:buf)
+        call remove(s:file_content, l:buf)
+    endif
 endfunction
 
 function! s:ensure_flush_all(buf, server_names) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -404,11 +404,11 @@ let s:file_content = {}
 function! s:text_changes(buf) abort
   if has_key(s:file_content, a:buf)
     let l:old_content = get(s:file_content, a:buf, [])
-    let l:new_content = getline(1, '$')
+    let l:new_content = getbufline(a:buf, 1, '$')
     let l:changes = lsp#utils#diff#compute(l:old_content, l:new_content)
     let s:file_content[a:buf] = l:new_content
   else
-    let l:new_content = getline(1, '$')
+    let l:new_content = getbufline(a:buf, 1, '$')
     let l:changes = {'text': l:new_content}
     let s:file_content[a:buf] = l:new_content
   endif
@@ -433,8 +433,6 @@ function! s:ensure_changed(buf, server_name, cb) abort
 
     let l:buffer_info['changed_tick'] = l:changed_tick
     let l:buffer_info['version'] = l:buffer_info['version'] + 1
-
-    " todo: support range in contentChanges
 
     call s:send_notification(a:server_name, {
         \ 'method': 'textDocument/didChange',
@@ -621,9 +619,7 @@ function! s:requires_eol_at_eof(buf) abort
 endfunction
 
 function! s:get_text_document_text(buf) abort
-    let l:buf_fileformat = getbufvar(a:buf, '&fileformat')
-    let l:eol = {'unix': "\n", 'dos': "\r\n", 'mac': "\r"}[l:buf_fileformat]
-    return join(getbufline(a:buf, 1, '$'), l:eol).(s:requires_eol_at_eof(a:buf) ? l:eol : '')
+    return join(getbufline(a:buf, 1, '$'), "\n")
 endfunction
 
 function! s:get_text_document(buf, buffer_info) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -135,6 +135,7 @@ function! s:register_events() abort
         autocmd BufReadPost * call s:on_text_document_did_open()
         autocmd BufWritePost * call s:on_text_document_did_save()
         autocmd BufWinLeave * call s:on_text_document_did_close()
+        autocmd BufWipeout * call s:on_buf_wipeout(bufnr('<afile>'))
         autocmd InsertLeave * call s:on_text_document_did_change()
         autocmd CursorMoved * call s:on_cursor_moved()
     augroup END
@@ -216,8 +217,11 @@ endfunction
 function! s:on_text_document_did_close() abort
     let l:buf = bufnr('%')
     call lsp#log('s:on_text_document_did_close()', l:buf)
-    if has_key(s:file_content, l:buf)
-        call remove(s:file_content, l:buf)
+endfunction
+
+function! s:on_buf_wipeout(buf) abort
+    if has_key(s:file_content, a:buf)
+        call remove(s:file_content, a:buf)
     endif
 endfunction
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -611,13 +611,6 @@ function! lsp#get_whitelisted_servers(...) abort
     return l:active_servers
 endfunction
 
-function! s:requires_eol_at_eof(buf) abort
-    let l:file_ends_with_eol = getbufvar(a:buf, '&eol')
-    let l:vim_will_save_with_eol = !getbufvar(a:buf, '&binary') &&
-                \ getbufvar(a:buf, '&fixeol')
-    return l:file_ends_with_eol || l:vim_will_save_with_eol
-endfunction
-
 function! s:get_text_document_text(buf) abort
     return join(getbufline(a:buf, 1, '$'), "\n")
 endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -160,7 +160,7 @@ function! s:on_text_document_did_save() abort
     let l:buf = bufnr('%')
     call lsp#log('s:on_text_document_did_save()', l:buf)
     for l:server_name in lsp#get_whitelisted_servers()
-        call s:ensure_flush(:buf, l:server_name, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})
+        call s:ensure_flush(l:buf, l:server_name, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})
     endfor
 endfunction
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -157,18 +157,18 @@ function! s:on_text_document_did_open() abort
 endfunction
 
 function! s:on_text_document_did_save() abort
-    call lsp#log('s:on_text_document_did_save()', bufnr('%'))
     let l:buf = bufnr('%')
+    call lsp#log('s:on_text_document_did_save()', l:buf)
     for l:server_name in lsp#get_whitelisted_servers()
-        call s:ensure_flush(bufnr('%'), l:server_name, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})
+        call s:ensure_flush(:buf, l:server_name, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})
     endfor
 endfunction
 
 function! s:on_text_document_did_change() abort
-    call lsp#log('s:on_text_document_did_change()', bufnr('%'))
     let l:buf = bufnr('%')
+    call lsp#log('s:on_text_document_did_change()', l:buf)
     for l:server_name in lsp#get_whitelisted_servers()
-        call s:ensure_flush(bufnr('%'), l:server_name, function('s:Noop'))
+        call s:ensure_flush(l:buf, l:server_name, function('s:Noop'))
     endfor
 endfunction
 
@@ -214,7 +214,9 @@ function! s:call_did_save(buf, server_name, result, cb) abort
 endfunction
 
 function! s:on_text_document_did_close() abort
-    call lsp#log('s:on_text_document_did_close()', bufnr('%'))
+    let l:buf = bufnr('%')
+    call lsp#log('s:on_text_document_did_close()', l:buf)
+    call remove(s:file_content, l:buf)
 endfunction
 
 function! s:ensure_flush_all(buf, server_names) abort

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -65,3 +65,23 @@ function! lsp#capabilities#get_text_document_save_registration_options(server_na
     endif
     return [0, { 'includeText': 0 }]
 endfunction
+
+" supports_did_change (boolean)
+function! lsp#capabilities#get_text_document_change_sync_kind(server_name) abort
+    let l:capabilities = lsp#get_server_capabilities(a:server_name)
+    if !empty(l:capabilities) && has_key(l:capabilities, 'textDocumentSync')
+        if type(l:capabilities['textDocumentSync']) == type({})
+            if  has_key(l:capabilities['textDocumentSync'], 'change') && type(l:capabilities['textDocumentSync']) == type(1)
+                let l:val = l:capabilities['textDocumentSync']['change']
+                return l:val >= 0 && l:val <= 2 ? l:val : 1
+            else
+                return 1
+            endif
+		elseif type(l:capabilities['textDocumentSync']) == type(1)
+		    return l:capabilities['textDocumentSync']
+        else
+            return 1
+        endif
+    endif
+    return 1
+endfunction

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -1,0 +1,113 @@
+" Computes a simplistic diff between [old] and [new].
+"
+" Returns a dict with keys `range`, `rangeLength`, and `text` matching the LSP
+" definition of `TextDocumentContentChangeEvent`.
+"
+" Finds a single change between the common prefix, and common postfix.
+function! lsp#utils#diff#compute(old, new) abort
+  let [start_line, start_char] = s:FirstDifference(a:old, a:new)
+  let [end_line, end_char] =
+      \ s:LastDifference(a:old[start_line:], a:new[start_line:], start_char)
+
+  let text = s:ExtractText(a:new, start_line, start_char, end_line, end_char)
+  let length = s:Length(a:old, start_line, start_char, end_line, end_char)
+
+  let adj_end_line = len(a:old) + end_line
+  let adj_end_char = end_line == 0 ? 0 : strlen(a:old[end_line]) + end_char + 1
+
+  let result = { 'range': {'start': {'line': start_line, 'character': start_char},
+      \  'end': {'line': adj_end_line, 'character': adj_end_char}},
+      \ 'text': text,
+      \ 'rangeLength': length,
+      \}
+
+  return result
+endfunction
+
+" Finds the line and character of the first different character between two
+" list of Strings.
+function! s:FirstDifference(old, new) abort
+  let line_count = min([len(a:old), len(a:new)])
+  let i = 0
+  while i < line_count
+    if a:old[i] !=# a:new[i] | break | endif
+    let i += 1
+  endwhile
+  if i >= line_count
+    return [line_count - 1, strlen(a:old[line_count - 1])]
+  endif
+  let old_line = a:old[i]
+  let new_line = a:new[i]
+  let length = min([strlen(old_line), strlen(new_line)])
+  let j = 0
+  while j < length
+    if old_line[j:j] !=# new_line[j:j] | break | endif
+    let j += 1
+  endwhile
+  return [i, j]
+endfunction
+
+function! s:LastDifference(old, new, start_char) abort
+  let line_count = min([len(a:old), len(a:new)])
+  if line_count == 0 | return [0, 0] | endif
+  let i = -1
+  while i >= -1 * line_count
+    if a:old[i] !=# a:new[i] | break | endif
+    let i -= 1
+  endwhile
+  if i <= -1 * line_count
+    let i = -1 * line_count
+    let old_line = a:old[i][a:start_char:]
+    let new_line = a:new[i][a:start_char:]
+  else
+    let old_line = a:old[i]
+    let new_line = a:new[i]
+  endif
+  let length = min([strlen(old_line), strlen(new_line)])
+  let j = -1
+  while j >= -1 * length
+    if old_line[j:j] !=# new_line[j:j] | break | endif
+    let j -= 1
+  endwhile
+  return [i, j]
+endfunction
+
+function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
+  if a:start_line == len(a:lines) + a:end_line
+    if a:end_line == 0 | return '' | endif
+    let result = a:lines[a:start_line][a:start_char:a:end_char]
+    " json_encode treats empty string computed this was as 'null'
+    if strlen(result) == 0 | let result = '' | endif
+    return result
+  endif
+  let result = a:lines[a:start_line][a:start_char:]."\n"
+  let adj_end_line = len(a:lines) + a:end_line
+  for line in a:lines[a:start_line + 1:a:end_line - 1]
+    let result .= line."\n"
+  endfor
+  if a:end_line != 0
+    let result .= a:lines[a:end_line][:a:end_char]
+  endif
+  return result
+endfunction
+
+function! s:Length(lines, start_line, start_char, end_line, end_char)
+    \ abort
+  let adj_end_line = len(a:lines) + a:end_line
+  if adj_end_line >= len(a:lines)
+    let adj_end_char = a:end_char - 1
+  else
+    let adj_end_char = strlen(a:lines[adj_end_line]) + a:end_char
+  endif
+  if a:start_line == adj_end_line
+    return adj_end_char - a:start_char + 1
+  endif
+  let result = strlen(a:lines[a:start_line]) - a:start_char + 1
+  let line = a:start_line + 1
+  while line < adj_end_line
+    let result += strlen(a:lines[line]) + 1
+    let line += 1
+  endwhile
+  let result += adj_end_char + 1
+  return result
+endfunction

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -9,7 +9,7 @@
 function! lsp#utils#diff#compute(old, new) abort
   let [l:start_line, l:start_char] = s:FirstDifference(a:old, a:new)
   let [l:end_line, l:end_char] =
-      \ s:LastDifference(a:old[l:start_line:], a:new[l:start_line:], l:start_char)
+      \ s:LastDifference(a:old[l:start_line :], a:new[l:start_line :], l:start_char)
 
   let l:text = s:ExtractText(a:new, l:start_line, l:start_char, l:end_line, l:end_char)
   let l:length = s:Length(a:old, l:start_line, l:start_char, l:end_line, l:end_char)
@@ -43,7 +43,7 @@ function! s:FirstDifference(old, new) abort
   let l:length = min([strlen(l:old_line), strlen(l:new_line)])
   let l:j = 0
   while l:j < l:length
-    if l:old_line[l:j:l:j] !=# l:new_line[l:j:l:j] | break | endif
+    if l:old_line[l:j : l:j] !=# l:new_line[l:j : l:j] | break | endif
     let l:j += 1
   endwhile
   return [l:i, l:j]
@@ -59,8 +59,8 @@ function! s:LastDifference(old, new, start_char) abort
   endwhile
   if l:i <= -1 * l:line_count
     let l:i = -1 * l:line_count
-    let l:old_line = a:old[l:i][a:start_char:]
-    let l:new_line = a:new[l:i][a:start_char:]
+    let l:old_line = a:old[l:i][a:start_char :]
+    let l:new_line = a:new[l:i][a:start_char :]
   else
     let l:old_line = a:old[l:i]
     let l:new_line = a:new[l:i]
@@ -68,7 +68,7 @@ function! s:LastDifference(old, new, start_char) abort
   let l:length = min([strlen(l:old_line), strlen(l:new_line)])
   let l:j = -1
   while l:j >= -1 * l:length
-    if l:old_line[l:j:l:j] !=# l:new_line[l:j:l:j] | break | endif
+    if l:old_line[l:j : l:j] !=# l:new_line[l:j : l:j] | break | endif
     let l:j -= 1
   endwhile
   return [l:i, l:j]
@@ -77,12 +77,12 @@ endfunction
 function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
   if a:start_line == len(a:lines) + a:end_line
     if a:end_line == 0 | return '' | endif
-    let l:result = a:lines[a:start_line][a:start_char:a:end_char]
+    let l:result = a:lines[a:start_line][a:start_char : a:end_char]
     " json_encode treats empty string computed this was as 'null'
     if strlen(l:result) == 0 | let l:result = '' | endif
     return l:result
   endif
-  let l:result = a:lines[a:start_line][a:start_char:]."\n"
+  let l:result = a:lines[a:start_line][a:start_char :]."\n"
   let l:adj_end_line = len(a:lines) + a:end_line
   for l:line in a:lines[a:start_line + 1:a:end_line - 1]
     let l:result .= l:line."\n"

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -7,109 +7,109 @@
 "
 " Finds a single change between the common prefix, and common postfix.
 function! lsp#utils#diff#compute(old, new) abort
-  let [start_line, start_char] = s:FirstDifference(a:old, a:new)
-  let [end_line, end_char] =
-      \ s:LastDifference(a:old[start_line:], a:new[start_line:], start_char)
+  let [l:start_line, l:start_char] = s:FirstDifference(a:old, a:new)
+  let [l:end_line, l:end_char] =
+      \ s:LastDifference(a:old[l:start_line:], a:new[l:start_line:], l:start_char)
 
-  let text = s:ExtractText(a:new, start_line, start_char, end_line, end_char)
-  let length = s:Length(a:old, start_line, start_char, end_line, end_char)
+  let l:text = s:ExtractText(a:new, l:start_line, l:start_char, l:end_line, l:end_char)
+  let l:length = s:Length(a:old, l:start_line, l:start_char, l:end_line, l:end_char)
 
-  let adj_end_line = len(a:old) + end_line
-  let adj_end_char = end_line == 0 ? 0 : strlen(a:old[end_line]) + end_char + 1
+  let l:adj_end_line = len(a:old) + l:end_line
+  let l:adj_end_char = l:end_line == 0 ? 0 : strlen(a:old[l:end_line]) + l:end_char + 1
 
-  let result = { 'range': {'start': {'line': start_line, 'character': start_char},
-      \  'end': {'line': adj_end_line, 'character': adj_end_char}},
-      \ 'text': text,
-      \ 'rangeLength': length,
+  let l:result = { 'range': {'start': {'line': l:start_line, 'character': l:start_char},
+      \  'end': {'line': l:adj_end_line, 'character': l:adj_end_char}},
+      \ 'text': l:text,
+      \ 'rangeLength': l:length,
       \}
 
-  return result
+  return l:result
 endfunction
 
 " Finds the line and character of the first different character between two
 " list of Strings.
 function! s:FirstDifference(old, new) abort
-  let line_count = min([len(a:old), len(a:new)])
-  let i = 0
-  while i < line_count
-    if a:old[i] !=# a:new[i] | break | endif
-    let i += 1
+  let l:line_count = min([len(a:old), len(a:new)])
+  let l:i = 0
+  while l:i < l:line_count
+    if a:old[l:i] !=# a:new[l:i] | break | endif
+    let l:i += 1
   endwhile
-  if i >= line_count
-    return [line_count - 1, strlen(a:old[line_count - 1])]
+  if i >= l:line_count
+    return [l:line_count - 1, strlen(a:old[l:line_count - 1])]
   endif
-  let old_line = a:old[i]
-  let new_line = a:new[i]
-  let length = min([strlen(old_line), strlen(new_line)])
-  let j = 0
-  while j < length
-    if old_line[j:j] !=# new_line[j:j] | break | endif
-    let j += 1
+  let l:old_line = a:old[l:i]
+  let l:new_line = a:new[l:i]
+  let l:length = min([strlen(l:old_line), strlen(l:new_line)])
+  let l:j = 0
+  while l:j < l:length
+    if l:old_line[l:j:l:j] !=# l:new_line[l:j:l:j] | break | endif
+    let l:j += 1
   endwhile
-  return [i, j]
+  return [l:i, l:j]
 endfunction
 
 function! s:LastDifference(old, new, start_char) abort
-  let line_count = min([len(a:old), len(a:new)])
-  if line_count == 0 | return [0, 0] | endif
-  let i = -1
-  while i >= -1 * line_count
-    if a:old[i] !=# a:new[i] | break | endif
-    let i -= 1
+  let l:line_count = min([len(a:old), len(a:new)])
+  if l:line_count == 0 | return [0, 0] | endif
+  let l:i = -1
+  while l:i >= -1 * l:line_count
+    if a:old[l:i] !=# a:new[l:i] | break | endif
+    let l:i -= 1
   endwhile
-  if i <= -1 * line_count
-    let i = -1 * line_count
-    let old_line = a:old[i][a:start_char:]
-    let new_line = a:new[i][a:start_char:]
+  if l:i <= -1 * l:line_count
+    let l:i = -1 * l:line_count
+    let l:old_line = a:old[l:i][a:start_char:]
+    let l:new_line = a:new[l:i][a:start_char:]
   else
-    let old_line = a:old[i]
-    let new_line = a:new[i]
+    let l:old_line = a:old[l:i]
+    let l:new_line = a:new[l:i]
   endif
-  let length = min([strlen(old_line), strlen(new_line)])
-  let j = -1
-  while j >= -1 * length
-    if old_line[j:j] !=# new_line[j:j] | break | endif
-    let j -= 1
+  let l:length = min([strlen(l:old_line), strlen(l:new_line)])
+  let l:j = -1
+  while l:j >= -1 * l:length
+    if l:old_line[l:j:l:j] !=# l:new_line[l:j:l:j] | break | endif
+    let l:j -= 1
   endwhile
-  return [i, j]
+  return [l:i, l:j]
 endfunction
 
 function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
   if a:start_line == len(a:lines) + a:end_line
     if a:end_line == 0 | return '' | endif
-    let result = a:lines[a:start_line][a:start_char:a:end_char]
+    let l:result = a:lines[a:start_line][a:start_char:a:end_char]
     " json_encode treats empty string computed this was as 'null'
-    if strlen(result) == 0 | let result = '' | endif
-    return result
+    if strlen(l:result) == 0 | let l:result = '' | endif
+    return l:result
   endif
-  let result = a:lines[a:start_line][a:start_char:]."\n"
-  let adj_end_line = len(a:lines) + a:end_line
-  for line in a:lines[a:start_line + 1:a:end_line - 1]
-    let result .= line."\n"
+  let l:result = a:lines[a:start_line][a:start_char:]."\n"
+  let l:adj_end_line = len(a:lines) + a:end_line
+  for l:line in a:lines[a:start_line + 1:a:end_line - 1]
+    let l:result .= l:line."\n"
   endfor
   if a:end_line != 0
-    let result .= a:lines[a:end_line][:a:end_char]
+    let l:result .= a:lines[a:end_line][:a:end_char]
   endif
-  return result
+  return l:result
 endfunction
 
 function! s:Length(lines, start_line, start_char, end_line, end_char)
     \ abort
-  let adj_end_line = len(a:lines) + a:end_line
-  if adj_end_line >= len(a:lines)
-    let adj_end_char = a:end_char - 1
+  let l:adj_end_line = len(a:lines) + a:end_line
+  if l:adj_end_line >= len(a:lines)
+    let l:adj_end_char = a:end_char - 1
   else
-    let adj_end_char = strlen(a:lines[adj_end_line]) + a:end_char
+    let l:adj_end_char = strlen(a:lines[l:adj_end_line]) + a:end_char
   endif
-  if a:start_line == adj_end_line
-    return adj_end_char - a:start_char + 1
+  if a:start_line == l:adj_end_line
+    return l:adj_end_char - a:start_char + 1
   endif
-  let result = strlen(a:lines[a:start_line]) - a:start_char + 1
-  let line = a:start_line + 1
-  while line < adj_end_line
-    let result += strlen(a:lines[line]) + 1
-    let line += 1
+  let l:result = strlen(a:lines[a:start_line]) - a:start_char + 1
+  let l:line = a:start_line + 1
+  while l:line < l:adj_end_line
+    let l:result += strlen(a:lines[l:line]) + 1
+    let l:line += 1
   endwhile
-  let result += adj_end_char + 1
-  return result
+  let l:result += l:adj_end_char + 1
+  return l:result
 endfunction

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -1,3 +1,5 @@
+" This is copied from https://github.com/natebosch/vim-lsc/blob/master/autoload/lsc/diff.vim
+"
 " Computes a simplistic diff between [old] and [new].
 "
 " Returns a dict with keys `range`, `rangeLength`, and `text` matching the LSP


### PR DESCRIPTION
Current implementation send whole text of buffer when text was changed. This make vim slowly. This change make it smaller using https://github.com/natebosch/vim-lsc/blob/master/autoload/lsc/diff.vim .

Thanks to @natebosch

See following screenshots. I'm editing src/compiler/checker.ts (1.8MB) in repository of typescript .

# Before applying this change

![omni-old](https://user-images.githubusercontent.com/10111/51084630-97ad3e00-1770-11e9-9d51-3ce570ad835e.gif)

# After applying this change

![omni-new](https://user-images.githubusercontent.com/10111/51084638-ab58a480-1770-11e9-9438-03d6f374ca6e.gif)

I guess most of time was taken in typescript-language-server.

If the buffer is smaller, completion is very fast.

![omni-new](https://user-images.githubusercontent.com/10111/51084699-bfe96c80-1771-11e9-978e-603ffd0fe0d8.gif)
