### PR TITLE
Support textEdit on omni completion

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -196,10 +196,12 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
                 \ 'kind': l:kind}
 
     " check support user_data.
+    " if not support but g:lsp_text_edit_enabled enabled,
+    " then print information to user and add information to log file.
     if !s:is_user_data_support && g:lsp_text_edit_enabled
-        echohl WarningMsg
-        echom 'textEdit support on omni complete requires Vim 8.0 patch 1493 or later(please check g:lsp_text_edit_enabled)'
-        echohl None
+        let l:no_support_error_message = 'textEdit support on omni complete requires Vim 8.0 patch 1493 or later(please check g:lsp_text_edit_enabled)'
+        call lsp#utils#error(l:no_support_error_message)
+        call lsp#log(l:no_support_error_message)
     endif
 
     " add user_data in completion item, if supported user_data.

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -256,9 +256,9 @@ function! s:apply_text_edit() abort
         return
     endif
 
-    " check user_data['vim-lsp/textEdit']
+    " check user_data type is Dictionary and user_data['vim-lsp/textEdit']
     let l:user_data = json_decode(v:completed_item['user_data'])
-    if !has_key(l:user_data, s:user_data_key)
+    if !(type(l:user_data) == type({}) && has_key(l:user_data, s:user_data_key))
         return
     endif
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -201,7 +201,7 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
                 \ s:user_data_key : l:text_edit
                 \ }
 
-        let l:completion['user_data'] = string(l:user_data)
+        let l:completion['user_data'] = json_encode(l:user_data)
     endif
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])
@@ -247,7 +247,7 @@ function! s:apply_text_edit() abort
     endif
 
     " check user_data['vim-lsp/textEdit']
-    let l:user_data = eval(v:completed_item['user_data'])
+    let l:user_data = json_decode(v:completed_item['user_data'])
     if !has_key(l:user_data, s:user_data_key)
         return
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -32,6 +32,7 @@ let s:completion_status_success = 'success'
 let s:completion_status_failed = 'failed'
 let s:completion_status_pending = 'pending'
 
+let s:is_user_data_support = has('patch-8.0.1493')
 let s:user_data_key = 'vim-lsp/textEdit'
 
 " }}}
@@ -193,6 +194,13 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
                 \ 'icase': 1,
                 \ 'dup': 1,
                 \ 'kind': l:kind}
+
+    " check support user_data.
+    if !s:is_user_data_support && g:lsp_text_edit_enabled
+        echohl WarningMsg
+        echom 'textEdit support on omni complete requires Vim 8.0 patch 1493 or later(please check g:lsp_text_edit_enabled)'
+        echohl None
+    endif
 
     " add user_data in completion item, if supported user_data.
     if g:lsp_text_edit_enabled && has_key(a:item, 'textEdit')

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -251,7 +251,7 @@ function! s:apply_text_edit() abort
 
     " check type
     let l:user_data = eval(v:completed_item['user_data'])
-    if l:user_data['type'] != s:completion_type
+    if l:user_data['type'] !=# s:completion_type
         return
     endif
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -251,7 +251,7 @@ function! s:apply_text_edit() abort
 
     " check type
     let l:user_data = eval(v:completed_item['user_data'])
-    if l:user_data['type'] !=# s:completion_type
+    if !has_key(l:user_data, 'type') || l:user_data['type'] !=# s:completion_type
         return
     endif
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -260,7 +260,7 @@ function! s:apply_text_edit() abort
     let l:expanded_text_edit = s:expand_range(l:text_edit, len(v:completed_item['word']))
 
     " apply textEdit
-    call lsp#utils#text_edit#apply_text_edits(fnamemodify(expand('%'), ':p'), [l:expanded_text_edit])
+    call lsp#utils#text_edit#apply_text_edits(expand('%:p'), [l:expanded_text_edit])
 
     " move to end of newText
     " TODO: add user definition cursor position mechanism

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -224,7 +224,7 @@ augroup lsp_completion_item_text_edit
     autocmd CompleteDone * call <SID>apply_text_edit()
 augroup END
 
