### PR TITLE
Handle partial matches in omnicompletion

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -142,7 +142,7 @@ function! s:get_completion_result(data) abort
 endfunction
 
 
-function! lsp#omni#remove_typed_part(word) abort
+function! s:remove_typed_part(word) abort
     let l:current_line = strpart(getline('.'), 0, col('.') - 1)
 
     let l:overlap_length = 0
@@ -176,7 +176,7 @@ function! lsp#omni#get_vim_completion_item(item) abort
         let l:abbr = a:item['label']
     endif
 
-    let l:word = lsp#omni#remove_typed_part(l:word)
+    let l:word = s:remove_typed_part(l:word)
     let l:menu = lsp#omni#get_kind_text(a:item)
     let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -38,17 +38,13 @@ let s:completion_status_pending = 'pending'
 let s:completion = {'counter': 0, 'status': '', 'matches': []}
 
 function! lsp#omni#complete(findstart, base) abort
-    let l:info = s:find_complete_servers_and_start_pos()
+    let l:info = s:find_complete_servers()
     if empty(l:info['server_names'])
         return a:findstart ? -1 : []
     endif
 
     if a:findstart
-        if g:lsp_async_completion
-            return col('.')
-        else
-            return l:info['findstart'] - 1
-        endif
+        return col('.')
     else
         if !g:lsp_async_completion
             let s:completion['status'] = s:completion_status_pending
@@ -71,7 +67,7 @@ function! lsp#omni#complete(findstart, base) abort
     endif
 endfunction
 
-function! s:handle_omnicompletion(server_name, startcol, complete_counter, data) abort
+function! s:handle_omnicompletion(server_name, complete_counter, data) abort
     if s:completion['counter'] != a:complete_counter
         " ignore old completion results
         return
@@ -86,7 +82,7 @@ function! s:handle_omnicompletion(server_name, startcol, complete_counter, data)
     let l:matches = l:result['matches']
 
     if g:lsp_async_completion
-        call complete(a:startcol, l:matches)
+        call complete(col('.'), l:matches)
     else
         let s:completion['matches'] = l:matches
         let s:completion['status'] = s:completion_status_success
@@ -99,7 +95,7 @@ endfunction
 
 " auxiliary functions {{{
 
-function! s:find_complete_servers_and_start_pos() abort
+function! s:find_complete_servers() abort
     let l:server_names = []
     for l:server_name in lsp#get_whitelisted_servers()
         let l:init_capabilities = lsp#get_server_capabilities(l:server_name)
@@ -109,16 +105,7 @@ function! s:find_complete_servers_and_start_pos() abort
         endif
     endfor
 
-    let l:typed = strpart(getline('.'), 0, col('.') - 1)
-    " TODO: allow user to customize refresh patterns
-    let l:refresh_pattern = '\k\+$'
-    let l:matchpos = lsp#utils#matchstrpos(l:typed, l:refresh_pattern)
-    let l:startpos = l:matchpos[1]
-    let l:endpos = l:matchpos[2]
-    let l:typed_len = l:endpos - l:startpos
-    let l:findstart = len(l:typed) - l:typed_len + 1
-
-    return { 'findstart': l:findstart, 'server_names': l:server_names }
+    return { 'server_names': l:server_names }
 endfunction
 
 function! s:send_completion_request(info) abort
@@ -131,7 +118,7 @@ function! s:send_completion_request(info) abort
                 \   'textDocument': lsp#get_text_document_identifier(),
                 \   'position': lsp#get_position(),
                 \ },
-                \ 'on_notification': function('s:handle_omnicompletion', [l:server_name, a:info['findstart'], s:completion['counter']]),
+                \ 'on_notification': function('s:handle_omnicompletion', [l:server_name, s:completion['counter']]),
                 \ })
 endfunction
 
@@ -154,6 +141,28 @@ function! s:get_completion_result(data) abort
     return {'matches': l:matches, 'incomplete': l:incomplete}
 endfunction
 
