### PR TITLE
normalize URI for diagnostic on Windows

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -6,6 +6,9 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
         return
     endif
     let l:uri = a:data['response']['params']['uri']
+    if s:is_win
+        let l:uri = substitute(l:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
+    endif
     if !has_key(s:diagnostics, l:uri)
         let s:diagnostics[l:uri] = {}
     endif


### PR DESCRIPTION
`lsp#ui#vim#diagnostics#get_diagnostics_under_cursor()` always return 0 on some langserver since some of langserver encode `:` to `%3A` (ex: clangd).

