### PR TITLE
Highlight references to the symbol under cursor

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3,6 +3,7 @@ their own copyright notices and license terms:
 
 * vim-lsc - https://github.com/natebosch/vim-lsc
     * autoload/lsc/diff.vim
+    * autoload/lsc/cursor.vim
     ====================================================================
 
     Copyright 2017 vim-lsc authors

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Refer to docs on configuring omnifunc or [asyncomplete.vim](https://github.com/p
 |`:LspHover`| Show hover information |
 |`:LspImplementation` | Show implementation of interface |
 |`:LspNextError`| jump to next error |
+|`:LspNextReference`| jump to next reference to the symbol under cursor |
 |`:LspPreviousError`| jump to previous error |
+|`:LspPreviousReference`| jump to previous reference to the symbol under cursor |
 |`:LspReferences`| Find references |
 |`:LspRename`| Rename symbol |
 |`:LspStatus` | Show the status of the language server |
@@ -116,6 +118,22 @@ let g:lsp_virtual_text_enabled = 0
 To your configuration.
 
 Virtual text will use the same highlight groups as signs feature.
+
+### Highlight references
+
+References to the symbol under the cursor are highlighted by default. To
+disable, set in your configuration:
+
+```viml
+let g:lsp_highlight_references_enabled = 0
+```
+
+To change the style of the highlighting, you can set or link the `lspReference`
+highlight group, e.g.:
+
+```viml
+highlight lspReference ctermfg=red guifg=red ctermbg=green guibg=green
+```
 
 ## Debugging
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -157,6 +157,8 @@ function! s:register_events() abort
             autocmd TextChangedP * call s:on_text_document_did_change()
         endif
         autocmd CursorMoved * call s:on_cursor_moved()
+        autocmd BufWinEnter,BufWinLeave,InsertEnter * call lsp#ui#vim#references#clean_references()
+        autocmd CursorMoved * call lsp#ui#vim#references#highlight(v:false)
     augroup END
     call s:on_text_document_did_open()
 endfunction

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -61,6 +61,10 @@ function! lsp#capabilities#has_type_definition_provider(server_name) abort
     return s:has_bool_provider(a:server_name, 'typeDefinitionProvider')
 endfunction
 
+function! lsp#capabilities#has_document_highlight_provider(server_name) abort
+    return s:has_bool_provider(a:server_name, 'documentHighlightProvider')
+endfunction
+
 " [supports_did_save (boolean), { 'includeText': boolean }]
 function! lsp#capabilities#get_text_document_save_registration_options(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -215,9 +215,9 @@ function! lsp#ui#vim#references#jump(offset) abort
     endif
 
     " Wrap index
-    while l:index < 0 || l:index >= len(w:lsp_reference_positions)
+    if l:index < 0 || l:index >= len(w:lsp_reference_positions)
         let l:index = (l:index % l:n + l:n) % l:n
-    endwhile
+    endif
 
     " Jump
     let l:target = w:lsp_reference_positions[l:index][0:1]

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -1,0 +1,225 @@
+" Global state
+let s:last_req_id = 0
+let s:pending = {}
+
+" Highlight group for references
+if !hlexists('lspReference')
+    highlight link lspReference CursorColumn
+endif
+
+" Convert a LSP range to one or more vim match positions.
+" If the range spans over multiple lines, break it down to multiple
+" positions, one for each line.
+" Return a list of positions.
+function! s:range_to_position(range) abort
+    let l:start = a:range['start']
+    let l:end = a:range['end']
+    let l:position = []
+
+    if l:end['line'] == l:start['line']
+        let l:position = [[
+        \ l:start['line'] + 1,
+        \ l:start['character'] + 1,
+        \ l:end['character'] - l:start['character']
+        \ ]]
+    else
+        " First line
+        let l:position = [[
+        \ l:start['line'] + 1,
+        \ l:start['character'] + 1,
+        \ 999
+        \ ]]
+
+        " Last line
+        call add(l:position, [
+        \ l:end['line'] + 1,
+        \ 1,
+        \ l:end['character']
+        \ ])
+
+        " Lines in the middle
+        let l:middle_lines = map(
+        \ range(l:start['line'] + 2, end['line']),
+        \ {_, l -> [l, 0, 999]}
+        \ )
+
+        call extend(l:position, l:middle_lines)
+    endif
+
+    return l:position
+endfunction
+
+" Compare two positions
+function! s:compare_positions(p1, p2) abort
+    let l:line_1 = a:p1[0]
+    let l:line_2 = a:p2[0]
+    if l:line_1 != l:line_2
+        return l:line_1 > l:line_2 ? 1 : -1
+    endif
+    let l:col_1 = a:p1[1]
+    let l:col_2 = a:p2[1]
+    return l:col_1 - l:col_2
+endfunction
+
+" If the cursor is over a reference, return its index in
+" the array. Otherwise, return -1.
+function! s:in_reference(reference_list) abort
+    let l:line = line('.')
+    let l:column = col('.')
+    let l:index = 0
+    for l:position in a:reference_list
+        if l:line == l:position[0] &&
+        \  l:column >= l:position[1] &&
+        \  l:column < l:position[1] + l:position[2]
+            return l:index
+        endif
+        let l:index += 1
+    endfor
+    return -1
+endfunction
+
+" Handle response from server.
+function! s:handle_references(ctx, data) abort
+    " Sanity checks
+    if lsp#client#is_error(a:data['response']) ||
+    \  !has_key(s:pending, a:ctx['filetype']) ||
+    \  !s:pending[a:ctx['filetype']]
+        return
+    endif
+    let s:pending[a:ctx['filetype']] = v:false
+
+    " More sanity checks
+    if  a:ctx['bufnr'] != bufnr('%') || a:ctx['last_req_id'] != s:last_req_id
+        return
+    endif
+
+    " Remove existing highlights from the buffer
+    call lsp#ui#vim#references#clean_references()
+
+    " Get references from the response
+    let l:reference_list = a:data['response']['result']
+    if empty(l:reference_list)
+        return
+    endif
+
+    " Convert references to vim positions
+    let l:position_list = []
+    for l:reference in l:reference_list
+        call extend(l:position_list, s:range_to_position(l:reference['range']))
+    endfor
+    call sort(l:position_list, function('s:compare_positions'))
+
+    " Ignore response if the cursor is not over a reference anymore
+    if s:in_reference(l:position_list) == -1
+        " If the cursor has moved: send another request
+        if a:ctx['curpos'] != getcurpos()
+            call lsp#ui#vim#references#highlight(v:true)
+        endif
+        return
+    endif
+
+    " Store references
+    let w:lsp_reference_positions = l:position_list
+    let w:lsp_reference_matches = []
+
+    " Apply highlights to the buffer
+    if g:lsp_highlight_references_enabled
+        for l:position in l:position_list
+            let l:match = matchaddpos('lspReference', [l:position], -5)
+            call add(w:lsp_reference_matches, l:match)
+        endfor
+    endif
+endfunction
+
+" Highlight references to the symbol under the cursor
+function! lsp#ui#vim#references#highlight(force_refresh) abort
+    " No need to change the highlights if the cursor has not left
+    " the currently highlighted symbol.
+    if !a:force_refresh &&
+    \  exists('w:lsp_reference_positions') &&
+    \  s:in_reference(w:lsp_reference_positions) != -1
+        return
+    endif
+
+    " A request for this symbol has already been sent
+    if has_key(s:pending, &filetype) && s:pending[&filetype]
+        return
+    endif
+
+    " Check if any server provides document highlight
+    let l:capability = 'lsp#capabilities#has_document_highlight_provider(v:val)'
+    let l:servers = filter(lsp#get_whitelisted_servers(), l:capability)
+
+    if len(l:servers) == 0
+        return
+    endif
+
+    " Send a request
+    let s:pending[&filetype] = v:true
+    let s:last_req_id += 1
+    let l:ctx = {
+        \ 'last_req_id': s:last_req_id,
+        \ 'curpos': getcurpos(),
+        \ 'bufnr': bufnr('%'),
+        \ 'filetype': &filetype,
+        \ }
+    call lsp#send_request(l:servers[0], {
+        \ 'method': 'textDocument/documentHighlight',
+        \ 'params': {
+        \   'textDocument': lsp#get_text_document_identifier(),
+        \   'position': lsp#get_position(),
+        \ },
+        \ 'on_notification': function('s:handle_references', [l:ctx]),
+        \ })
+endfunction
+
+" Remove all reference highlights from the buffer
+function! lsp#ui#vim#references#clean_references() abort
+    let s:pending[&filetype] = v:false
+    if exists('w:lsp_reference_matches')
+        for l:match in w:lsp_reference_matches
+            silent! call matchdelete(l:match)
+        endfor
+        unlet w:lsp_reference_matches
+        unlet w:lsp_reference_positions
+    endif
+endfunction
+
+" Cyclically move between references by `offset` occurrences.
+function! lsp#ui#vim#references#jump(offset) abort
+    if !exists('w:lsp_reference_positions')
+        echohl WarningMsg
+        echom 'References not available'
+        echohl None
+        return
+    endif
+
+    " Get index of reference under cursor
+    let l:index = s:in_reference(w:lsp_reference_positions)
+    if l:index < 0
+        return
+    endif
+
+    let l:n = len(w:lsp_reference_positions)
+    let l:index += a:offset
+
+    " Show a message when reaching TOP/BOTTOM of the file
+    if l:index < 0
+        echohl WarningMsg
+        echom 'search hit TOP, continuing at BOTTOM'
+        echohl None
+    elseif l:index >= len(w:lsp_reference_positions)
+        echohl WarningMsg
+        echom 'search hit BOTTOM, continuing at TOP'
+        echohl None
+    endif
+
+    " Wrap index
+    while l:index < 0 || l:index >= len(w:lsp_reference_positions)
+        let l:index = (l:index % l:n + l:n) % l:n
+    endwhile
+
+    " Jump
+    let l:target = w:lsp_reference_positions[l:index][0:1]
+    silent exec 'normal! ' . l:target[0] . 'G' . l:target[1] . '|'
+endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -5,7 +5,7 @@
 CONTENTS                                                  *vim-lsp-contents*
 
     Introduction                          |vim-lsp-introduction|
