### PR TITLE
UltiSnips integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ vim-lsp supports incremental changes of Language Server Protocol.
 
 Refer to docs on configuring omnifunc or [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim).
 
+## Snippets (UltiSnips)
+
+If you have UltiSnips already installed, you can enable LSP snippet integration using:
+```vim
+let g:lsp_ultisnips_integration = 1
+```
+Make sure to read the notes in `:h g:lsp_ultisnips_integration` before enabling this feature.
+
 ## Supported commands
 
 **Note:**

--- a/README.md
+++ b/README.md
@@ -45,14 +45,6 @@ vim-lsp supports incremental changes of Language Server Protocol.
 
 Refer to docs on configuring omnifunc or [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim).
 
-## Snippets (UltiSnips)
-
-If you have UltiSnips already installed, you can enable LSP snippet integration using:
-```vim
-let g:lsp_ultisnips_integration = 1
-```
-Make sure to read the notes in `:h g:lsp_ultisnips_integration` before enabling this feature.
-
 ## Supported commands
 
 **Note:**

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ vim-lsp supports incremental changes of Language Server Protocol.
 
 Refer to docs on configuring omnifunc or [asyncomplete.vim](https://github.com/prabirshrestha/asyncomplete.vim).
 
+## Snippets
+vim-lsp does not support snippets by default. If you want snippet integration, you will first have to install a third-party snippet plugin and a plugin that integrates it in vim-lsp.
+At the moment, you have two options:
+1. [UltiSnips](https://github.com/SirVer/ultisnips) together with [vim-lsp-ultisnips](https://github.com/thomasfaingnaert/vim-lsp-ultisnips)
+2. [neosnippet.vim](https://github.com/Shougo/neosnippet.vim) together with [vim-lsp-neosnippet](https://github.com/thomasfaingnaert/vim-lsp-neosnippet)
+
+For more information, refer to the readme and documentation of the respective plugins.
+
 ## Supported commands
 
 **Note:**

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -357,7 +357,7 @@ function! s:ensure_start(buf, server_name, cb) abort
     endif
 endfunction
 
-function! lsp#default_get_supported_capabilities() abort
+function! lsp#default_get_supported_capabilities(server_info) abort
     return {
     \   'workspace': {
     \       'applyEdit ': v:true
@@ -402,7 +402,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     if has_key(l:server_info, 'capabilities')
         let l:capabilities = l:server_info['capabilities']
     else
-        let l:capabilities = call(g:Lsp_get_supported_capabilities, [])
+        let l:capabilities = call(g:Lsp_get_supported_capabilities, [server_info])
     endif
 
     if has_key(l:server_info, 'initialization_options')

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -411,7 +411,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     if has_key(l:server_info, 'capabilities')
         let l:capabilities = l:server_info['capabilities']
     else
-        let l:capabilities = call(g:Lsp_get_supported_capabilities, [server_info])
+        let l:capabilities = call(g:lsp_get_supported_capabilities[0], [server_info])
     endif
 
     let l:request = {

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -394,11 +394,26 @@ function! s:ensure_init(buf, server_name, cb) abort
     if has_key(l:server_info, 'capabilities')
         let l:capabilities = l:server_info['capabilities']
     else
-        let l:capabilities = {
-        \   'workspace': {
-        \       'applyEdit ': v:true
-        \   }
-        \ }
+        if g:lsp_ultisnips_integration
+            let l:capabilities = {
+            \   'textDocument': {
+            \       'completion': {
+            \           'completionItem': {
+            \               'snippetSupport': v:true,
+            \           },
+            \       },
+            \   },
+            \   'workspace': {
+            \       'applyEdit ': v:true
+            \   }
+            \ }
+        else
+            let l:capabilities = {
+            \   'workspace': {
+            \       'applyEdit ': v:true
+            \   }
+            \ }
+        endif
     endif
 
     if has_key(l:server_info, 'initialization_options')

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -357,6 +357,14 @@ function! s:ensure_start(buf, server_name, cb) abort
     endif
 endfunction
 
+function! lsp#default_get_supported_capabilities() abort
+    return {
+    \   'workspace': {
+    \       'applyEdit ': v:true
+    \   }
+    \ }
+endfunction
+
 function! s:ensure_init(buf, server_name, cb) abort
     let l:server = s:servers[a:server_name]
 
@@ -394,26 +402,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     if has_key(l:server_info, 'capabilities')
         let l:capabilities = l:server_info['capabilities']
     else
-        if g:lsp_ultisnips_integration
-            let l:capabilities = {
-            \   'textDocument': {
-            \       'completion': {
-            \           'completionItem': {
-            \               'snippetSupport': v:true,
-            \           },
-            \       },
-            \   },
-            \   'workspace': {
-            \       'applyEdit ': v:true
-            \   }
-            \ }
-        else
-            let l:capabilities = {
-            \   'workspace': {
-            \       'applyEdit ': v:true
-            \   }
-            \ }
-        endif
+        let l:capabilities = call(g:Lsp_get_supported_capabilities, [])
     endif
 
     if has_key(l:server_info, 'initialization_options')

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -178,12 +178,6 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         let l:abbr = a:item['label']
     endif
 
-    if g:lsp_ultisnips_integration && has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
-        let l:snippet = substitute(a:item['insertText'], '\%x00', '\\n', 'g')
-        let l:word = trim(a:item['label'])
-        let l:trigger = l:word
-    endif
-
     if l:do_remove_typed_part
         let l:word = s:remove_typed_part(l:word)
     endif
@@ -205,10 +199,6 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         if type(a:item['documentation']) == type('')
             let l:completion['info'] .= a:item['documentation']
         endif
-    endif
-
-    if exists('l:snippet')
-        let l:completion['user_data'] = string([l:trigger, l:snippet])
     endif
 
     return l:completion

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -212,11 +212,11 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
     return l:completion
 endfunction
 
-function! s:expand_snippet(timer)
+function! s:expand_snippet(timer) abort
     call feedkeys("\<C-r>=UltiSnips#Anon(\"" . s:snippet . "\", \"" . s:trigger . "\", '', 'i')\<CR>")
 endfunction
 
-function! s:handle_snippet(item)
+function! s:handle_snippet(item) abort
     if !has_key(a:item, 'user_data')
         return
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -235,7 +235,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
 endfunction
 
 function! lsp#omni#get_vim_completion_item(...) abort
-    return call(g:Lsp_get_vim_completion_item, a:000)
+    return call(g:lsp_get_vim_completion_item[0], a:000)
 endfunction
 
 augroup lsp_completion_item_text_edit

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -269,16 +269,19 @@ function! s:apply_text_edits() abort
     "       ],
     "     }
     if !g:lsp_text_edit_enabled
+        doautocmd User lsp_complete_done
         return
     endif
 
     " completion faild or not select complete item
     if empty(v:completed_item)
+        doautocmd User lsp_complete_done
         return
     endif
 
     " check user_data
     if !has_key(v:completed_item, 'user_data')
+        doautocmd User lsp_complete_done
         return
     endif
 
@@ -287,10 +290,12 @@ function! s:apply_text_edits() abort
         let l:user_data = json_decode(v:completed_item['user_data'])
     catch
         " do nothing if user_data is not json type string.
+        doautocmd User lsp_complete_done
         return
     endtry
 
     if type(l:user_data) != type({})
+        doautocmd User lsp_complete_done
         return
     endif
 
@@ -323,6 +328,8 @@ function! s:apply_text_edits() abort
     let l:pos[2] += l:col_offset
     call setpos("'a", l:saved_mark)
     call setpos('.', l:pos)
+
+    doautocmd User lsp_complete_done
 endfunction
 
 function! s:expand_range(text_edit, expand_length) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -212,6 +212,10 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
     return l:completion
 endfunction
 
+function! s:expand_snippet(timer)
+    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . s:snippet . "\", \"" . s:trigger . "\", '', 'i')\<CR>")
+endfunction
+
 function! s:handle_snippet(item)
     if !has_key(a:item, 'user_data')
         return
@@ -219,10 +223,10 @@ function! s:handle_snippet(item)
 
     execute 'let l:user_data = ' . a:item['user_data']
 
-    let l:trigger = l:user_data[0]
-    let l:snippet = l:user_data[1]
+    let s:trigger = l:user_data[0]
+    let s:snippet = l:user_data[1]
 
-    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . l:snippet . "\", \"" . l:trigger . "\", '', 'i')\<CR>")
+    call timer_start(0, function('s:expand_snippet'))
 endfunction
 
 if g:lsp_ultisnips_integration

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -180,6 +180,7 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
 
     if g:lsp_ultisnips_integration && has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
         let l:snippet = substitute(a:item['insertText'], '\%x00', '\\n', 'g')
+        let l:word = trim(a:item['label'])
         let l:trigger = l:word
     endif
 
@@ -218,7 +219,7 @@ function! s:handle_snippet(item)
 
     execute 'let l:user_data = ' . a:item['user_data']
 
-    let l:trigger = trim(l:user_data[0])
+    let l:trigger = l:user_data[0]
     let l:snippet = l:user_data[1]
 
     call feedkeys("\<C-r>=UltiSnips#Anon(\"" . l:snippet . "\", \"" . l:trigger . "\", '', 'i')\<CR>")

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -178,6 +178,11 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
         let l:abbr = a:item['label']
     endif
 
+    if g:lsp_ultisnips_integration && has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
+        let l:snippet = substitute(a:item['insertText'], '\%x00', '\\n', 'g')
+        let l:trigger = l:word
+    endif
+
     if a:do_remove_typed_part
         let l:word = s:remove_typed_part(l:word)
     endif
@@ -199,8 +204,8 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
         endif
     endif
 
-    if g:lsp_ultisnips_integration && has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
-        let l:completion['user_data'] = a:item['insertText']
+    if exists('l:snippet')
+        let l:completion['user_data'] = string([l:trigger, l:snippet])
     endif
 
     return l:completion
@@ -211,10 +216,12 @@ function! s:handle_snippet(item)
         return
     endif
 
-    let l:snippet = substitute(a:item['user_data'], '\%x00', '\\n', 'g')
-    let s:trigger = a:item['word']
+    execute 'let l:user_data = ' . a:item['user_data']
 
-    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . l:snippet . "\", \"" . s:trigger . "\", '', 'i')\<CR>")
+    let l:trigger = trim(l:user_data[0])
+    let l:snippet = l:user_data[1]
+
+    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . l:snippet . "\", \"" . l:trigger . "\", '', 'i')\<CR>")
 endfunction
 
 if g:lsp_ultisnips_integration

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -199,7 +199,29 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
         endif
     endif
 
+    if g:lsp_ultisnips_integration && has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
+        let l:completion['user_data'] = a:item['insertText']
+    endif
+
     return l:completion
 endfunction
+
+function! s:handle_snippet(item)
+    if !has_key(a:item, 'user_data')
+        return
+    endif
+
+    let l:snippet = substitute(a:item['user_data'], '\%x00', '\\n', 'g')
+    let s:trigger = a:item['word']
+
+    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . l:snippet . "\", \"" . s:trigger . "\", '', 'i')\<CR>")
+endfunction
+
+if g:lsp_ultisnips_integration
+    augroup lsp_ultisnips
+        autocmd!
+        autocmd CompleteDone * call s:handle_snippet(v:completed_item)
+    augroup end
+endif
 
 " }}}

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -208,28 +208,4 @@ function! lsp#omni#get_vim_completion_item(...) abort
     return call(g:Lsp_get_vim_completion_item, a:000)
 endfunction
 
-function! s:expand_snippet(timer) abort
-    call feedkeys("\<C-r>=UltiSnips#Anon(\"" . s:snippet . "\", \"" . s:trigger . "\", '', 'i')\<CR>")
-endfunction
-
-function! s:handle_snippet(item) abort
-    if !has_key(a:item, 'user_data')
-        return
-    endif
-
-    execute 'let l:user_data = ' . a:item['user_data']
-
-    let s:trigger = l:user_data[0]
-    let s:snippet = l:user_data[1]
-
-    call timer_start(0, function('s:expand_snippet'))
-endfunction
-
-if g:lsp_ultisnips_integration
-    augroup lsp_ultisnips
-        autocmd!
-        autocmd CompleteDone * call s:handle_snippet(v:completed_item)
-    augroup end
-endif
-
 " }}}

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -163,7 +163,7 @@ function! s:remove_typed_part(word) abort
     return strpart(a:word, l:overlap_length)
 endfunction
 
-function! lsp#omni#get_vim_completion_item(item, ...) abort
+function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     let l:do_remove_typed_part = get(a:, 1, 0)
 
     if g:lsp_insert_text_enabled && has_key(a:item, 'insertText') && !empty(a:item['insertText'])
@@ -212,6 +212,10 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
     endif
 
     return l:completion
+endfunction
+
+function! lsp#omni#get_vim_completion_item(...) abort
+    return call(g:Lsp_get_vim_completion_item, a:000)
 endfunction
 
 function! s:expand_snippet(timer) abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -15,6 +15,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
       g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
       g:lsp_use_event_queue       |g:lsp_use_event_queue|
+      g:lsp_ultisnips_integration |g:lsp_ultisnips_integration|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -158,6 +159,27 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
     Example:
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
+
+g:lsp_ultisnips_integration                   *g:lsp_ultisnips_integration*
+    Type: |Number|
+    Default: `0`
+
+    Enable UltiSnips integration with vim-lsp. If enabled, accepting a
+    completion item that is a snippet will expand it using UltiSnips.
+    This requires Vim 8.0 patch 1493 and UltiSnips already installed.
+
+    Note:
+	* UltiSnips does not implement all lsp snippet features. For example,
+	  choice placeholders (e.g. ${1|one,two,three}) will just be displayed
+	  verbatim.
+	* If you want snippets to expand when the snippet trigger is the only
+	  match, you need to add menuone to 'completeopt'.
+	* Because UltiSnips forgets the tabstop locations when switching
+	  buffers, nested snippets may not work if the |preview-window| is
+	  enabled. To fix this, you can either remove preview from
+	  'completeopt', or check if
+	  https://github.com/SirVer/ultisnips/pull/1055
+	  solves the issue for you.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -17,8 +17,8 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_text_edit_enabled              |g:lsp_text_edit_enabled|
       g:lsp_signs_enabled                  |g:lsp_signs_enabled|
       g:lsp_use_event_queue                |g:lsp_use_event_queue|
-      g:Lsp_get_vim_completion_item        |g:Lsp_get_vim_completion_item|
-      g:Lsp_get_supported_capabilities     |g:Lsp_get_supported_capabilities|
+      g:lsp_get_vim_completion_item        |g:lsp_get_vim_completion_item|
+      g:lsp_get_supported_capabilities     |g:lsp_get_supported_capabilities|
     Functions                            |vim-lsp-functions|
       enable                               |vim-lsp-enable|
       disable                              |vim-lsp-disable|
@@ -201,25 +201,27 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
 
-g:Lsp_get_vim_completion_item               *g:Lsp_get_vim_completion_item*
-    Type: |Funcref|
-    Default: `function('lsp#omni#default_get_vim_completion_item')`
+g:lsp_get_vim_completion_item               *g:lsp_get_vim_completion_item*
+    Type: |List|
+    Default: `[function('lsp#omni#default_get_vim_completion_item')]`
 
-    A reference to the function that vim-lsp should use to produce the items
-    in the completion menu. Changing this variable allows customizing how
-    items are displayed in the completion menu, or adding custom `user_data`
-    to items (see |complete-items|).
+    A |List| containing one element of type |Funcref|. This element is a
+    reference to the function that vim-lsp should use to produce the items in
+    the completion menu. Changing this variable allows customizing how items
+    are displayed in the completion menu, or adding custom `user_data` to
+    items (see |complete-items|).
 
     Note: You can reuse functionality provided by vim-lsp by calling
     `lsp#omni#default_get_vim_completion_item` from within your function.
 
-g:Lsp_get_supported_capabilities         *g:Lsp_get_supported_capabilities*
-    Type: |Funcref|
-    Default: `function('lsp#default_get_supported_capabilities')`
+g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
+    Type: |List|
+    Default: `[function('lsp#default_get_supported_capabilities')]`
 
-    A reference to the function that vim-lsp should use to obtain the
-    supported LSP capabilities. Changing this variable allows customizing
-    which capabilities vim-lsp sends to a language server.
+    A |List| containing one element of type |Funcref|. This element is a
+    reference to the function that vim-lsp should use to obtain the supported
+    LSP capabilities. Changing this variable allows customizing which
+    capabilities vim-lsp sends to a language server.
 
     Note: You can obtain the default supported capabilities of vim-lsp by
     calling `lsp#omni#default_get_supported_capabilities` from within your

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -50,6 +50,8 @@ CONTENTS                                                  *vim-lsp-contents*
       LspRename                             |LspRename|
       LspTypeDefinition                     |LspTypeDefinition|
       LspWorkspaceSymbol                    |LspWorkspaceSymbol|
+    Autocommands                          |vim-lsp-autocommands|
+      lsp_complete_done                     |lsp_complete_done|
     Mappings                              |vim-lsp-mappings|
     Autocomplete                          |vim-lsp-autocomplete|
       omnifunc                              |vim-lsp-omnifunc|
@@ -605,6 +607,21 @@ Search and show workspace symbols.
 LspStatus                                                        *LspStatus*
 
 Prints the status of all registered servers.
+
+===============================================================================
+Autocommands                                          *vim-lsp-autocommands*
+
+lsp_complete_done                                        *lsp_complete_done*
+
+This autocommand is run after Insert mode completion is done, similar to
+|CompleteDone|. However, the difference is that |lsp_complete_done| is run
+only after vim-lsp has finished executing its internal |CompleteDone|
+autocommands (e.g. applying text edits). It is thus ideal to use for snippet
+expansion, or custom post processing of completed items. Just like
+|CompleteDone|, the Vim variable |v:completed_item| contains information about
+the completed item. It is guaranteed that vim-lsp does not change the content
+of this variable during its |CompleteDone| autocommands.
+
 
 ===============================================================================
 Mappings	                                          *vim-lsp-mappings*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -4,45 +4,47 @@
 ================================================================================
 CONTENTS                                                  *vim-lsp-contents*
 
-    Introduction		|vim-lsp-introduction|
-    Install			|vim-lsp-install|
-    Language Servers		|vim-lsp-language-servers|
-      Configure                   |vim-lsp-configure-source|
-      Wiki                        |vim-lsp-configure-wiki|
-    Options			|vim-lsp-options|
-      g:lsp_diagnostics_enabled   |g:lsp_diagnostics_enabled|
-      g:lsp_auto_enable           |g:lsp_auto_enable|
-      g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
-      g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
-      g:lsp_use_event_queue       |g:lsp_use_event_queue|
-    Functions			|vim-lsp-functions|
-      enable                      |vim-lsp-enable|
-      disable                     |vim-lsp-disable|
-      register_server             |vim-lsp-register_server|
-      stop_server                 |vim-lsp-stop_server|
-    Commands			|vim-lsp-commands|
-      LspCodeAction               |LspCodeAction|
-      LspDocumentDiagnostics      |LspDocumentDiagnostics|
-      LspDeclaration              |LspDeclaration|
-      LspDefinition               |LspDefinition|
-      LspDocumentFormat           |LspDocumentFormat|
-      LspDocumentFormatSync       |LspDocumentFormatSync|
-      LspDocumentRangeFormat      |LspDocumentRangeFormat|
-      LspDocumentSymbol           |LspDocumentSymbol|
-      LspHover                    |LspHover|
-      LspNextError                |LspNextError|
-      LspPreviousError            |LspPreviousError|
-      LspImplementation           |LspImplementation|
-      LspReferences               |LspReferences|
-      LspRename                   |LspRename|
-      LspTypeDefinition           |LspTypeDefinition|
-      LspWorkspaceSymbol          |LspWorkspaceSymbol|
-    Mappings			|vim-lsp-mappings|
-    Autocomplete		|vim-lsp-autocomplete|
-      omnifunc                    |vim-lsp-omnifunc|
-      asyncomplete.vim            |vim-lsp-asyncomplete|
-    Snippets			|vim-lsp-snippets|
-    License			|vim-lsp-license|
+    Introduction		          |vim-lsp-introduction|
+    Install			          |vim-lsp-install|
+    Language Servers		          |vim-lsp-language-servers|
+      Configure                             |vim-lsp-configure-source|
+      Wiki                                  |vim-lsp-configure-wiki|
+    Options			          |vim-lsp-options|
+      g:lsp_diagnostics_enabled             |g:lsp_diagnostics_enabled|
+      g:lsp_auto_enable                     |g:lsp_auto_enable|
+      g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
+      g:lsp_insert_text_enabled             |g:lsp_insert_text_enabled|
+      g:lsp_use_event_queue                 |g:lsp_use_event_queue|
+      g:Lsp_get_vim_completion_item         |g:Lsp_get_vim_completion_item|
+      g:Lsp_get_supported_capabilities      |g:Lsp_get_supported_capabilities|
+    Functions			          |vim-lsp-functions|
+      enable                                |vim-lsp-enable|
+      disable                               |vim-lsp-disable|
+      register_server                       |vim-lsp-register_server|
+      stop_server                           |vim-lsp-stop_server|
+    Commands			          |vim-lsp-commands|
+      LspCodeAction                         |LspCodeAction|
+      LspDocumentDiagnostics                |LspDocumentDiagnostics|
+      LspDeclaration                        |LspDeclaration|
+      LspDefinition                         |LspDefinition|
+      LspDocumentFormat                     |LspDocumentFormat|
+      LspDocumentFormatSync                 |LspDocumentFormatSync|
+      LspDocumentRangeFormat                |LspDocumentRangeFormat|
+      LspDocumentSymbol                     |LspDocumentSymbol|
+      LspHover                              |LspHover|
+      LspNextError                          |LspNextError|
+      LspPreviousError                      |LspPreviousError|
+      LspImplementation                     |LspImplementation|
+      LspReferences                         |LspReferences|
+      LspRename                             |LspRename|
+      LspTypeDefinition                     |LspTypeDefinition|
+      LspWorkspaceSymbol                    |LspWorkspaceSymbol|
+    Mappings			          |vim-lsp-mappings|
+    Autocomplete		          |vim-lsp-autocomplete|
+      omnifunc                              |vim-lsp-omnifunc|
+      asyncomplete.vim                      |vim-lsp-asyncomplete|
+    Snippets			          |vim-lsp-snippets|
+    License			          |vim-lsp-license|
 
 
 ================================================================================
@@ -159,6 +161,30 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
     Example:
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
+
+g:Lsp_get_vim_completion_item               *g:Lsp_get_vim_completion_item*
+    Type: |Funcref|
+    Default: `function('lsp#omni#default_get_vim_completion_item')`
+
+    A reference to the function that vim-lsp should use to produce the items
+    in the completion menu. Changing this variable allows customizing how
+    items are displayed in the completion menu, or adding custom `user_data`
+    to items (see |complete-items|).
+
+    Note: You can reuse functionality provided by vim-lsp by calling
+    `lsp#omni#default_get_vim_completion_item` from within your function.
+
+g:Lsp_get_supported_capabilities         *g:Lsp_get_supported_capabilities*
+    Type: |Funcref|
+    Default: `function('lsp#default_get_supported_capabilities')`
+
+    A reference to the function that vim-lsp should use to obtain the
+    supported LSP capabilities. Changing this variable allows customizing
+    which capabilities vim-lsp sends to a language server.
+
+    Note: You can obtain the default supported capabilities of vim-lsp by
+    calling `lsp#omni#default_get_supported_capabilities` from within your
+    function.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -41,6 +41,7 @@ CONTENTS                                                  *vim-lsp-contents*
     Autocomplete		|vim-lsp-autocomplete|
       omnifunc                    |vim-lsp-omnifunc|
       asyncomplete.vim            |vim-lsp-asyncomplete|
+    Snippets			|vim-lsp-snippets|
     License			|vim-lsp-license|
 
 
@@ -472,6 +473,24 @@ Example:
     Plug 'prabirshrestha/asyncomplete-lsp.vim'
 
 For additional configuration refer to asyncomplete.vim docs.
+
+===============================================================================
+Snippets                                                  *vim-lsp-snippets*
+
+To integrate snippets in vim-lsp, you will first have to install a third-party
+snippet plugin, and a plugin that integrates it in vim-lsp. At the moment,
+you have two options:
+
+1. UltiSnips and vim-lsp-ultisnips
+https://github.com/SirVer/ultisnips
+https://github.com/thomasfaingnaert/vim-lsp-ultisnips
+
+2. neosnippet.vim and vim-lsp-neosnippet
+https://github.com/Shougo/neosnippet.vim
+https://github.com/thomasfaingnaert/vim-lsp-neosnippet
+
+Refer to the readme and docs of vim-lsp-ultisnips and vim-lsp-neosnippet for
+more information and configuration options.
 
 ===============================================================================
 License                                                    *vim-lsp-license*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -15,7 +15,6 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
       g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
       g:lsp_use_event_queue       |g:lsp_use_event_queue|
-      g:lsp_ultisnips_integration |g:lsp_ultisnips_integration|
     Functions			|vim-lsp-functions|
       enable                      |vim-lsp-enable|
       disable                     |vim-lsp-disable|
@@ -159,27 +158,6 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
     Example:
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
-
-g:lsp_ultisnips_integration                   *g:lsp_ultisnips_integration*
-    Type: |Number|
-    Default: `0`
-
-    Enable UltiSnips integration with vim-lsp. If enabled, accepting a
-    completion item that is a snippet will expand it using UltiSnips.
-    This requires Vim 8.0 patch 1493 and UltiSnips already installed.
-
-    Note:
-	* UltiSnips does not implement all lsp snippet features. For example,
-	  choice placeholders (e.g. ${1|one,two,three}) will just be displayed
-	  verbatim.
-	* If you want snippets to expand when the snippet trigger is the only
-	  match, you need to add menuone to 'completeopt'.
-	* Because UltiSnips forgets the tabstop locations when switching
-	  buffers, nested snippets may not work if the |preview-window| is
-	  enabled. To fix this, you can either remove preview from
-	  'completeopt', or check if
-	  https://github.com/SirVer/ultisnips/pull/1055
-	  solves the issue for you.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -20,14 +20,6 @@ let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
-let g:lsp_ultisnips_integration = get(g:, 'lsp_ultisnips_integration', 0)
-
-" Required for user_data
-if g:lsp_ultisnips_integration && !has('patch-8.0.1493')
-    echohl WarningMsg
-    echom 'vim-lsp UltiSnips integration requires Vim 8.0 patch 1493 or later'
-    echohl None
-endif
 
 let g:Lsp_get_vim_completion_item = get(g:, 'Lsp_get_vim_completion_item', function('lsp#omni#default_get_vim_completion_item'))
 let g:Lsp_get_supported_capabilities = get(g:, 'Lsp_get_supported_capabilities', function('lsp#default_get_supported_capabilities'))

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -24,8 +24,8 @@ let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('p
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 
-let g:Lsp_get_vim_completion_item = get(g:, 'Lsp_get_vim_completion_item', function('lsp#omni#default_get_vim_completion_item'))
-let g:Lsp_get_supported_capabilities = get(g:, 'Lsp_get_supported_capabilities', function('lsp#default_get_supported_capabilities'))
+let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
+let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -20,6 +20,7 @@ let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', 0)
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
+let g:lsp_ultisnips_integration = get(g:, 'lsp_ultisnips_integration', 0)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -22,6 +22,13 @@ let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', 0)
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_ultisnips_integration = get(g:, 'lsp_ultisnips_integration', 0)
 
+" Required for user_data
+if g:lsp_ultisnips_integration && !has('patch-8.0.1493')
+    echohl WarningMsg
+    echom "vim-lsp UltiSnips integration requires Vim 8.0 patch 1493 or later"
+    echohl None
+endif
+
 if g:lsp_auto_enable
     augroup lsp_auto_enable
         autocmd!

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -29,6 +29,8 @@ if g:lsp_ultisnips_integration && !has('patch-8.0.1493')
     echohl None
 endif
 
+let g:Lsp_get_vim_completion_item = get(g:, 'Lsp_get_vim_completion_item', function('lsp#omni#default_get_vim_completion_item'))
+
 if g:lsp_auto_enable
     augroup lsp_auto_enable
         autocmd!

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -30,6 +30,7 @@ if g:lsp_ultisnips_integration && !has('patch-8.0.1493')
 endif
 
 let g:Lsp_get_vim_completion_item = get(g:, 'Lsp_get_vim_completion_item', function('lsp#omni#default_get_vim_completion_item'))
+let g:Lsp_get_supported_capabilities = get(g:, 'Lsp_get_supported_capabilities', function('lsp#default_get_supported_capabilities'))
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -25,7 +25,7 @@ let g:lsp_ultisnips_integration = get(g:, 'lsp_ultisnips_integration', 0)
 " Required for user_data
 if g:lsp_ultisnips_integration && !has('patch-8.0.1493')
     echohl WarningMsg
-    echom "vim-lsp UltiSnips integration requires Vim 8.0 patch 1493 or later"
+    echom 'vim-lsp UltiSnips integration requires Vim 8.0 patch 1493 or later'
     echohl None
 endif
 


### PR DESCRIPTION
I added a new variable `g:lsp_ultisnips_integration` which, when set to `1`, uses UltiSnips to provide LSP snippet functionality.
If `g:lsp_ultisnips_integration = 0` (the default), vim-lsp should continue to function in exactly the same way as it does now, so this PR should not break anything.
This requires UltiSnips to be installed, and Vim 8.0 patch 1493 or higher (for `user_data`).

A couple notes:
* Because UltiSnips deletes all tabstops when switching buffers, you have to remove `preview` from `'completeopt'`. Alternatively, you can try https://github.com/SirVer/ultisnips/pull/1055.
* If you want snippets to expand when its trigger is the only match, you need to add `menuone` to `'completeopt'`. This is because in that case, the `CompleteDone` autocommand is called with `v:completed_item = {}` instead of the completed item. If anyone knows another fix for this, please let me know.
* UltiSnips does not implement the complete LSP spec. For example, choice placeholders will just be displayed verbatim. However, because I am most familiar with UltiSnips as a vim snippet plugin, I decided to use it instead of other solutions. Besides, most of the important features are present.
* I tested this with omnifunc, however because I am using `CompleteDone`, I believe this should also work with asyncomplete.vim.

Demo with C++ in clangd:
![demo](https://user-images.githubusercontent.com/10748726/52919520-75748600-3303-11e9-8139-65f12fcb0fb9.gif)

Minimal vimrc to reproduce:
```vim
call plug#begin()

Plug 'SirVer/ultisnips'
Plug 'prabirshrestha/async.vim'
Plug 'thomasfaingnaert/vim-lsp', {'branch': 'ultisnips-integration'}

call plug#end()

let g:UltiSnipsExpandTrigger="<tab>"
let g:UltiSnipsJumpForwardTrigger="<tab>"
let g:UltiSnipsJumpBackwardTrigger="<s-tab>"

if executable('clangd')
    augroup vim_lsp_cpp
        autocmd!
        autocmd User lsp_setup call lsp#register_server({
                    \ 'name': 'clangd',
                    \ 'cmd': {server_info->['clangd']},
                    \ 'whitelist': ['c', 'cpp', 'objc', 'objcpp', 'cc'],
                    \ })
        autocmd FileType c,cpp,objc,objcpp,cc setlocal omnifunc=lsp#complete
    augroup end
endif

set completeopt-=preview
set completeopt+=menuone

let g:lsp_ultisnips_integration = 1
```
