### PR TITLE
Initialization Options should be an option could be opt-out.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -401,24 +401,23 @@ function! s:ensure_init(buf, server_name, cb) abort
         \ }
     endif
 
+    let l:request = {
+    \   'method': 'initialize',
+    \   'params': {
+    \     'capabilities': l:capabilities,
+    \     'rootUri': l:root_uri,
+    \     'rootPath': lsp#utils#uri_to_path(l:root_uri),
+    \     'trace': 'off',
+    \   },
+    \ }
+
     if has_key(l:server_info, 'initialization_options')
-        let l:initialization_options = l:server_info['initialization_options']
-    else
-        let l:initialization_options = {}
+        let l:request['initialization_options'] = l:server_info['initialization_options']
     endif
 
     let l:server['init_callbacks'] = [a:cb]
 
-    call s:send_request(a:server_name, {
-        \ 'method': 'initialize',
-        \ 'params': {
-        \   'capabilities': l:capabilities,
-        \   'rootUri': l:root_uri,
-        \   'rootPath': lsp#utils#uri_to_path(l:root_uri),
-        \   'trace': 'off',
-        \   'initializationOptions': l:initialization_options,
-        \ },
-        \ })
+    call s:send_request(a:server_name, l:request)
 endfunction
 
 function! s:ensure_conf(buf, server_name, cb) abort


### PR DESCRIPTION
Some of language servers expects that initializationOptions must have fields if the initializationOptions is set.

https://github.com/vscode-langservers/vscode-html-languageserver/blob/18bed63e90d661407306d3b66a856e951036567d/src/htmlServerMain.ts#L97

So when do not specify initializationOptions for lsp#register_server, the language server always crash.