### PR TITLE
Fix newline in completion popup.

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -223,7 +223,7 @@ function! lsp#omni#get_vim_completion_item(item, ...) abort
     endif
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])
-        let l:completion['menu'] = a:item['detail']
+        let l:completion['menu'] = substitute(a:item['detail'], '[ \t\n\r]\+', ' ', 'g')
     endif
 
     if has_key(a:item, 'documentation')

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -93,5 +93,28 @@ Describe lsp#omni
 
             Assert Equals(got, want)
         End
+
+        It should return item with newlines in 'menu' replaced
+            let item = {
+            \ 'label': 'my-label',
+            \ 'documentation': 'my documentation.',
+            \ 'detail': "my-detail\nmore-detail",
+            \ 'kind': '3'
+            \}
+
+            let want = {
+            \ 'word': 'my-label',
+            \ 'abbr': 'my-label',
+            \ 'info': 'my documentation.',
+            \ 'icase': 1,
+            \ 'dup': 1,
+            \ 'empty': 1,
+            \ 'kind': 'function',
+            \ 'menu': 'my-detail more-detail'
+            \}
+            let got = lsp#omni#get_vim_completion_item(item)
+
+            Assert Equals(got, want)
+        End
     End
 End


### PR DESCRIPTION
Server may return newlines in `detail` property of a completion item. In completion popup they are displayed as `<00>`. This PR replaces them with spaces.