-    Install			                        |vim-lsp-install|
+    Install                               |vim-lsp-install|
     Language Servers                      |vim-lsp-language-servers|
       Configure                             |vim-lsp-configure-source|
       Wiki                                  |vim-lsp-configure-wiki|

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -4,46 +4,49 @@
 ================================================================================
 CONTENTS                                                  *vim-lsp-contents*
 
-    Introduction		|vim-lsp-introduction|
-    Install			|vim-lsp-install|
-    Language Servers		|vim-lsp-language-servers|
-      Configure                   |vim-lsp-configure-source|
-      Wiki                        |vim-lsp-configure-wiki|
-    Options			|vim-lsp-options|
-      g:lsp_diagnostics_enabled   |g:lsp_diagnostics_enabled|
-      g:lsp_auto_enable           |g:lsp_auto_enable|
-      g:lsp_preview_keep_focus    |g:lsp_preview_keep_focus|
-      g:lsp_insert_text_enabled   |g:lsp_insert_text_enabled|
-      g:lsp_text_edit_enabled     |g:lsp_text_edit_enabled|
-      g:lsp_signs_enabled         |g:lsp_signs_enabled|
-      g:lsp_use_event_queue       |g:lsp_use_event_queue|
-    Functions			|vim-lsp-functions|
-      enable                      |vim-lsp-enable|
-      disable                     |vim-lsp-disable|
-      register_server             |vim-lsp-register_server|
-      stop_server                 |vim-lsp-stop_server|
-    Commands			|vim-lsp-commands|
-      LspCodeAction               |LspCodeAction|
-      LspDocumentDiagnostics      |LspDocumentDiagnostics|
-      LspDeclaration              |LspDeclaration|
-      LspDefinition               |LspDefinition|
-      LspDocumentFormat           |LspDocumentFormat|
-      LspDocumentFormatSync       |LspDocumentFormatSync|
-      LspDocumentRangeFormat      |LspDocumentRangeFormat|
-      LspDocumentSymbol           |LspDocumentSymbol|
-      LspHover                    |LspHover|
-      LspNextError                |LspNextError|
-      LspPreviousError            |LspPreviousError|
-      LspImplementation           |LspImplementation|
-      LspReferences               |LspReferences|
-      LspRename                   |LspRename|
-      LspTypeDefinition           |LspTypeDefinition|
-      LspWorkspaceSymbol          |LspWorkspaceSymbol|
-    Mappings			|vim-lsp-mappings|
-    Autocomplete		|vim-lsp-autocomplete|
-      omnifunc                    |vim-lsp-omnifunc|
-      asyncomplete.vim            |vim-lsp-asyncomplete|
-    License			|vim-lsp-license|
+    Introduction                          |vim-lsp-introduction|
+    Install			                        |vim-lsp-install|
+    Language Servers                      |vim-lsp-language-servers|
+      Configure                             |vim-lsp-configure-source|
+      Wiki                                  |vim-lsp-configure-wiki|
+    Options                               |vim-lsp-options|
+      g:lsp_diagnostics_enabled             |g:lsp_diagnostics_enabled|
+      g:lsp_auto_enable                     |g:lsp_auto_enable|
+      g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
+      g:lsp_insert_text_enabled             |g:lsp_insert_text_enabled|
+      g:lsp_text_edit_enabled               |g:lsp_text_edit_enabled|
+      g:lsp_signs_enabled                   |g:lsp_signs_enabled|
+      g:lsp_use_event_queue                 |g:lsp_use_event_queue|
+      g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
+    Functions                             |vim-lsp-functions|
+      enable                                |vim-lsp-enable|
+      disable                               |vim-lsp-disable|
+      register_server                       |vim-lsp-register_server|
+      stop_server                           |vim-lsp-stop_server|
+    Commands                              |vim-lsp-commands|
+      LspCodeAction                         |LspCodeAction|
+      LspDocumentDiagnostics                |LspDocumentDiagnostics|
+      LspDeclaration                        |LspDeclaration|
+      LspDefinition                         |LspDefinition|
+      LspDocumentFormat                     |LspDocumentFormat|
+      LspDocumentFormatSync                 |LspDocumentFormatSync|
+      LspDocumentRangeFormat                |LspDocumentRangeFormat|
+      LspDocumentSymbol                     |LspDocumentSymbol|
+      LspHover                              |LspHover|
+      LspNextError                          |LspNextError|
+      LspNextReference                      |LspNextReference|
+      LspPreviousError                      |LspPreviousError|
+      LspPreviousReference                  |LspPreviousReference|
+      LspImplementation                     |LspImplementation|
+      LspReferences                         |LspReferences|
+      LspRename                             |LspRename|
+      LspTypeDefinition                     |LspTypeDefinition|
+      LspWorkspaceSymbol                    |LspWorkspaceSymbol|
+    Mappings                              |vim-lsp-mappings|
+    Autocomplete                          |vim-lsp-autocomplete|
+      omnifunc                              |vim-lsp-omnifunc|
+      asyncomplete.vim                      |vim-lsp-asyncomplete|
+    License                               |vim-lsp-license|
 
 
 ================================================================================
