### PR TITLE
Prepare range for rename

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -1,7 +1,7 @@
 function! s:has_bool_provider(server_name, ...) abort
     let l:value = lsp#get_server_capabilities(a:server_name)
     for l:provider in a:000
-        if empty(l:value) || !has_key(l:value, l:provider) || type(l:value) != type({})
+        if empty(l:value) || type(l:value) != type({}) || !has_key(l:value, l:provider)
             return 0
         endif
         let l:value = l:value[l:provider]
@@ -26,7 +26,11 @@ function! lsp#capabilities#has_hover_provider(server_name) abort
 endfunction
 
 function! lsp#capabilities#has_rename_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'renameProvider') || s:has_bool_provider(a:server_name, 'renameProvider', 'prepareProvider')
+    return s:has_bool_provider(a:server_name, 'renameProvider')
+endfunction
+
+function! lsp#capabilities#has_rename_prepare_provider(server_name) abort
+    return s:has_bool_provider(a:server_name, 'renameProvider', 'prepareProvider')
 endfunction
 
 function! lsp#capabilities#has_document_formatting_provider(server_name) abort

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -129,7 +129,7 @@ function! lsp#ui#vim#references() abort
     echo 'Retrieving references ...'
 endfunction
 
-function! s:rename(server, new_name) abort
+function! s:rename(server, new_name, pos) abort
     if empty(a:new_name)
         echo '... Renaming aborted ...'
         return
@@ -140,7 +140,7 @@ function! s:rename(server, new_name) abort
         \ 'method': 'textDocument/rename',
         \ 'params': {
         \   'textDocument': lsp#get_text_document_identifier(),
-        \   'position': lsp#get_position(),
+        \   'position': a:pos,
         \   'newName': a:new_name,
         \ },
         \ 'on_notification': function('s:handle_workspace_edit', [a:server, s:last_req_id, 'rename']),
@@ -179,7 +179,7 @@ function! lsp#ui#vim#rename() abort
         return
     endif
 
-    call s:rename(l:server, input('new name: ', expand('<cword>')))
+    call s:rename(l:server, input('new name: ', expand('<cword>')), lsp#get_position())
 endfunction
 
 function! s:document_format(sync) abort
@@ -429,7 +429,7 @@ function! s:handle_rename_prepare(server, last_req_id, type, data) abort
         let l:name .= l:lines[l:range['end']['line']][: l:range['end']['character']-1]
     endif
 
-    call timer_start(1, {x->s:rename(a:server, input('new name: ', l:name))})
+    call timer_start(1, {x->s:rename(a:server, input('new name: ', l:name), l:range['start'])})
 endfunction
 
 function! s:handle_workspace_edit(server, last_req_id, type, data) abort

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -129,8 +129,36 @@ function! lsp#ui#vim#references() abort
     echo 'Retrieving references ...'
 endfunction
 
+function! s:rename(server, old_name) abort
+    let l:new_name = input('new name: ', a:old_name)
+
+    if empty(l:new_name)
+        echo '... Renaming aborted ...'
+        return
+    endif
+
+    " needs to flush existing open buffers
+    call lsp#send_request(a:server, {
+        \ 'method': 'textDocument/rename',
+        \ 'params': {
+        \   'textDocument': lsp#get_text_document_identifier(),
+        \   'position': lsp#get_position(),
+        \   'newName': l:new_name,
+        \ },
+        \ 'on_notification': function('s:handle_workspace_edit', [a:server, s:last_req_id, 'rename']),
+        \ })
+
+    echo ' ... Renaming ...'
+endfunction
+
 function! lsp#ui#vim#rename() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_rename_provider(v:val)')
+    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_rename_prepare_provider(v:val)')
+    let l:prepare_support = 1
+    if len(l:servers) == 0
+        let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_rename_provider(v:val)')
+        let l:prepare_support = 0
+    endif
+
     let s:last_req_id = s:last_req_id + 1
 
     if len(l:servers) == 0
@@ -138,27 +166,22 @@ function! lsp#ui#vim#rename() abort
         return
     endif
 
-    let l:new_name = input('new name: ', expand('<cword>'))
+    " TODO: ask the user which server it should use to rename if there are multiple
+    let l:server = l:servers[0]
 
