### PR TITLE
Navigate directly to error column

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -202,7 +202,7 @@ function! s:get_all_buffer_diagnostics() abort
     return l:all_diagnostics
 endfunction
 
-function! s:compare_diagnostics(d1, d2)
+function! s:compare_diagnostics(d1, d2) abort
     let l:range1 = a:d1['range']
     let l:line1 = l:range1['start']['line'] + 1
     let l:col1 = l:range1['start']['character'] + 1

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -49,38 +49,124 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
 endfunction
 
 function! lsp#ui#vim#diagnostics#get_diagnostics_under_cursor() abort
-    let l:uri = lsp#utils#get_buffer_uri()
-
-    let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
-    if !l:has_diagnostics
+    let l:diagnostics = s:get_all_buffer_diagnostics()
+    if !len(l:diagnostics)
         return
     endif
 
     let l:line = line('.')
     let l:col = col('.')
 
-    let l:closeset_diagnostics = {}
-    let l:closeset_distance = -1
+    let l:closest_diagnostics = {}
+    let l:closest_distance = -1
 
-    for [l:server_name, l:data] in items(l:diagnostics)
-        for l:diagnostic in l:data['response']['params']['diagnostics']
-            let l:range = l:diagnostic['range']
-            let l:start_line = l:range['start']['line'] + 1
-            let l:start_col = l:range['start']['character'] + 1
-            let l:end_line = l:range['end']['line'] + 1
-            let l:end_character = l:range['end']['character'] + 1
+    for l:diagnostic in l:diagnostics
+        let l:range = l:diagnostic['range']
+        let l:start_line = l:range['start']['line'] + 1
+        let l:start_col = l:range['start']['character'] + 1
+        let l:end_line = l:range['end']['line'] + 1
+        let l:end_character = l:range['end']['character'] + 1
 
-            if l:line == l:start_line
-                let l:distance = abs(l:start_col - l:col)
-                if l:closeset_distance < 0 || l:distance < l:closeset_distance
-                    let l:closeset_diagnostics = l:diagnostic
-                    let l:closeset_distance = l:distance
-                endif
+        if l:line == l:start_line
+            let l:distance = abs(l:start_col - l:col)
+            if l:closest_distance < 0 || l:distance < l:closest_distance
+                let l:closest_diagnostics = l:diagnostic
+                let l:closest_distance = l:distance
             endif
-        endfor
+        endif
     endfor
 