-function! s:apply_text_edit()
+function! s:apply_text_edit() abort
     " textEdit support function(callin from CompleteDone).
     "
     " expected user_data structure:
@@ -240,7 +240,7 @@ function! s:apply_text_edit()
     endif
 
     " completion faild or not select complete item
-    if empty(v:completed_item) || v:completed_item['word'] == ''
+    if empty(v:completed_item) || v:completed_item['word'] ==# ''
         return
     endif
 
@@ -271,7 +271,7 @@ function! s:apply_text_edit()
     call cursor(l:line, l:col + l:new_text_length)
 endfunction
 
-function! s:expand_range(text_edit, expand_length)
+function! s:expand_range(text_edit, expand_length) abort
     let expanded_text_edit = a:text_edit
     let l:expanded_text_edit['range']['end']['character'] += a:expand_length
 

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -474,7 +474,7 @@ function! s:handle_text_edit(server, last_req_id, type, data) abort
         return
     endif
 
-    call s:apply_text_edits(a:data['request']['params']['textDocument']['uri'], a:data['response']['result'])
+    call lsp#utils#buffer#apply_text_edits(a:data['request']['params']['textDocument']['uri'], a:data['response']['result'])
 
     echo 'Document formatted'
 endfunction
@@ -517,7 +517,7 @@ function! s:apply_workspace_edits(workspace_edits) abort
         let l:cur_buffer = bufnr('%')
         let l:view = winsaveview()
         for [l:uri, l:text_edits] in items(a:workspace_edits['changes'])
-            call s:apply_text_edits(l:uri, l:text_edits)
+            call lsp#utils#buffer#apply_text_edits(l:uri, l:text_edits)
         endfor
         if l:cur_buffer !=# bufnr('%')
             execute 'keepjumps keepalt b ' . l:cur_buffer
@@ -528,7 +528,7 @@ function! s:apply_workspace_edits(workspace_edits) abort
         let l:cur_buffer = bufnr('%')
         let l:view = winsaveview()
         for l:text_document_edit in a:workspace_edits['documentChanges']
