### PR TITLE
Expose diagnostics count for current buffer.

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -781,3 +781,8 @@ endfunction
 function! lsp#get_buffer_diagnostics_counts() abort
     return lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts()
 endfunction
+
+" Return first error line or v:null if there are no errors
+function! lsp#get_buffer_first_error_line() abort
+    return lsp#ui#vim#diagnostics#get_buffer_first_error_line()
+endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -775,3 +775,9 @@ function! s:send_didchange_queue(...) abort
     endfor
     let s:didchange_queue = []
 endfunction
+
+" Return dict with diagnostic counts for current buffer
+" { 'error': 1, 'warning': 0, 'information': 0, 'hint': 0 }
+function! lsp#get_buffer_diagnostics_counts() abort
+    return lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts()
+endfunction

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -184,7 +184,7 @@ function! s:get_diagnostics(uri) abort
             endif
         endif
     endif
-    return [0, []]
+    return [0, {}]
 endfunction
 
 " Get diagnostics for the current buffer URI from all servers
@@ -217,5 +217,30 @@ function! s:compare_diagnostics(d1, d2) abort
     else
         return l:line1 > l:line2 ? 1 : -1
     endif
+endfunction
+
+let s:diagnostic_kinds = {
+    \ 1: 'error',
+    \ 2: 'warning',
+    \ 3: 'information',
+    \ 4: 'hint',
+    \ }
+
+function! lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts() abort
+    let l:counts = {
+        \ 'error': 0,
+        \ 'warning': 0,
+        \ 'information': 0,
+        \ 'hint': 0,
+        \ }
+    let l:uri = lsp#utils#get_buffer_uri()
+    let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
+    for [l:server_name, l:data] in items(l:diagnostics)
+        for l:diag in l:data['response']['params']['diagnostics']
+            let l:key = get(s:diagnostic_kinds, l:diag['severity'], 'error')
+            let l:counts[l:key] += 1
+        endfor
+    endfor
+    return l:counts
 endfunction
 " vim sw=4 ts=4 et

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -243,4 +243,18 @@ function! lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts() abort
     endfor
     return l:counts
 endfunction
+
+function! lsp#ui#vim#diagnostics#get_buffer_first_error_line() abort
+    let l:uri = lsp#utils#get_buffer_uri()
+    let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
+    let l:first_error_line = v:null
+    for [l:server_name, l:data] in items(l:diagnostics)
+        for l:diag in l:data['response']['params']['diagnostics']
+            if l:diag['severity'] ==# 1 && (l:first_error_line ==# v:null || l:first_error_line ># l:diag['range']['start']['line'])
+                let l:first_error_line = l:diag['range']['start']['line']
+            endif
+        endfor
+    endfor
+    return l:first_error_line ==# v:null ? v:null : l:first_error_line + 1
+endfunction
 " vim sw=4 ts=4 et

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -26,6 +26,8 @@ CONTENTS                                                  *vim-lsp-contents*
       stop_server                           |vim-lsp-stop_server|
       utils#find_nearest_parent_file_directory
                               |vim-lsp-utils-find_nearest_parent_file_directory|
+      vim-lsp-get_buffer_diagnostics_counts |vim-lsp-get_buffer_diagnostics_counts|
+      vim-lsp-get_buffer_first_error_line   |vim-lsp-get_buffer_first_error_line|
     Commands                              |vim-lsp-commands|
       LspCodeAction                         |LspCodeAction|
       LspDocumentDiagnostics                |LspDocumentDiagnostics|
@@ -445,6 +447,12 @@ Get dict with diagnostic counts for current buffer. Useful e.g. for display
 in status line.
 
     Returns dictionary with keys "error", "warning", "information", "hint".
+
+lsp#get_buffer_first_error_line        *vim-lsp-get_buffer_first_error_line*
+
+Get line number of first error in current buffer.
+
+    Returns |Number| or |v:null| if there are no errors.
 
 ===============================================================================
 Commands	                                          *vim-lsp-commands*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -439,6 +439,13 @@ This method is mainly used to generate 'root_uri' when registering server.
 	* If there is not directory with the specific files or diretories
 	  found, the method will return an empty string.
 
+lsp#get_buffer_diagnostics_counts    *vim-lsp-get_buffer_diagnostics_counts*
+
+Get dict with diagnostic counts for current buffer. Useful e.g. for display
+in status line.
+
+    Returns dictionary with keys "error", "warning", "information", "hint".
+
 ===============================================================================
 Commands	                                          *vim-lsp-commands*
 


### PR DESCRIPTION
Adds `lsp#get_buffer_diagnostics_counts()` which returns dict with counts keyed by diagnostic kind.

Closes #346 