### PR TITLE
Use `g:ignorecase` to indicates whether or not ignorecase to matchs completion word

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -71,7 +71,7 @@ function! lsp#omni#complete(findstart, base) abort
     endif
 endfunction
 
-function! s:prefix_match(word, prefix, ignorecase)
+function! s:prefix_match(word, prefix, ignorecase) abort
     if a:ignorecase
         let l:word = tolower(a:word)
         let l:prefix = tolower(a:prefix)

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -63,16 +63,15 @@ function! lsp#omni#complete(findstart, base) abort
             while s:completion['status'] is# s:completion_status_pending && !complete_check()
                 sleep 10m
             endwhile
-            let ignorecase = g:lsp_omni_completion_ignorecase || &g:ignorecase
-            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> s:prefix_match(match['word'], a:base, ignorecase)})
+            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> s:prefix_match(match['word'], a:base)})
             let s:completion['status'] = ''
             return s:completion['matches']
         endif
     endif
 endfunction
 
-function! s:prefix_match(word, prefix, ignorecase) abort
-    if a:ignorecase
+function! s:prefix_match(word, prefix) abort
+    if &g:ignorecase
         let l:word = tolower(a:word)
         let l:prefix = tolower(a:prefix)
     else

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -63,22 +63,26 @@ function! lsp#omni#complete(findstart, base) abort
             while s:completion['status'] is# s:completion_status_pending && !complete_check()
                 sleep 10m
             endwhile
-            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> s:prefix_match(match['word'], a:base)})
+            let Is_prefix_match = s:create_prefix_matcher(a:base)
+            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> Is_prefix_match(match['word'])})
             let s:completion['status'] = ''
             return s:completion['matches']
         endif
     endif
 endfunction
 
-function! s:prefix_match(word, prefix) abort
+function! s:normalize_word(word) abort
     if &g:ignorecase
-        let l:word = tolower(a:word)
-        let l:prefix = tolower(a:prefix)
+        return tolower(a:word)
     else
-        let l:word = a:word
-        let l:prefix = a:prefix
+        return a:word
     endif
-    return stridx(l:word, l:prefix) == 0
+endfunction
+
+function! s:create_prefix_matcher(prefix) abort
+    let l:prefix = s:normalize_word(a:prefix)
+
+    return { word -> stridx(s:normalize_word(word), l:prefix) == 0 }
 endfunction
 
 function! s:handle_omnicompletion(server_name, complete_counter, data) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -63,12 +63,23 @@ function! lsp#omni#complete(findstart, base) abort
             while s:completion['status'] is# s:completion_status_pending && !complete_check()
                 sleep 10m
             endwhile
-            let l:base = tolower(a:base)
-            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> stridx(tolower(match['word']), l:base) == 0})
+            let ignorecase = g:lsp_omni_completion_ignorecase || &g:ignorecase
+            let s:completion['matches'] = filter(s:completion['matches'], {_, match -> s:prefix_match(match['word'], a:base, ignorecase)})
             let s:completion['status'] = ''
             return s:completion['matches']
         endif
     endif
+endfunction
+
+function! s:prefix_match(word, prefix, ignorecase)
+    if a:ignorecase
+        let l:word = tolower(a:word)
+        let l:prefix = tolower(a:prefix)
+    else
+        let l:word = a:word
+        let l:prefix = a:prefix
+    endif
+    return stridx(l:word, l:prefix) == 0
 endfunction
 
 function! s:handle_omnicompletion(server_name, complete_counter, data) abort

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -25,7 +25,6 @@ let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('p
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
-let g:lsp_omni_completion_ignorecase = get(g:, 'lsp_omni_completion_ignorecase', 0)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -25,6 +25,7 @@ let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('p
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
+let g:lsp_omni_completion_ignorecase = get(g:, 'lsp_omni_completion_ignorecase', 0)
 
 if g:lsp_auto_enable
     augroup lsp_auto_enable


### PR DESCRIPTION
In most cases, ignorecase is not necessary, so we may add an option to control whether to turn it on.

Note: only support `g:lsp_async_completion = 0` mode.