### PR TITLE
Use location list instead of quickfix for diagnostics

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -36,7 +36,7 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
         let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
     endfor
 
-    call setqflist(l:result)
+    call setloclist(0, l:result)
 
     " autocmd FileType qf setlocal wrap
 
@@ -44,7 +44,7 @@ function! lsp#ui#vim#diagnostics#document_diagnostics() abort
         call lsp#utils#error('No diagnostics results found')
     else
         echo 'Retrieved diagnostics results'
-        botright copen
+        botright lopen
     endif
 endfunction
 


### PR DESCRIPTION
Diagnostics are enabled only for current document which makes it
pointless to feed them to the QuickFix which is global. This PR changes
that behaviour to use location list, which is window-local, instead.

Close #75