### PR TITLE
Split window with jumping to another file from modified buffer

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -369,7 +369,11 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 normal! m'
                 let l:loc = a:ctx['list'][0]
                 let l:buffer = bufnr(l:loc['filename'])
-                let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:loc['filename']
+                if &modified
+                    let l:cmd = l:buffer !=# -1 ? 'sb ' . l:buffer : 'split ' . l:loc['filename']
+                else
+                    let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:loc['filename']
+                endif
                 execute l:cmd . ' | call cursor('.l:loc['lnum'].','.l:loc['col'].')'
                 echo 'Retrieved ' . a:type
                 redraw


### PR DESCRIPTION
When LspDefinition on modified buffer, E37 occured. Window should be splited.