### PR TITLE
Send initialized notification to the server.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -606,9 +606,11 @@ function! s:handle_initialize(server_name, data) abort
     if !lsp#client#is_error(l:response)
         let l:server['init_result'] = l:response
     else
-      let l:server['failed'] = l:response['error']
-      call lsp#utils#error('Failed to initialize ' . a:server_name . ' with error ' . l:response['error']['code'] . ': ' . l:response['error']['message'])
+        let l:server['failed'] = l:response['error']
+        call lsp#utils#error('Failed to initialize ' . a:server_name . ' with error ' . l:response['error']['code'] . ': ' . l:response['error']['message'])
     endif
+
+    call s:send_notification(a:server_name, { 'method': 'initialized', 'params': {} })
 
     for l:Init_callback in l:init_callbacks
         call l:Init_callback(a:data)


### PR DESCRIPTION
According to LSP 3.0 specification, client should send 'initialized'
notification after client received response to 'initialize' request.

https://microsoft.github.io/language-server-protocol/specification#initialized

Should fix #311.