@@ -197,6 +200,26 @@ g:lsp_use_event_queue                               *g:lsp_use_event_queue*
     Example:
 	let g:lsp_use_event_queue = 1
 	let g:lsp_use_event_queue = 0
+
+g:lsp_highlight_references_enabled         *g:lsp_highlight_references_enabled*
+    Type: |Number|
+    Default: `1`
+
+    Enable highlighting of the references to the symbol under the cursor.
+
+    Example:
+>
+    let g:lsp_highlight_references_enabled = 1
+    let g:lsp_highlight_references_enabled = 0
+<
+
+    To change the style of the highlighting, you can set or link the `lspReference`
+    highlight group.
+
+    Example:
+>
+    highlight lspReference ctermfg=red guifg=red ctermbg=green guibg=green
+<
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*
@@ -427,9 +450,17 @@ LspNextError						     *LspNextError*
 
 Jump to Next err diagnostics
 
+LspNextReference                                          *LspNextReference*
+
+Jump to the next reference of the symbol under cursor.
+
 LspPreviousError					 *LspPreviousError*
 
 Jump to Previous err diagnostics
+
+LspPreviousReference                                  *LspPreviousReference*
+
+Jump to the previous reference of the symbol under cursor.
 
 LspImplementation                                        *LspImplementation*
 
