### PR TITLE
Fix text edits not preserving v:completed_item

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -158,12 +158,10 @@ function! s:generate_sub_cmd_insert(text_edit) abort
     let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
 
     if l:start_character >= len(getline(l:start_line))
-        let l:sub_cmd .= 'a'
+        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"
     else
-        let l:sub_cmd .= 'i'
+        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>P"
     endif
-
-    let l:sub_cmd .= printf('%s', l:new_text)
 
     return l:sub_cmd
 endfunction
@@ -183,8 +181,7 @@ function! s:generate_sub_cmd_replace(text_edit) abort
     if len(l:new_text) == 0
         let l:sub_cmd .= 'x'
     else
-        let l:sub_cmd .= 'c'
-        let l:sub_cmd .= printf('%s', l:new_text) " change text
+        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"
     endif
 
     return l:sub_cmd

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -60,7 +60,7 @@ function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
             set selection=exclusive
             set virtualedit=onemore
 
-            execute l:cmd
+            silent execute l:cmd
         finally
             let &paste = l:was_paste
             let &selection = l:was_selection

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -115,6 +115,91 @@ Describe lsp#utils#text_edit
             let l:buffer_text = s:get_text()
             Assert Equals(l:buffer_text, ['foo', 'ar', ''])
         End
+
+        It preserves v:completed_item
+            " Add some text to buffer
+            call s:set_text(['foo', 'bar'])
+
+            " Go to end of file and invoke completion
+            execute "normal Gof\<C-p>\<Esc>"
+
+            " Make sure that v:completed_item is set
+            Assert Equals(v:completed_item["word"], "foo")
+            let l:old_completed_item = v:completed_item
+
+            " Perform some text edits
+
+            " Insert
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       }
+                    \   },
+                    \   'newText': 'baz'
+                    \ }])
+
+            " Insert empty
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            " Replace
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       }
+                    \   },
+                    \   'newText': 'replaced'
+                    \ }])
+
+            " Delete
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 1,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 1,
+                    \           'character': 1
+                    \       }
+                    \   },
+                    \   'newText': ''
+                    \ }])
+
+            " Make sure v:completed_item is not changed
+            Assert Equals(v:completed_item, l:old_completed_item)
+        End
     End
 End
 


### PR DESCRIPTION
As discussed in https://github.com/prabirshrestha/vim-lsp/pull/306#issuecomment-491477815 and https://github.com/prabirshrestha/vim-lsp/pull/306#issuecomment-493664731, `lsp#utils#text_edit#apply_text_edits` does not preserve `v:completed_item`, because it uses `c`, `a` and `i`, and entering insert mode resets `v:completed_item`.

I fixed this by using `p` and `P` instead. I also added a test to make sure this bug remains fixed.

Slight note: the text_edit command is `execute`'d in `apply_text_edits`, however the command is built in a different function. Thus I had to use the variable `l:merged_text_edit` (local to `apply_text_edits`) inside `generate_sub_cmd_...`. I'm not a huge fan of this, so perhaps you have a better suggestion on how to tackle this?

/cc @mikoto2000 