### PR TITLE
Fix to allow "textEdit property provide and null value".

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -204,14 +204,21 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
         call lsp#log(l:no_support_error_message)
     endif
 
-    " add user_data in completion item, if supported user_data.
+    " add user_data in completion item, when
+    "     1. provided user_data
+    "     2. provided textEdit
+    "     3. textEdit value is Dictionary
     if g:lsp_text_edit_enabled && has_key(a:item, 'textEdit')
         let l:text_edit = a:item['textEdit']
-        let l:user_data = {
-                \ s:user_data_key : l:text_edit
-                \ }
 
-        let l:completion['user_data'] = json_encode(l:user_data)
+        " type check
+        if type(l:text_edit) == type({})
+            let l:user_data = {
+                    \ s:user_data_key : l:text_edit
+                    \ }
+
+            let l:completion['user_data'] = json_encode(l:user_data)
+        endif
     endif
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -63,5 +63,32 @@ Describe lsp#omni
 
             Assert Equals(got, want)
         End
+
+        It should not add user_data, if provide textEdit property and textEdit value is null
+            if !has('patch-8.0.1493')
+                Skip This test requires 'patch-8.0.1493'
+            endif
+
+            let item = {
+            \ 'label': 'my-label',
+            \ 'documentation': 'my documentation.',
+            \ 'detail': 'my-detail',
+            \ 'kind': '3',
+            \ 'textEdit': v:null
+            \}
+
+            let want = {
+            \ 'word': 'my-label',
+            \ 'abbr': 'my-label',
+            \ 'info': 'my documentation.',
+            \ 'icase': 1,
+            \ 'dup': 1,
+            \ 'kind': 'function',
+            \ 'menu': 'my-detail',
+            \}
+            let got = lsp#omni#get_vim_completion_item(item)
+
+            Assert Equals(got, want)
+        End
     End
 End


### PR DESCRIPTION
See #355.

I fixed to allow "textEdit property provide and null value".
(Not add user_data, when textEdit not provide or null)