### PR TITLE
default g:lsp_use_event_queue to 1

### DIFF
--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -14,6 +14,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_auto_enable           |g:lsp_auto_enable|
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
       g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
+      g:lsp_use_event_queue       |g:lsp_use_event_queue|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -147,6 +148,16 @@ g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
 	let g:lsp_insert_text_enabled = 1
 	let g:lsp_insert_text_enabled = 0
 
+g:lsp_use_event_queue                               *g:lsp_use_event_queue*
+    Type: |Number|
+    Default: `1` for neovim or vim with patch-8.1.0889
+
+    Enable event queue which improves performance by reducing the communication
+    between client and server.
+
+    Example:
+	let g:lsp_use_event_queue = 1
+	let g:lsp_use_event_queue = 0
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -18,7 +18,7 @@ let g:lsp_diagnostics_echo_cursor = get(g:, 'lsp_diagnostics_echo_cursor', 0)
 let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
-let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', 0)
+let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 
 if g:lsp_auto_enable


### PR DESCRIPTION
@mattn So I tried using `g:lsp_use_event_queue=1` and I'm not seeing any issues hence thinking of turning it on by default. Once this https://github.com/vim/vim/pull/3920 is merged we could use that patch as the minbar to enable it by default.