+
+function! lsp#omni#remove_typed_part(word) abort
+    let l:current_line = strpart(getline('.'), 0, col('.') - 1)
+
+    let l:overlap_length = 0
+    let l:i = 1
+    let l:max_possible_overlap = min([len(a:word), len(l:current_line)])
+
+    while l:i <= l:max_possible_overlap
+        let l:current_line_suffix = strpart(l:current_line, len(l:current_line) - l:i, l:i)
+        let l:word_prefix = strpart(a:word, 0, l:i)
+
+        if l:current_line_suffix == l:word_prefix
+            let l:overlap_length = l:i
+        endif
+
+        let l:i += 1
+    endwhile
+
+    return strpart(a:word, l:overlap_length)
+endfunction
+
 function! lsp#omni#get_vim_completion_item(item) abort
     if g:lsp_insert_text_enabled && has_key(a:item, 'insertText') && !empty(a:item['insertText'])
         if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] != 1
@@ -166,6 +175,8 @@ function! lsp#omni#get_vim_completion_item(item) abort
         let l:word = a:item['label']
         let l:abbr = a:item['label']
     endif
+
+    let l:word = lsp#omni#remove_typed_part(l:word)
     let l:menu = lsp#omni#get_kind_text(a:item)
     let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -136,7 +136,7 @@ function! s:get_completion_result(data) abort
         let l:incomplete = 0
     endif
 
-    let l:matches = type(l:items) == type([]) ? map(l:items, {_, item -> lsp#omni#get_vim_completion_item(item) }) : []
+    let l:matches = type(l:items) == type([]) ? map(l:items, {_, item -> lsp#omni#get_vim_completion_item(item, 1) }) : []
 
     return {'matches': l:matches, 'incomplete': l:incomplete}
 endfunction
@@ -163,7 +163,9 @@ function! s:remove_typed_part(word) abort
     return strpart(a:word, l:overlap_length)
 endfunction
 
-function! lsp#omni#get_vim_completion_item(item) abort
+function! lsp#omni#get_vim_completion_item(item, ...) abort
+    let a:do_remove_typed_part = get(a:, 1, 0)
+
     if g:lsp_insert_text_enabled && has_key(a:item, 'insertText') && !empty(a:item['insertText'])
         if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] != 1
             let l:word = a:item['label']
@@ -176,7 +178,9 @@ function! lsp#omni#get_vim_completion_item(item) abort
         let l:abbr = a:item['label']
     endif
 
-    let l:word = s:remove_typed_part(l:word)
+    if a:do_remove_typed_part
+        let l:word = s:remove_typed_part(l:word)
+    endif
     let l:menu = lsp#omni#get_kind_text(a:item)
     let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
 


### PR DESCRIPTION
Instead of choosing a good start position for omnicompletion using `'iskeyword'`, I always start omnicompletion at the current cursor position.
To avoid the problem discussed in https://github.com/prabirshrestha/vim-lsp/issues/291#issuecomment-462064628, where e.g. `std::co` would be completed to `std::cocout`, I remove the longest prefix of `word` that is also a suffix of the text present before the cursor.
This is done using a helper function `lsp#omni#remove_typed_part`.

This is similar to the behaviour of VSCode, so this guarantees maximal compatibility with language servers:
```
The `insertText` is subject to interpretation by the client side.
Some tools might not take the string literally. For example
VS Code when code complete is requested in this example `con<cursor position>`
and a completion item with an `insertText` of `console` is provided it
will only insert `sole`. Therefore it is recommended to use `textEdit` instead
since it avoids additional client side interpretation.
```
(Source: https://microsoft.github.io/language-server-protocol/specification#textDocument_completion, under `response > completionItem > insertText`)

This fixes #291.
I tested this using both `lsp_async_completion` set to `0` and to `1`, with the language servers `clangd` and `pyls` and I didn't see any issues.
However, I can't tell for sure if this won't break something for someone else.