### PR TITLE
Introduce option to always populate quickfix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ preferred to turn them off and use other plugins instead (like
 let g:lsp_diagnostics_enabled = 0         " disable diagnostics support
 ```
 
+To automatically populate quickfix with diagnostics:
+
+```viml
+let g:lsp_diagnostics_always_populate_quickfix = 1
+```
+
 #### Signs
 
 ```viml

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -14,6 +14,16 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     endif
     let s:diagnostics[l:uri][a:server_name] = a:data
 
+    if g:lsp_diagnostics_always_populate_quickfix
+        let l:result = []
+        for [l:uri, l:diagnostics] in items(s:diagnostics)
+            for [l:server_name, l:data] in items(l:diagnostics)
+                let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
+            endfor
+        endfor
+        call setqflist(l:result)
+    endif
+
     call lsp#ui#vim#signs#set(a:server_name, a:data)
 endfunction
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -159,6 +159,15 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
 
+g:lsp_diagnostics_always_populate_quickfix  *g:lsp_diagnostics_always_populate_quickfix*
+    Type: boolean
+    Default: 0
+
+    By default vim-lsp doesn't fill the |quickfix| with the errors found
+    by the servers, in order to reduce clashes with other plugins. Enable this
+    option to tell vim-lsp to always stick any detected errors into the
+    |quickfix|.
+
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -19,7 +19,8 @@ let g:lsp_diagnostics_echo_delay = get(g:, 'lsp_diagnostics_echo_delay', 500)
 let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
-let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
+let g:lsp_insert_text_enabled = get(g:, 'lsp_insert_text_enabled', 1)
+let g:lsp_diagnostics_always_populate_quickfix = get(g:, 'lsp_diagnostics_always_populate_quickfix', 0)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable


### PR DESCRIPTION
When g:lsp_diagnostics_always_populate_quickfix is set to 1, vim-lsp
will automatically populate quickfix with all received diagnostics
(quickfix will contain diagnostics from all files, not just the one that
is currently open).