### PR TITLE
Skip loading on old versions of vim without json

### DIFF
--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -1,4 +1,4 @@
-if exists('g:lsp_loaded')
+if exists('g:lsp_loaded') || !exists('*json_encode') || !has('timers') || !has('lambda')
     finish
 endif
 let g:lsp_loaded = 1


### PR DESCRIPTION
Avoid barfing up errors if user edits a file where lsp is configured,
but we can't run. 

I was getting errors because json_encode didn't exist before, but this commit fixes them.

Tested on Vim 7.4.52 (package provided on Ubuntu for Windows Subsystem for Linux):

    VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:43:18)
    Included patches: 1-52
    Extra patches: 8.0.0056