-            call s:apply_text_edits(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
+            call lsp#utils#buffer#apply_text_edits(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
         endfor
         if l:cur_buffer !=# bufnr('%')
             execute 'keepjumps keepalt b ' . l:cur_buffer
@@ -537,251 +537,3 @@ function! s:apply_workspace_edits(workspace_edits) abort
     endif
 endfunction
 
-function! s:apply_text_edits(uri, text_edits) abort
-    " https://microsoft.github.io/language-server-protocol/specification#textedit
-    " The order in the array defines the order in which the inserted string
-    " appear in the resulting text.
-    "
-    " The edits must be applied in the reverse order so the early edits will
-    " not interfere with the position of later edits, they need to be applied
-    " one at the time or put together as a single command.
-    "
-    " Example: {"range": {"end": {"character": 45, "line": 5}, "start":
-    " {"character": 45, "line": 5}}, "newText": "\n"}, {"range": {"end":
-    " {"character": 45, "line": 5}, "start": {"character": 45, "line": 5}},
-    " "newText": "import javax.ws.rs.Consumes;"}]}}
-    "
-    " If we apply the \n first we will need adjust the line range of the next
-    " command (so the import will be written on the next line) , but if we
-    " write the import first and then the \n everything will be fine.
-    " If you do not apply a command one at  time, you will need to adjust the
-    " range columns after which edit. You will get this (only one execution):
-    "
-    " execute 'keepjumps normal! 6G045laimport javax.ws.rs.Consumes;'" |
-    " execute 'keepjumps normal! 6G045la\n'
-    "
-    " resulting in this:
-    " import javax.servlet.http.HttpServletRequest;i
-    " mport javax.ws.rs.Consumes;
-    "
-    " instead of this (multiple executions):
-    " execute 'keepjumps normal! 6G045laimport javax.ws.rs.Consumes;'"
-    " execute 'keepjumps normal! 6G045li\n'
-    "
-    " resulting in this:
-    " import javax.servlet.http.HttpServletRequest;
-    " import javax.ws.rs.Consumes;
-    "
-    "
-    " The sort is also necessary since the LSP specification does not
-    " guarantee that text edits are sorted.
-    "
-    " Example:
-    " Initial text:  "abcdef"
-    " Edits:
-    " ((0, 0), (0, 1), "") - remove first character 'a'
-    " ((0, 4), (0, 5), "") - remove fifth character 'e'
-    " ((0, 2), (0, 3), "") - remove third character 'c'
-    let l:text_edits = sort(deepcopy(a:text_edits), '<SID>sort_text_edit_desc')
-    let l:i = 0
-
-    while l:i < len(l:text_edits)
-        let l:merged_text_edit = s:merge_same_range(l:i, l:text_edits)
-        let l:cmd = s:build_cmd(a:uri, l:merged_text_edit['merged'])
-
-        try
-            let l:was_paste = &paste
-            let l:was_selection = &selection
-            let l:was_virtualedit = &virtualedit
-            let l:was_view = winsaveview()
-
-            set paste
-            set selection=exclusive
-            set virtualedit=onemore
-
-            execute l:cmd
-        finally
-            let &paste = l:was_paste
-            let &selection = l:was_selection
-            let &virtualedit = l:was_virtualedit
-            call winrestview(l:was_view)
-        endtry
-
-        let l:i = l:merged_text_edit['end_index']
-    endwhile
-endfunction
-
-" Merge the edits on the same range so we do not have to reverse the
-" text_edits  that are inserts, also from the specification:
-" If multiple inserts have the same position, the order in the array
-" defines the order in which the inserted strings appear in the
-" resulting text
-function! s:merge_same_range(start_index, text_edits) abort
-    let l:i = a:start_index + 1
-    let l:merged = deepcopy(a:text_edits[a:start_index])
-
-    while l:i < len(a:text_edits) &&
-        \ s:is_same_range(l:merged['range'], a:text_edits[l:i]['range'])
-
-        let l:merged['newText'] .= a:text_edits[l:i]['newText']
-        let l:i += 1
-    endwhile
-
-    return {'merged': l:merged, 'end_index': l:i}
-endfunction
-
-function! s:is_same_range(range1, range2) abort
-    return a:range1['start']['line'] == a:range2['start']['line'] &&
-        \ a:range1['end']['line'] == a:range2['end']['line'] &&
-        \ a:range1['start']['character'] == a:range2['start']['character'] &&
-        \ a:range1['end']['character'] == a:range2['end']['character']
-endfunction
-
-" https://microsoft.github.io/language-server-protocol/specification#textedit
-function! s:is_insert(range) abort
-    return a:range['start']['line'] == a:range['end']['line'] &&
-        \ a:range['start']['character'] == a:range['end']['character']
-endfunction
-
-" Compares two text edits, based on the starting position of the range.
-" Assumes that edits have non-overlapping ranges.
-"
-" `text_edit1` and `text_edit2` are dictionaries and represent LSP TextEdit type.
-"
-" Returns 0 if both text edits starts at the same position (insert text),
-" positive value if `text_edit1` starts before `text_edit2` and negative value
-" otherwise.
-function! s:sort_text_edit_desc(text_edit1, text_edit2) abort
-    if a:text_edit1['range']['start']['line'] != a:text_edit2['range']['start']['line']
-        return a:text_edit2['range']['start']['line'] - a:text_edit1['range']['start']['line']
-    endif
-
-    if a:text_edit1['range']['start']['character'] != a:text_edit2['range']['start']['character']
-        return a:text_edit2['range']['start']['character'] - a:text_edit1['range']['start']['character']
-    endif
-
-    return !s:is_insert(a:text_edit1['range']) ? -1 :
-        \ s:is_insert(a:text_edit2['range']) ? 0 : 1
-endfunction
-
-function! s:build_cmd(uri, text_edit) abort
-    let l:path = lsp#utils#uri_to_path(a:uri)
-    let l:buffer = bufnr(l:path)
-    let l:cmd = 'keepjumps keepalt ' . (l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:path)
-    let s:text_edit = deepcopy(a:text_edit)
-
-    let s:text_edit['range'] = s:parse_range(s:text_edit['range'])
-    let l:sub_cmd = s:generate_sub_cmd(s:text_edit)
-    let l:escaped_sub_cmd = substitute(l:sub_cmd, '''', '''''', 'g')
-    let l:cmd = l:cmd . " | execute 'keepjumps normal! " . l:escaped_sub_cmd . "'"
-
-    call lsp#log('s:build_cmd', l:cmd)
-
-    return l:cmd
-endfunction
-
-function! s:generate_sub_cmd(text_edit) abort
-    if s:is_insert(a:text_edit['range'])
-        return s:generate_sub_cmd_insert(a:text_edit)
-    else
-        return s:generate_sub_cmd_replace(a:text_edit)
-    endif
-endfunction
-
-function! s:generate_sub_cmd_insert(text_edit) abort
-    let l:start_line = a:text_edit['range']['start']['line']
-    let l:start_character = a:text_edit['range']['start']['character']
-    let l:new_text = s:parse(a:text_edit['newText'])
-
-    let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
-    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
-
-    if len(l:new_text) == 0
-        let l:sub_cmd .= 'x'
-    else
-        if l:start_character >= len(getline(l:start_line))
-            let l:sub_cmd .= 'a'
-        else
-            let l:sub_cmd .= 'i'
-        endif
-    endif
-
-    let l:sub_cmd .= printf('%s', l:new_text)
-
-    return l:sub_cmd
-endfunction
-
-function! s:generate_sub_cmd_replace(text_edit) abort
-    let l:start_line = a:text_edit['range']['start']['line']
-    let l:start_character = a:text_edit['range']['start']['character']
-    let l:end_line = a:text_edit['range']['end']['line']
-    let l:end_character = a:text_edit['range']['end']['character']
-    let l:new_text = substitute(a:text_edit['newText'], '\n$', '', '')
-
-    let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
-    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character) " move to the first position
-    let l:sub_cmd .= 'v'
-    let l:sub_cmd .= s:generate_move_end_cmd(l:end_line, l:end_character) " move to the last position
-
-    if len(l:new_text) == 0
-        let l:sub_cmd .= 'x'
-    else
-        let l:sub_cmd .= 'c'
-        let l:sub_cmd .= printf('%s', l:new_text) " change text
-    endif
-
-    return l:sub_cmd
-endfunction
-
-function! s:generate_move_start_cmd(line_pos, character_pos) abort
-    let l:result = printf('%dG0', a:line_pos) " move the line and set to the cursor at the beginning
-    if a:character_pos > 0
-        let l:result .= printf('%dl', a:character_pos) " move right until the character
-    endif
-    return l:result
-endfunction
-
-function! s:generate_move_end_cmd(line_pos, character_pos) abort
-    let l:result = printf('%dG0', a:line_pos) " move the line and set to the cursor at the beginning
-    if a:character_pos > 0
-        let l:result .= printf('%dl', a:character_pos) " move right until the character
-    else
-        let l:result = printf('%dG$', a:line_pos - 1) " move most right
-    endif
-    return l:result
-endfunction
-
-function! s:parse(text) abort
-    " https://stackoverflow.com/questions/71417/why-is-r-a-newline-for-vim
-    return substitute(a:text, '\(^\n|\n$\|\r\n\)', '\r', 'g')
-endfunction
-
-function! s:preprocess_cmd(range) abort
-    " preprocess by opening the folds, this is needed because the line you are
-    " going might have a folding
-    let l:preprocess = ''
-
-    if foldlevel(a:range['start']['line']) > 0
-        let l:preprocess .= a:range['start']['line']
-        let l:preprocess .= 'GzO'
-    endif
-
-    if foldlevel(a:range['end']['line']) > 0
-        let l:preprocess .= a:range['end']['line']
-        let l:preprocess .= 'GzO'
-    endif
-
-    return l:preprocess
-endfunction
-
-" https://microsoft.github.io/language-server-protocol/specification#text-documents
-" Position in a text document expressed as zero-based line and zero-based
-" character offset, and since we are using the character as a offset position
-" we do not have to fix its position
-function! s:parse_range(range) abort
-    let s:range = deepcopy(a:range)
-    let s:range['start']['line'] =  a:range['start']['line'] + 1
-    let s:range['end']['line'] = a:range['end']['line'] + 1
-
-    return s:range
-endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -474,7 +474,7 @@ function! s:handle_text_edit(server, last_req_id, type, data) abort
         return
     endif
 
-    call lsp#utils#buffer#apply_text_edits(a:data['request']['params']['textDocument']['uri'], a:data['response']['result'])
+    call lsp#utils#text_edit#apply_text_edits(a:data['request']['params']['textDocument']['uri'], a:data['response']['result'])
 
     echo 'Document formatted'
 endfunction
@@ -517,7 +517,7 @@ function! s:apply_workspace_edits(workspace_edits) abort
         let l:cur_buffer = bufnr('%')
         let l:view = winsaveview()
         for [l:uri, l:text_edits] in items(a:workspace_edits['changes'])
-            call lsp#utils#buffer#apply_text_edits(l:uri, l:text_edits)
+            call lsp#utils#text_edit#apply_text_edits(l:uri, l:text_edits)
         endfor
         if l:cur_buffer !=# bufnr('%')
             execute 'keepjumps keepalt b ' . l:cur_buffer
@@ -528,7 +528,7 @@ function! s:apply_workspace_edits(workspace_edits) abort
         let l:cur_buffer = bufnr('%')
         let l:view = winsaveview()
         for l:text_document_edit in a:workspace_edits['documentChanges']
-            call lsp#utils#buffer#apply_text_edits(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
+            call lsp#utils#text_edit#apply_text_edits(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
         endfor
         if l:cur_buffer !=# bufnr('%')
             execute 'keepjumps keepalt b ' . l:cur_buffer

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -1,0 +1,248 @@
+function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
+    " https://microsoft.github.io/language-server-protocol/specification#textedit
+    " The order in the array defines the order in which the inserted string
+    " appear in the resulting text.
+    "
+    " The edits must be applied in the reverse order so the early edits will
+    " not interfere with the position of later edits, they need to be applied
+    " one at the time or put together as a single command.
+    "
+    " Example: {"range": {"end": {"character": 45, "line": 5}, "start":
+    " {"character": 45, "line": 5}}, "newText": "\n"}, {"range": {"end":
+    " {"character": 45, "line": 5}, "start": {"character": 45, "line": 5}},
+    " "newText": "import javax.ws.rs.Consumes;"}]}}
+    "
+    " If we apply the \n first we will need adjust the line range of the next
+    " command (so the import will be written on the next line) , but if we
+    " write the import first and then the \n everything will be fine.
+    " If you do not apply a command one at  time, you will need to adjust the
+    " range columns after which edit. You will get this (only one execution):
+    "
+    " execute 'keepjumps normal! 6G045laimport javax.ws.rs.Consumes;'" |
+    " execute 'keepjumps normal! 6G045la\n'
+    "
+    " resulting in this:
+    " import javax.servlet.http.HttpServletRequest;i
+    " mport javax.ws.rs.Consumes;
+    "
+    " instead of this (multiple executions):
+    " execute 'keepjumps normal! 6G045laimport javax.ws.rs.Consumes;'"
+    " execute 'keepjumps normal! 6G045li\n'
+    "
+    " resulting in this:
+    " import javax.servlet.http.HttpServletRequest;
+    " import javax.ws.rs.Consumes;
+    "
+    "
+    " The sort is also necessary since the LSP specification does not
+    " guarantee that text edits are sorted.
+    "
+    " Example:
+    " Initial text:  "abcdef"
+    " Edits:
+    " ((0, 0), (0, 1), "") - remove first character 'a'
+    " ((0, 4), (0, 5), "") - remove fifth character 'e'
+    " ((0, 2), (0, 3), "") - remove third character 'c'
+    let l:text_edits = sort(deepcopy(a:text_edits), '<SID>sort_text_edit_desc')
+    let l:i = 0
+
+    while l:i < len(l:text_edits)
+        let l:merged_text_edit = s:merge_same_range(l:i, l:text_edits)
+        let l:cmd = s:build_cmd(a:uri, l:merged_text_edit['merged'])
+
+        try
+            let l:was_paste = &paste
+            let l:was_selection = &selection
+            let l:was_virtualedit = &virtualedit
+            let l:was_view = winsaveview()
+
+            set paste
+            set selection=exclusive
+            set virtualedit=onemore
+
+            execute l:cmd
+        finally
+            let &paste = l:was_paste
+            let &selection = l:was_selection
+            let &virtualedit = l:was_virtualedit
+            call winrestview(l:was_view)
+        endtry
+
+        let l:i = l:merged_text_edit['end_index']
+    endwhile
+endfunction
+
+" Merge the edits on the same range so we do not have to reverse the
+" text_edits  that are inserts, also from the specification:
+" If multiple inserts have the same position, the order in the array
+" defines the order in which the inserted strings appear in the
+" resulting text
+function! s:merge_same_range(start_index, text_edits) abort
+    let l:i = a:start_index + 1
+    let l:merged = deepcopy(a:text_edits[a:start_index])
+
+    while l:i < len(a:text_edits) &&
+        \ s:is_same_range(l:merged['range'], a:text_edits[l:i]['range'])
+
+        let l:merged['newText'] .= a:text_edits[l:i]['newText']
+        let l:i += 1
+    endwhile
+
+    return {'merged': l:merged, 'end_index': l:i}
+endfunction
+
+function! s:is_same_range(range1, range2) abort
+    return a:range1['start']['line'] == a:range2['start']['line'] &&
+        \ a:range1['end']['line'] == a:range2['end']['line'] &&
+        \ a:range1['start']['character'] == a:range2['start']['character'] &&
+        \ a:range1['end']['character'] == a:range2['end']['character']
+endfunction
+
+" https://microsoft.github.io/language-server-protocol/specification#textedit
+function! s:is_insert(range) abort
+    return a:range['start']['line'] == a:range['end']['line'] &&
+        \ a:range['start']['character'] == a:range['end']['character']
+endfunction
+
+" Compares two text edits, based on the starting position of the range.
+" Assumes that edits have non-overlapping ranges.
+"
+" `text_edit1` and `text_edit2` are dictionaries and represent LSP TextEdit type.
+"
+" Returns 0 if both text edits starts at the same position (insert text),
+" positive value if `text_edit1` starts before `text_edit2` and negative value
+" otherwise.
+function! s:sort_text_edit_desc(text_edit1, text_edit2) abort
+    if a:text_edit1['range']['start']['line'] != a:text_edit2['range']['start']['line']
+        return a:text_edit2['range']['start']['line'] - a:text_edit1['range']['start']['line']
+    endif
+
+    if a:text_edit1['range']['start']['character'] != a:text_edit2['range']['start']['character']
+        return a:text_edit2['range']['start']['character'] - a:text_edit1['range']['start']['character']
+    endif
+
+    return !s:is_insert(a:text_edit1['range']) ? -1 :
+        \ s:is_insert(a:text_edit2['range']) ? 0 : 1
+endfunction
+
+function! s:build_cmd(uri, text_edit) abort
+    let l:path = lsp#utils#uri_to_path(a:uri)
+    let l:buffer = bufnr(l:path)
+    let l:cmd = 'keepjumps keepalt ' . (l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . l:path)
+    let s:text_edit = deepcopy(a:text_edit)
+
+    let s:text_edit['range'] = s:parse_range(s:text_edit['range'])
+    let l:sub_cmd = s:generate_sub_cmd(s:text_edit)
+    let l:escaped_sub_cmd = substitute(l:sub_cmd, '''', '''''', 'g')
+    let l:cmd = l:cmd . " | execute 'keepjumps normal! " . l:escaped_sub_cmd . "'"
+
+    call lsp#log('s:build_cmd', l:cmd)
+
+    return l:cmd
+endfunction
+
+function! s:generate_sub_cmd(text_edit) abort
+    if s:is_insert(a:text_edit['range'])
+        return s:generate_sub_cmd_insert(a:text_edit)
+    else
+        return s:generate_sub_cmd_replace(a:text_edit)
+    endif
+endfunction
+
+function! s:generate_sub_cmd_insert(text_edit) abort
+    let l:start_line = a:text_edit['range']['start']['line']
+    let l:start_character = a:text_edit['range']['start']['character']
+    let l:new_text = s:parse(a:text_edit['newText'])
+
+    let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
+    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
+
+    if len(l:new_text) == 0
+        let l:sub_cmd .= 'x'
+    else
+        if l:start_character >= len(getline(l:start_line))
+            let l:sub_cmd .= 'a'
+        else
+            let l:sub_cmd .= 'i'
+        endif
+    endif
+
+    let l:sub_cmd .= printf('%s', l:new_text)
+
+    return l:sub_cmd
+endfunction
+
+function! s:generate_sub_cmd_replace(text_edit) abort
+    let l:start_line = a:text_edit['range']['start']['line']
+    let l:start_character = a:text_edit['range']['start']['character']
+    let l:end_line = a:text_edit['range']['end']['line']
+    let l:end_character = a:text_edit['range']['end']['character']
+    let l:new_text = substitute(a:text_edit['newText'], '\n$', '', '')
+
+    let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
+    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character) " move to the first position
+    let l:sub_cmd .= 'v'
+    let l:sub_cmd .= s:generate_move_end_cmd(l:end_line, l:end_character) " move to the last position
+
+    if len(l:new_text) == 0
+        let l:sub_cmd .= 'x'
+    else
+        let l:sub_cmd .= 'c'
+        let l:sub_cmd .= printf('%s', l:new_text) " change text
+    endif
+
+    return l:sub_cmd
+endfunction
+
+function! s:generate_move_start_cmd(line_pos, character_pos) abort
+    let l:result = printf('%dG0', a:line_pos) " move the line and set to the cursor at the beginning
+    if a:character_pos > 0
+        let l:result .= printf('%dl', a:character_pos) " move right until the character
+    endif
+    return l:result
+endfunction
+
+function! s:generate_move_end_cmd(line_pos, character_pos) abort
+    let l:result = printf('%dG0', a:line_pos) " move the line and set to the cursor at the beginning
+    if a:character_pos > 0
+        let l:result .= printf('%dl', a:character_pos) " move right until the character
+    else
+        let l:result = printf('%dG$', a:line_pos - 1) " move most right
+    endif
+    return l:result
+endfunction
+
+function! s:parse(text) abort
+    " https://stackoverflow.com/questions/71417/why-is-r-a-newline-for-vim
+    return substitute(a:text, '\(^\n|\n$\|\r\n\)', '\r', 'g')
+endfunction
+
+function! s:preprocess_cmd(range) abort
+    " preprocess by opening the folds, this is needed because the line you are
+    " going might have a folding
+    let l:preprocess = ''
+
+    if foldlevel(a:range['start']['line']) > 0
+        let l:preprocess .= a:range['start']['line']
+        let l:preprocess .= 'GzO'
+    endif
+
+    if foldlevel(a:range['end']['line']) > 0
+        let l:preprocess .= a:range['end']['line']
+        let l:preprocess .= 'GzO'
+    endif
+
+    return l:preprocess
+endfunction
+
+" https://microsoft.github.io/language-server-protocol/specification#text-documents
+" Position in a text document expressed as zero-based line and zero-based
+" character offset, and since we are using the character as a offset position
+" we do not have to fix its position
+function! s:parse_range(range) abort
+    let s:range = deepcopy(a:range)
+    let s:range['start']['line'] =  a:range['start']['line'] + 1
+    let s:range['end']['line'] = a:range['end']['line'] + 1
+
+    return s:range
+endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -14,6 +14,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_auto_enable           |g:lsp_auto_enable|
       g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
       g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
+      g:lsp_text_edit_enabled     |g:lsp_text_edit_enabled|
       g:lsp_signs_enabled         |g:lsp_signs_enabled|
       g:lsp_use_event_queue       |g:lsp_use_event_queue|
     Functions			|vim-lsp-functions|
@@ -149,6 +150,17 @@ g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
     Example:
 	let g:lsp_insert_text_enabled = 1
 	let g:lsp_insert_text_enabled = 0
+
+g:lsp_text_edit_enabled                              *g:lsp_text_edit_enabled*
+    Type: |Number|
+    Default: `1`
+
+    Enable support for completion textEdit property. Set to `0` to disable
+    using textEdit.
+
+    Example:
+	let g:lsp_text_edit_enabled = 1
+	let g:lsp_text_edit_enabled = 0
 
 g:lsp_signs_enabled                                   *g:lsp_signs_enabled*
     Type: |Number|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -20,6 +20,7 @@ let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
+let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', 1)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -20,7 +20,7 @@ let g:lsp_next_sign_id = get(g:, 'lsp_next_sign_id', 6999)
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
-let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', 1)
+let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -15,8 +15,7 @@ Describe lsp#omni
             \ 'icase': 1,
             \ 'dup': 1,
             \ 'kind': 'function',
-            \ 'menu': 'my-detail',
-            \ 'user_data': '{}'
+            \ 'menu': 'my-detail'
             \}
             let got = lsp#omni#get_vim_completion_item(item)
 

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -15,7 +15,8 @@ Describe lsp#omni
             \ 'icase': 1,
             \ 'dup': 1,
             \ 'kind': 'function',
-            \ 'menu': 'my-detail'
+            \ 'menu': 'my-detail',
+            \ 'user_data': '{}'
             \}
             let got = lsp#omni#get_vim_completion_item(item)
 

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -21,5 +21,47 @@ Describe lsp#omni
 
             Assert Equals(got, want)
         End
+
+        It should return result contained user_data['vim-lsp/textEdit'], if exist textEdit in item
+            if !has('patch-8.0.1493')
+                Skip This test requires 'patch-8.0.1493'
+            endif
+
+            let l:text_edit = {
+            \    'range': {
+            \      'start': {'line': 5, 'character': 0},
+            \      'end': {'line': 5, 'character': 5}
+            \    },
+            \    'newText': 'yyy'
+            \  }
+
+            let item = {
+            \ 'label': 'my-label',
+            \ 'documentation': 'my documentation.',
+            \ 'detail': 'my-detail',
+            \ 'kind': '3',
+            \ 'textEdit': l:text_edit
+            \}
+
+            let l:want_user_data = {
+            \  'vim-lsp/textEdit': l:text_edit
+            \}
+
+            let l:want_user_data_string = json_encode(l:want_user_data)
+
+            let want = {
+            \ 'word': 'my-label',
+            \ 'abbr': 'my-label',
+            \ 'info': 'my documentation.',
+            \ 'icase': 1,
+            \ 'dup': 1,
+            \ 'kind': 'function',
+            \ 'menu': 'my-detail',
+            \ 'user_data': l:want_user_data_string
+            \}
+            let got = lsp#omni#get_vim_completion_item(item)
+
+            Assert Equals(got, want)
+        End
     End
 End


### PR DESCRIPTION
See #142.

I add support textEdit on omni completion.

1. Moved functions about TextEdit, to utils.
2. Added apply_text_edit function and CompleteDone auto command.
    1. Added `user_data` in completion items, contained textEdit data.
    2. Call `s:apply_text_edit` from CompleteDone
    3. `s:apply_text_edit` parse `user_data` and call `lsp#utils#text_edit#apply_text_edits`