### PR TITLE
Remove trailing space in 'applyEdit ' field.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -397,7 +397,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     else
         let l:capabilities = {
         \   'workspace': {
-        \       'applyEdit ': v:true
+        \       'applyEdit': v:true
         \   }
         \ }
     endif


### PR DESCRIPTION
The 'applyEdit ' field inside initialize request (inside
capabilities.workspace) has trailing space which is incorrect and can
cause servers to ignore this capability.