### PR TITLE
Use correct highlight group name (fix #340)

### DIFF
--- a/autoload/lsp/ui/vim/virtual.vim
+++ b/autoload/lsp/ui/vim/virtual.vim
@@ -80,7 +80,8 @@ function! s:place_virtual(server_name, path, diagnostics) abort
             let l:line = l:item['range']['start']['line']
 
             let l:name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
-            call nvim_buf_set_virtual_text(l:bufnr, l:ns, l:line, [[l:item['message'], l:name]], {})
+            let l:hl_name = l:name . 'Text'
+            call nvim_buf_set_virtual_text(l:bufnr, l:ns, l:line, [[l:item['message'], l:hl_name]], {})
         endfor
     endif
 endfunction


### PR DESCRIPTION
Did not edit signs.vim because it seemed to handle the highlight group appropriately.