### PR TITLE
Populate required processId in InitializeParams.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -404,6 +404,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     let l:request = {
     \   'method': 'initialize',
     \   'params': {
+    \     'processId': getpid(),
     \     'capabilities': l:capabilities,
     \     'rootUri': l:root_uri,
     \     'rootPath': lsp#utils#uri_to_path(l:root_uri),


### PR DESCRIPTION
According to LSP 3.0 specification, params in 'initialize' request is
required (it can be null, but it has to be specified). This change
populates the processId with PID of vim process.