### PR TITLE
Fix for VIM bug - Explicitly specify line numbers

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics/textprop.vim
+++ b/autoload/lsp/ui/vim/diagnostics/textprop.vim
@@ -83,7 +83,7 @@ function! s:clear_all_highlights() abort
                     \ 'type': l:prop_type,
                     \ 'bufnr': l:bufnr,
                     \ 'all': v:true,
-                    \ })
+                    \ }, 1, line('$'))
             endif
         endfor
 
@@ -101,7 +101,7 @@ function! s:clear_highlights(server_name, path) abort
             \ 'type': l:prop_type,
             \ 'bufnr': l:bufnr,
             \ 'all': v:true,
-            \ })
+            \ }, 1, line('$'))
     endfor
 endfunction
 


### PR DESCRIPTION
I've just spent about an hour digging through your code trying to work out why no signs were being added even though document diagnostics are working fine. After some painful debugging, I've established that `remove_prop` is throwing an error indicating that there are not enough arguments being supplied.

Although 'prop_remove' is described as a function with only one argument in the help file, the commit that introduced it made the second argument mandatory (https://github.com/vim/vim/commit/98aefe7c3250bb5d4153b994f878594d1745424e#diff-8b45c2119adf39fb1ea787e5b46cd3e4R779). This was fixed a couple of months ago (https://github.com/vim/vim/commit/0a2f578e22de7e4d82075578afdd5fc2d2dd8134), but since I'm using Macvim which doesn't appear to be a bleeding edge build, this is broken for me.

This PR explicitly supplies the first and last line number of the current file, which provides exactly the same behaviour, but doesn't blow up for users that don't have the above bugfix yet.