-    return l:closeset_diagnostics
+    return l:closest_diagnostics
+endfunction
+
+function! lsp#ui#vim#diagnostics#next_error() abort
+    let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
+        \ {_, diagnostic -> diagnostic['severity'] ==# 1 })
+    if !len(l:diagnostics)
+        return
+    endif
+    call sort(l:diagnostics, 's:compare_diagnostics')
+
+    let l:view = winsaveview()
+    let l:next_line = 0
+    let l:next_col = 0
+    for l:diagnostic in l:diagnostics
+        let l:line = l:diagnostic['range']['start']['line'] + 1
+        let l:col = l:diagnostic['range']['start']['character'] + 1
+        if l:line > l:view['lnum']
+            \ || (l:line == l:view['lnum'] && l:col > l:view['col'] + 1)
+            let l:next_line = l:line
+            let l:next_col = l:col - 1
+            break
+        endif
+    endfor
+
+    if l:next_line == 0
+        " Wrap to start
+        let l:next_line = l:diagnostics[0]['range']['start']['line'] + 1
+        let l:next_col = l:diagnostics[0]['range']['start']['character']
+    endif
+
+    let l:view['lnum'] = l:next_line
+    let l:view['col'] = l:next_col
+    let l:view['topline'] = 1
+    let l:height = winheight(0)
+    let totalnum = line('$')
+    if totalnum > l:height
+        let l:half = l:height / 2
+        if l:totalnum - l:half < l:view['lnum']
+            let l:view['topline'] = l:totalnum - l:height + 1
+        else
+            let l:view['topline'] = l:view['lnum'] - l:half
+        endif
+    endif
+    call winrestview(l:view)
+endfunction
+
+function! lsp#ui#vim#diagnostics#previous_error() abort
+    let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
+        \ {_, diagnostic -> diagnostic['severity'] ==# 1 })
+    if !len(l:diagnostics)
+        return
+    endif
+    call sort(l:diagnostics, 's:compare_diagnostics')
+
+    let l:view = winsaveview()
+    let l:next_line = 0
+    let l:next_col = 0
+    let l:index = len(l:diagnostics) - 1
+    while l:index >= 0
+        let l:line = l:diagnostics[l:index]['range']['start']['line'] + 1
+        let l:col = l:diagnostics[l:index]['range']['start']['character'] + 1
+        if l:line < l:view['lnum']
+            \ || (l:line == l:view['lnum'] && l:col < l:view['col'])
+            let l:next_line = l:line
+            let l:next_col = l:col - 1
+            break
+        endif
+        let l:index = l:index - 1
+    endwhile
+
+    if l:next_line == 0
+        " Wrap to end
+        let l:next_line = l:diagnostics[-1]['range']['start']['line'] + 1
+        let l:next_col = l:diagnostics[-1]['range']['start']['character']
+    endif
+
+    let l:view['lnum'] = l:next_line
+    let l:view['col'] = l:next_col
+    let l:view['topline'] = 1
+    let l:height = winheight(0)
+    let totalnum = line('$')
+    if totalnum > l:height
+        let l:half = l:height / 2
+        if l:totalnum - l:half < l:view['lnum']
+            let l:view['topline'] = l:totalnum - l:height + 1
+        else
+            let l:view['topline'] = l:view['lnum'] - l:half
+        endif
+    endif
+    call winrestview(l:view)
 endfunction
 
 function! s:get_diagnostics(uri) abort
@@ -98,3 +184,36 @@ function! s:get_diagnostics(uri) abort
     endif
     return [0, []]
 endfunction
+
+" Get diagnostics for the current buffer URI from all servers
+function! s:get_all_buffer_diagnostics() abort
+    let l:uri = lsp#utils#get_buffer_uri()
+
+    let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
+    if !l:has_diagnostics
+        return []
+    endif
+
+    let l:all_diagnostics = []
+    for [l:server_name, l:data] in items(l:diagnostics)
+        call extend(l:all_diagnostics, l:data['response']['params']['diagnostics'])
+    endfor
+
+    return l:all_diagnostics
+endfunction
+
+function! s:compare_diagnostics(d1, d2)
+    let l:range1 = a:d1['range']
+    let l:line1 = l:range1['start']['line'] + 1
+    let l:col1 = l:range1['start']['character'] + 1
+    let l:range2 = a:d2['range']
+    let l:line2 = l:range2['start']['line'] + 1
+    let l:col2 = l:range2['start']['character'] + 1
+
+    if l:line1 == l:line2
+        return l:col1 == l:col2 ? 0 : l:col1 > l:col2 ? 1 : -1
+    else
+        return l:line1 > l:line2 ? 1 : -1
+    endif
+endfunction
+" vim sw=4 ts=4 et

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -46,12 +46,12 @@ function! lsp#ui#vim#signs#next_error() abort
     endif
     let l:view = winsaveview()
     let l:next_line = 0
-    let l:next_col = 0
+    " let l:next_col = 0
     for l:sign in l:signs
         if l:sign['lnum'] > l:view['lnum']
-            \ || (l:sign['lnum'] == l:view['lnum'] && l:sign['col'] > l:view['col'] + 1)
+            " \ || (l:sign['lnum'] == l:view['lnum'] && l:sign['col'] > l:view['col'] + 1)
             let l:next_line = l:sign['lnum']
-            let l:next_col = l:sign['col'] - 1
+            " let l:next_col = l:sign['col'] - 1
             break
         endif
     endfor
@@ -59,11 +59,11 @@ function! lsp#ui#vim#signs#next_error() abort
     if l:next_line == 0
         " Wrap to start
         let l:next_line = l:signs[0]['lnum']
-        let l:next_col = l:signs[0]['col'] - 1
+        " let l:next_col = l:signs[0]['col'] - 1
     endif
 
     let l:view['lnum'] = l:next_line
-    let l:view['col'] = l:next_col
+    " let l:view['col'] = l:next_col
     let l:view['topline'] = 1
     let l:height = winheight(0)
     let totalnum = line('$')
@@ -85,13 +85,13 @@ function! lsp#ui#vim#signs#previous_error() abort
     endif
     let l:view = winsaveview()
     let l:next_line = 0
-    let l:next_col = 0
+    " let l:next_col = 0
     let l:index = len(l:signs) - 1
     while l:index >= 0
         if l:signs[l:index]['lnum'] < l:view['lnum']
-            \ || (l:signs[l:index]['lnum'] == l:view['lnum'] && l:signs[l:index]['col'] > l:view['col'] + 1)
+            " \ || (l:signs[l:index]['lnum'] == l:view['lnum'] && l:signs[l:index]['col'] > l:view['col'] + 1)
             let l:next_line = l:signs[l:index]['lnum']
-            let l:next_col = l:signs[l:index]['col'] - 1
+            " let l:next_col = l:signs[l:index]['col'] - 1
             break
         endif
         let l:index = l:index - 1
@@ -100,11 +100,11 @@ function! lsp#ui#vim#signs#previous_error() abort
     if l:next_line == 0
         " Wrap to end
         let l:next_line = l:signs[-1]['lnum']
-        let l:next_col = l:signs[-1]['col'] - 1
+        " let l:next_col = l:signs[-1]['col'] - 1
     endif
 
     let l:view['lnum'] = l:next_line
-    let l:view['col'] = l:next_col
+    " let l:view['col'] = l:next_col
     let l:view['topline'] = 1
     let l:height = winheight(0)
     let totalnum = line('$')

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -40,14 +40,14 @@ function! lsp#ui#vim#signs#enable() abort
 endfunction
 
 function! lsp#ui#vim#signs#next_error() abort
-    let l:signs = s:get_signs(bufnr('%'))
+    let l:signs = filter(copy(s:get_signs(bufnr('%'))), {i,sign -> sign['name'] ==# 'LspError' })
     if empty(l:signs)
         return
     endif
     let l:view = winsaveview()
     let l:next_line = 0
     for l:sign in l:signs
-        if l:sign['name'] ==# 'LspError' && l:sign['lnum'] > l:view['lnum']
+        if l:sign['lnum'] > l:view['lnum']
             \ || (l:sign['lnum'] == l:view['lnum'] && l:sign['col'] > l:view['col'] + 1)
             let l:next_line = l:sign['lnum']
             let l:next_col = l:sign['col'] - 1
@@ -56,7 +56,9 @@ function! lsp#ui#vim#signs#next_error() abort
     endfor
 
     if l:next_line == 0
-        return
+        " Wrap to start
+        let l:next_line = l:signs[0]['lnum']
+        let l:next_col = l:signs[0]['col'] - 1
     endif
 
     let l:view['lnum'] = l:next_line
@@ -76,7 +78,7 @@ function! lsp#ui#vim#signs#next_error() abort
 endfunction
 
 function! lsp#ui#vim#signs#previous_error() abort
-    let l:signs = s:get_signs(bufnr('%'))
+    let l:signs = filter(copy(s:get_signs(bufnr('%'))), {i,sign -> sign['name'] ==# 'LspError' })
     if empty(l:signs)
         return
     endif
@@ -87,14 +89,16 @@ function! lsp#ui#vim#signs#previous_error() abort
         if l:signs[l:index]['lnum'] < l:view['lnum']
             \ || (l:signs[l:index]['lnum'] == l:view['lnum'] && l:signs[l:index]['col'] > l:view['col'] + 1)
             let l:next_line = l:signs[l:index]['lnum']
-            let l:next_col = l:err_pos[1] - 1
+            let l:next_col = l:signs[l:index]['col'] - 1
             break
         endif
         let l:index = l:index - 1
     endwhile
 
     if l:next_line == 0
-        return
+        " Wrap to end
+        let l:next_line = l:signs[-1]['lnum']
+        let l:next_col = l:signs[-1]['col'] - 1
     endif
 
     let l:view['lnum'] = l:next_line

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -46,6 +46,7 @@ function! lsp#ui#vim#signs#next_error() abort
     endif
     let l:view = winsaveview()
     let l:next_line = 0
+    let l:next_col = 0
     for l:sign in l:signs
         if l:sign['lnum'] > l:view['lnum']
             \ || (l:sign['lnum'] == l:view['lnum'] && l:sign['col'] > l:view['col'] + 1)
@@ -84,6 +85,7 @@ function! lsp#ui#vim#signs#previous_error() abort
     endif
     let l:view = winsaveview()
     let l:next_line = 0
+    let l:next_col = 0
     let l:index = len(l:signs) - 1
     while l:index >= 0
         if l:signs[l:index]['lnum'] < l:view['lnum']

--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -48,7 +48,9 @@ function! lsp#ui#vim#signs#next_error() abort
     let l:next_line = 0
     for l:sign in l:signs
         if l:sign['name'] ==# 'LspError' && l:sign['lnum'] > l:view['lnum']
+            \ || (l:sign['lnum'] == l:view['lnum'] && l:sign['col'] > l:view['col'] + 1)
             let l:next_line = l:sign['lnum']
+            let l:next_col = l:sign['col'] - 1
             break
         endif
     endfor
@@ -58,6 +60,7 @@ function! lsp#ui#vim#signs#next_error() abort
     endif
 
     let l:view['lnum'] = l:next_line
+    let l:view['col'] = l:next_col
     let l:view['topline'] = 1
     let l:height = winheight(0)
     let totalnum = line('$')
@@ -82,7 +85,9 @@ function! lsp#ui#vim#signs#previous_error() abort
     let l:index = len(l:signs) - 1
     while l:index >= 0
         if l:signs[l:index]['lnum'] < l:view['lnum']
+            \ || (l:signs[l:index]['lnum'] == l:view['lnum'] && l:signs[l:index]['col'] > l:view['col'] + 1)
             let l:next_line = l:signs[l:index]['lnum']
+            let l:next_col = l:err_pos[1] - 1
             break
         endif
         let l:index = l:index - 1
@@ -93,6 +98,7 @@ function! lsp#ui#vim#signs#previous_error() abort
     endif
 
     let l:view['lnum'] = l:next_line
+    let l:view['col'] = l:next_col
     let l:view['topline'] = 1
     let l:height = winheight(0)
     let totalnum = line('$')
@@ -190,14 +196,16 @@ function! s:place_signs(server_name, path, diagnostics) abort
     if !empty(a:diagnostics) && bufnr(a:path) >= 0
         for l:item in a:diagnostics
             let l:line = l:item['range']['start']['line'] + 1
+            let l:character = l:item['range']['start']['character'] + 1
 
             let l:name = 'LspError'
             if has_key(l:item, 'severity') && !empty(l:item['severity'])
                 let l:sign_name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
                 " pass 0 and let vim generate sign id
-                let l:sign_id = sign_place(0, l:sign_group, l:sign_name, a:path, { 'lnum': l:line })
+                let l:sign_id = sign_place(0, l:sign_group, l:sign_name, a:path, { 'lnum': l:line, 'col': l:character })
                 call lsp#log('add signs', l:sign_id)
             endif
         endfor
     endif
 endfunction
+" vim sw=4 ts=4 et

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -34,8 +34,8 @@ command! LspDefinition call lsp#ui#vim#definition()
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
 command! LspDocumentDiagnostics call lsp#ui#vim#diagnostics#document_diagnostics()
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover#get_hover_under_cursor()
-command! LspNextError call lsp#ui#vim#signs#next_error()
-command! LspPreviousError call lsp#ui#vim#signs#previous_error()
+command! LspNextError call lsp#ui#vim#diagnostics#next_error()
+command! LspPreviousError call lsp#ui#vim#diagnostics#previous_error()
 command! LspReferences call lsp#ui#vim#references()
 command! LspRename call lsp#ui#vim#rename()
 command! LspTypeDefinition call lsp#ui#vim#type_definition()
@@ -54,8 +54,8 @@ nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition()<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
 nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#ui#vim#diagnostics#document_diagnostics()<cr>
 nnoremap <plug>(lsp-hover) :<c-u>call lsp#ui#vim#hover#get_hover_under_cursor()<cr>
-nnoremap <plug>(lsp-next-error) :<c-u>call lsp#ui#vim#signs#next_error()<cr>
-nnoremap <plug>(lsp-previous-error) :<c-u>call lsp#ui#vim#signs#previous_error()<cr>
+nnoremap <plug>(lsp-next-error) :<c-u>call lsp#ui#vim#diagnostics#next_error()<cr>
+nnoremap <plug>(lsp-previous-error) :<c-u>call lsp#ui#vim#diagnostics#previous_error()<cr>
 nnoremap <plug>(lsp-references) :<c-u>call lsp#ui#vim#references()<cr>
 nnoremap <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename()<cr>
 nnoremap <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition()<cr>


### PR DESCRIPTION
This PR adds the error column to the array of errors (previously an array of line numbers, now an array of [line,column] pairs). This allows navigation directly to the error position, but also nvaigating to multiple errors in a single line.

It also introduces "wrapping" around the ends of the buffer, to find the "next" error when the cursor is positioned after the last error (separate commit).

I don't know if this 2nd part is controversial - I use it and think it makes sense, but if preferred I can wrap this in an optional variable, i.e. `g:lsp_wrap_error_navigation`?