### PR TITLE
Add g:lsp_insert_text_enabled option

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -154,7 +154,7 @@ function! s:get_completion_result(data) abort
 endfunction
 
 function! lsp#omni#get_vim_completion_item(item) abort
-    if has_key(a:item, 'insertText') && !empty(a:item['insertText'])
+    if g:lsp_insert_text_enabled && has_key(a:item, 'insertText') && !empty(a:item['insertText'])
         if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] != 1
             let l:word = a:item['label']
         else

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -13,6 +13,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_diagnostics_enabled   |g:lsp_diagnostics_enabled|
       g:lsp_auto_enable           |g:lsp_auto_enable|
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
+      g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -134,6 +135,18 @@ g:lsp_preview_keep_focus                         *g:lsp_preview_keep_focus*
 	let g:lsp_preview_keep_focus = 0
 
     * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
+
+g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
+    Type: |Number|
+    Default: `1`
+
+    Enable support for completion insertText property. Set to `0` to disable
+    using insertText.
+
+    Example:
+	let g:lsp_insert_text_enabled = 1
+	let g:lsp_insert_text_enabled = 0
+
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -19,6 +19,7 @@ let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', 0)
+let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable


### PR DESCRIPTION
Related to #261 

Add `g:lsp_insert_text_enabled` option to opt in or opt out `insertText` for completion.
Default value is `1`. So, this PR do not change behavior if `g:lsp_insert_text_enabled` is not set.

```vim
" Enable to use insertText (Default)
let g:lsp_insert_text_enabled = 1
" Disable to use insertText
let g:lsp_insert_text_enabled = 0
```