### PR TITLE
Reapply fixes for EOL injection.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -664,8 +664,17 @@ function! lsp#get_whitelisted_servers(...) abort
     return l:active_servers
 endfunction
 
+function! s:requires_eol_at_eof(buf) abort
+    let l:file_ends_with_eol = getbufvar(a:buf, '&eol')
+    let l:vim_will_save_with_eol = !getbufvar(a:buf, '&binary') &&
+                \ getbufvar(a:buf, '&fixeol')
+    return l:file_ends_with_eol || l:vim_will_save_with_eol
+endfunction
+
 function! s:get_text_document_text(buf, server_name) abort
-    return join(s:get_last_file_content(a:server_name, a:buf), "\n")
+    let l:buf_fileformat = getbufvar(a:buf, '&fileformat')
+    let l:eol = {'unix': "\n", 'dos': "\r\n", 'mac': "\r"}[l:buf_fileformat]
+    return join(s:get_last_file_content(a:server_name, a:buf), l:eol).(s:requires_eol_at_eof(a:buf) ? l:eol : '')
 endfunction
 
 function! s:get_text_document(buf, server_name, buffer_info) abort


### PR DESCRIPTION
PRs #160 (merged in 3cee859) and #158 (merged in 9806023) introduce the
use of a platform-specific EOL marker and logic to conditionally inject
an extra EOL at the end of the last line when sending file contents to
the language server.

These fixes resolved an issue where some backends (pyls with flake8, for
example) would raise a linter error due to a missing EOL at the end of
the file. They were reverted in 34c2a1e and 1e0c19d, presumably by
accident.

Resolves #264 