@@ -471,7 +502,9 @@ Available plug mappings are following:
   (lsp-document-diagnostics)
   (lsp-hover)
   (lsp-next-error)
+  (lsp-next-reference)
   (lsp-previous-error)
+  (lsp-previous-reference)
   (lsp-references)
   (lsp-rename)
   (lsp-workspace-symbol)

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -23,6 +23,7 @@ let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
+let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable
@@ -50,6 +51,8 @@ command! -range LspDocumentRangeFormatSync call lsp#ui#vim#document_range_format
 command! LspImplementation call lsp#ui#vim#implementation()
 command! LspTypeDefinition call lsp#ui#vim#type_definition()
 command! -nargs=0 LspStatus echo lsp#get_server_status()
+command! LspNextReference call lsp#ui#vim#references#jump(+1)
+command! LspPreviousReference call lsp#ui#vim#references#jump(-1)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
 nnoremap <plug>(lsp-declaration) :<c-u>call lsp#ui#vim#declaration()<cr>
@@ -67,3 +70,5 @@ nnoremap <plug>(lsp-document-format) :<c-u>call lsp#ui#vim#document_format()<cr>
 vnoremap <plug>(lsp-document-format) :call lsp#ui#vim#document_range_format()<cr>
 nnoremap <plug>(lsp-implementation) :<c-u>call lsp#ui#vim#implementation()<cr>
 nnoremap <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
+nnoremap <plug>(lsp-next-reference) :<c-u>call lsp#ui#vim#references#jump(+1)<cr>
+nnoremap <plug>(lsp-previous-reference) :<c-u>call lsp#ui#vim#references#jump(-1)<cr>


### PR DESCRIPTION
Use the `textDocument/documentHighlight` method to retrieve references
to the symbol under the cursor, and highlight them with `matchaddpos()`.
Add the commands `LscPreviusReference` and `LscNextReference` to
navigate between references within the buffer.

Adaption from the implementation of "Highlight references" in vim-lsc:
https://github.com/natebosch/vim-lsc/blob/5b587b0c/autoload/lsc/cursor.vim

![out](https://user-images.githubusercontent.com/8300317/56097547-0deb4900-5ef6-11e9-8b13-515a6ae50107.gif)