### PR TITLE
Fix lsp#utils#text_edit#apply_text_edits when end position was newline character.

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -57,7 +57,17 @@ function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
             let l:was_view = winsaveview()
 
             set paste
-            set selection=exclusive
+
+            let l:start_line = l:merged_text_edit['merged']['range']['start']['line']
+            let l:end_line = l:merged_text_edit['merged']['range']['end']['line']
+            let l:end_character = l:merged_text_edit['merged']['range']['end']['character']
+            if l:start_line < l:end_line && l:end_character <= 0
+                " set inclusive if end position was newline character.
+                set selection=inclusive
+            else
+                set selection=exclusive
+            endif
+
             set virtualedit=onemore
 
             silent execute l:cmd

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -93,7 +93,7 @@ Describe lsp#utils#text_edit
             Assert Equals(l:buffer_text, ['foo', 'replacedar', ''])
         End
 
-        It delete range string
+        It replace range string to empty newText
             call s:set_text(['foo', 'bar'])
 
             call lsp#utils#text_edit#apply_text_edits(
@@ -114,6 +114,257 @@ Describe lsp#utils#text_edit
 
             let l:buffer_text = s:get_text()
             Assert Equals(l:buffer_text, ['foo', 'ar', ''])
+        End
+
+        It single line start character is -1
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': -1
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 3
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', '', ''])
+        End
+
+        It single line start character is 0
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 3
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', '', ''])
+        End
+
+        It single line start character is 1
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 3
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', 'b', ''])
+        End
+
+        It single line end character is `len(getline('.')) - 1`
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 2
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', 'r', ''])
+        End
+
+        It single line end character is `len(getline('.'))`
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 3
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', '', ''])
+        End
+
+        It single line end character is `len(getline('.')) + 1`
+            call s:set_text(['foo', 'bar'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 4
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            " if newline character deleting, need end position is next line zero character.
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['foo', '', ''])
+        End
+
+        It replace range string to empty newText, multiline top to top
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['bar', 'baz', ''])
+        End
+
+        It replace range string to empty newText, multiline top to tail
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 2
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['r', 'baz', ''])
+
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 3
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['', 'baz', ''])
+
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 4
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            " if newline character deleting, need end position is next line zero character.
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['', 'baz', ''])
+        End
+
+        It replace range string to empty newText, multiline middle to middle
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 1
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 2
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['fr', 'baz', ''])
         End
 
         It preserves v:completed_item


### PR DESCRIPTION
See: #386. I fixed it.

But there is still one problem the last line cannot delete.
https://github.com/prabirshrestha/vim-lsp/blob/4cdfaa93b558a17990373b5a93cfe9b0ba63e0cc/test/lsp/utils/text_edit.vimspec#L234-L256

Do you have any solution or workaround?