-    if empty(l:new_name)
-        echo '... Renaming aborted ...'
+    if l:prepare_support
+        call lsp#send_request(l:server, {
+            \ 'method': 'textDocument/prepareRename',
+            \ 'params': {
+            \   'textDocument': lsp#get_text_document_identifier(),
+            \   'position': lsp#get_position(),
+            \ },
+            \ 'on_notification': function('s:handle_rename_prepare', [l:server, s:last_req_id, 'rename_prepare']),
+            \ })
         return
     endif
 
-    " TODO: ask the user which server it should use to rename if there are multiple
-    let l:server = l:servers[0]
-    " needs to flush existing open buffers
-    call lsp#send_request(l:server, {
-        \ 'method': 'textDocument/rename',
-        \ 'params': {
-        \   'textDocument': lsp#get_text_document_identifier(),
-        \   'position': lsp#get_position(),
-        \   'newName': l:new_name,
-        \ },
-        \ 'on_notification': function('s:handle_workspace_edit', [l:server, s:last_req_id, 'rename']),
-        \ })
-
-    echo ' ... Renaming ...'
+    call s:rename(l:server, expand('<cword>'))
 endfunction
 
 function! s:document_format(sync) abort
@@ -380,6 +403,31 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
             endif
         endif
     endif
+endfunction
+
+function! s:handle_rename_prepare(server, last_req_id, type, data) abort
+    if a:last_req_id != s:last_req_id
+        return
+    endif
+
+    if lsp#client#is_error(a:data['response'])
+        call lsp#utils#error('Failed to retrieve '. a:type . ' for ' . a:server . ': ' . lsp#client#error_message(a:data['response']))
+        return
+    endif
+
+    let l:range = a:data['response']['result']
+    let l:lines = getline(1, '$')
+    if l:range['start']['line'] ==# l:range['end']['line']
+        let l:name = l:lines[l:range['start']['line']][l:range['start']['character'] : l:range['end']['character']-1]
+    else
+        let l:name = l:lines[l:range['start']['line']][l:range['start']['character'] :]
+        for l:i in range(l:range['start']['line']+1, l:range['end']['line']-1)
+            let l:name .= "\n" . l:lines[l:i]
+        endfor
+        let l:name .= l:lines[l:range['end']['line']][: l:range['end']['character']-1]
+    endif
+
+    call s:rename(a:server, l:name)
 endfunction
 
 function! s:handle_workspace_edit(server, last_req_id, type, data) abort

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -129,10 +129,8 @@ function! lsp#ui#vim#references() abort
     echo 'Retrieving references ...'
 endfunction
 
-function! s:rename(server, old_name) abort
-    let l:new_name = input('new name: ', a:old_name)
-
-    if empty(l:new_name)
+function! s:rename(server, new_name) abort
+    if empty(a:new_name)
         echo '... Renaming aborted ...'
         return
     endif
@@ -143,7 +141,7 @@ function! s:rename(server, old_name) abort
         \ 'params': {
         \   'textDocument': lsp#get_text_document_identifier(),
         \   'position': lsp#get_position(),
-        \   'newName': l:new_name,
+        \   'newName': a:new_name,
         \ },
         \ 'on_notification': function('s:handle_workspace_edit', [a:server, s:last_req_id, 'rename']),
         \ })
@@ -181,7 +179,7 @@ function! lsp#ui#vim#rename() abort
         return
     endif
 
-    call s:rename(l:server, expand('<cword>'))
+    call s:rename(l:server, input('new name: ', expand('<cword>')))
 endfunction
 
 function! s:document_format(sync) abort
@@ -427,7 +425,7 @@ function! s:handle_rename_prepare(server, last_req_id, type, data) abort
         let l:name .= l:lines[l:range['end']['line']][: l:range['end']['character']-1]
     endif
 
-    call s:rename(a:server, l:name)
+    call timer_start(1, {x->s:rename(a:server, input('new name: ', l:name))})
 endfunction
 
 function! s:handle_workspace_edit(server, last_req_id, type, data) abort


### PR DESCRIPTION
Related to https://github.com/prabirshrestha/vim-lsp/issues/212

Vim does not know which range will be replaced while rename. And `expand('<cword>')` is depend on `iskeyword` option of vim. So resolve range for the rename.