### PR TITLE
*DO NOT MERGE* sample snippet support

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -391,6 +391,13 @@ function! s:ensure_init(buf, server_name, cb) abort
         let l:capabilities = l:server_info['capabilities']
     else
         let l:capabilities = {
+        \   'textDocument': {
+        \       'completion': {
+        \           'completionItem': {
+        \               'snippetSupport': v:true,
+        \           },
+        \       },
+        \   },
         \   'workspace': {
         \       'applyEdit ': v:true
         \   }

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -160,12 +160,21 @@ function! lsp#omni#get_vim_completion_item(item) abort
         else
             let l:word = a:item['insertText']
         endif
+        if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
+            let l:snippet = substitute(a:item['insertText'], '$0', '${0:}', '')
+            let l:snippet = a:item['insertText']
+        endif
         let l:abbr = a:item['label']
     else
         let l:word = a:item['label']
         let l:abbr = a:item['label']
     endif
-    let l:menu = lsp#omni#get_kind_text(a:item)
+    if exists('l:snippet')
+        let l:menu = 'Snip'
+        call SimpleSnippets#addFlashSnippet(l:word, l:snippet)
+    else
+        let l:menu = lsp#omni#get_kind_text(a:item)
+    endif
     let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])


### PR DESCRIPTION
**Do not merge**. This is me trying out how we can support snippets in vim-lsp.
This is using https://github.com/andreyorst/SimpleSnippets-snippets but we should allow anyone to hook into vim-lsp so they can easily use any snippet plugins they use.

```vim
Plug 'andreyorst/SimpleSnippets.vim'
Plug 'prabirshrestha/async.vim'
Plug 'prabirshrestha/vim-lsp'
Plug 'prabirshrestha/asyncomplete.vim'
Plug 'prabirshrestha/asyncomplete-lsp.vim'

autocmd! CompleteDone * if pumvisible() == 0 | pclose | endif
let g:asyncomplete_auto_popup = 1

let g:SimpleSnippets_dont_remap_tab = 1
inoremap <silent><expr><Tab> pumvisible() ? "\<c-n>" :
    \SimpleSnippets#isExpandableOrJumpable() ?
    \"<Esc>:call SimpleSnippets#expandOrJump()<Cr>" :
    \"\<Tab>"
inoremap <silent><expr><S-Tab> pumvisible() ? "\<c-p>" :
    \SimpleSnippets#isJumpable() ?
    \"<Esc>:call SimpleSnippets#jumpBackwards()<Cr>" :
    \"\<S-Tab>"
inoremap <silent><expr><Cr> pumvisible() ?
    \SimpleSnippets#isExpandableOrJumpable() ?
    \"\<Esc>:call SimpleSnippets#expandOrJump()\<Cr>" :
    \"\<Cr>" : "\<Cr>"
snoremap <silent><expr><Tab> SimpleSnippets#isExpandableOrJumpable() ?
    \"<Esc>:call SimpleSnippets#expandOrJump()<Cr>" : "\<Tab>"
snoremap <silent><expr><S-Tab> SimpleSnippets#isJumpable() ?
    \"<Esc>:call SimpleSnippets#jumpBackwards()<Cr>" :
    \"\<S-Tab>"

if executable('cquery')
  au User lsp_setup call lsp#register_server({
    \ 'name': 'cquery',
    \ 'cmd': {server_info->['cquery']},
    \ 'root_uri': {server_info->lsp#utils#path_to_uri(lsp#utils#find_nearest_parent_file_directory(lsp#utils#get_buffer_path(), 'compile_commands.json'))},
    \ 'initialization_options': { 'cacheDirectory':  '/tmp/cquery' },
    \ 'whitelist': ['c', 'cpp', 'objc', 'objcpp'],
    \ })
endif
```