### PR TITLE
Fix sending empty changes when deleting text

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -452,7 +452,7 @@ function! s:text_changes(buf, server_name) abort
         let l:old_content = s:get_last_file_content(a:buf, a:server_name)
         let l:new_content = getbufline(a:buf, 1, '$')
         let l:changes = lsp#utils#diff#compute(l:old_content, l:new_content)
-        if empty(l:changes.text) && l:changes.rangeLength == 0
+        if empty(l:changes.text) && l:changes.rangeLength ==# 0
             return []
         endif
         call s:update_file_content(a:buf, a:server_name, l:new_content)

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -452,7 +452,7 @@ function! s:text_changes(buf, server_name) abort
         let l:old_content = s:get_last_file_content(a:buf, a:server_name)
         let l:new_content = getbufline(a:buf, 1, '$')
         let l:changes = lsp#utils#diff#compute(l:old_content, l:new_content)
-        if empty(l:changes.text)
+        if empty(l:changes.text) && l:changes.rangeLength == 0
             return []
         endif
         call s:update_file_content(a:buf, a:server_name, l:new_content)


### PR DESCRIPTION
When incremental sync is enabled, text deletion is not sent to the server. In this case, `contextChanges` is empty as shown below.
```
Tue 29 Jan 2019 10:22:23 AM JST:["--->",1,"pyls",{"method":"textDocument/didChange","params":{"contentChanges":[],"textDocument":{"uri":"file:///home/pi/test.py","version":5}}}]
```
I fixed it so that the diff is sent correctly like below.
```
Tue 29 Jan 2019 10:21:00 AM JST:["--->",1,"pyls",{"method":"textDocument/didChange","params":{"contentChanges":[{"range":{"end":{"character":16,"line":0},"start":{"character":0,"line":0}},"text":"","rangeLength":16}],"textDocument":{"uri":"file:///home/pi/test.py","version":5}}}]
```