### PR TITLE
Proper use of `kind` completion item property

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -181,16 +181,18 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
     if l:do_remove_typed_part
         let l:word = s:remove_typed_part(l:word)
     endif
-    let l:menu = lsp#omni#get_kind_text(a:item)
-    let l:completion = { 'word': l:word, 'abbr': l:abbr, 'menu': l:menu, 'info': '', 'icase': 1, 'dup': 1 }
+    let l:kind = lsp#omni#get_kind_text(a:item)
+    let l:completion = {
+                \ 'word': l:word,
+                \ 'abbr': l:abbr,
+                \ 'menu': '',
+                \ 'info': '',
+                \ 'icase': 1,
+                \ 'dup': 1,
+                \ 'kind': l:kind }
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])
-        if empty(l:menu)
-            let l:completion['menu'] = a:item['detail']
-        else
-            let l:completion['menu'] = '[' . l:menu . '] ' . a:item['detail']
-        endif
-        let l:completion['info'] .= a:item['detail'] . ' '
+        let l:completion['menu'] = a:item['detail']
     endif
 
     if has_key(a:item, 'documentation')

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -1,0 +1,25 @@
+Describe lsp#omni
+    Describe lsp#omni#get_vim_completion_item
+        It should return item with proper kind
+            let item = {
+            \ 'label': 'my-label',
+            \ 'documentation': 'my documentation.',
+            \ 'detail': 'my-detail',
+            \ 'kind': '3'
+            \}
+
+            let want = {
+            \ 'word': 'my-label',
+            \ 'abbr': 'my-label',
+            \ 'info': 'my documentation.',
+            \ 'icase': 1,
+            \ 'dup': 1,
+            \ 'kind': 'function',
+            \ 'menu': 'my-detail'
+            \}
+            let got = lsp#omni#get_vim_completion_item(item)
+
+            Assert Equals(got, want)
+        End
+    End
+End


### PR DESCRIPTION
Both lsp and vim has concept of `kind` for completion items, which `vim-lsp` isn't utilizing. Proper use of this property is extremely useful, for example to nvim GUIs.

Stuff like this is possible with the `kind` information (notice the icon):

![image](https://user-images.githubusercontent.com/4594126/52905574-bfe2fd80-3244-11e9-9585-7149ac615399.png)
