### PR TITLE
Check for codeActionKinds in codeActionProvider

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -54,6 +54,14 @@ function! lsp#capabilities#has_implementation_provider(server_name) abort
 endfunction
 
 function! lsp#capabilities#has_code_action_provider(server_name) abort
+    let l:capabilities = lsp#get_server_capabilities(a:server_name)
+    if !empty(l:capabilities) && has_key(l:capabilities, 'codeActionProvider')
+        if type(l:capabilities['codeActionProvider']) == type({})
+            if has_key(l:capabilities['codeActionProvider'], 'codeActionKinds') && type(l:capabilities['codeActionProvider']['codeActionKinds']) == type([])
+                return len(l:capabilities['codeActionProvider']['codeActionKinds']) != 0
+            endif
+        endif
+    endif
     return s:has_bool_provider(a:server_name, 'codeActionProvider')
 endfunction
 


### PR DESCRIPTION
This was tested with ccls, which will return CodeActionOptions instead
of a boolean in codeActionProvider. According to spec this is an invalid
response by ccls, because as a client we didn't signal
codeActionLiteralSupport. But I think it can be safely assumed that the
server provides code actions when he returns a non empty list of
codeActionKinds.