### PR TITLE
Fix cursor positioning when jumping to next/prev reference

### DIFF
--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -221,5 +221,5 @@ function! lsp#ui#vim#references#jump(offset) abort
 
     " Jump
     let l:target = w:lsp_reference_positions[l:index][0:1]
-    silent exec 'normal! ' . l:target[0] . 'G' . l:target[1] . '|'
+    silent exec 'normal! ' . l:target[0] . 'G0' . (l:target[1] == 1 ? '' : l:target[1]-1 . 'l')
 endfunction

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -221,5 +221,6 @@ function! lsp#ui#vim#references#jump(offset) abort
 
     " Jump
     let l:target = w:lsp_reference_positions[l:index][0:1]
+    normal! m`
     call cursor(l:target[0], l:target[1])
 endfunction

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -221,5 +221,5 @@ function! lsp#ui#vim#references#jump(offset) abort
 
     " Jump
     let l:target = w:lsp_reference_positions[l:index][0:1]
-    silent exec 'normal! ' . l:target[0] . 'G0' . (l:target[1] == 1 ? '' : l:target[1]-1 . 'l')
+    call cursor(l:target[0], l:target[1])
 endfunction


### PR DESCRIPTION
On tab-indented lines, (or any line where column number and virtual
column number are different) `|` puts the cursor on the nth virtual
column, not the nth character of the line. This caused the
Lsp{Next,Previous}Reference commands to place the cursor on the wrong
column on tab-indented lines.