### PR TITLE
preview information shown in hover at the cursor

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -26,6 +26,8 @@ augroup _lsp_silent_
     autocmd User lsp_server_init silent
     autocmd User lsp_server_exit silent
     autocmd User lsp_complete_done silent
+    autocmd User lsp_float_opened silent
+    autocmd User lsp_float_closed silent
 augroup END
 
 function! lsp#log_verbose(...) abort

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -1,10 +1,83 @@
+let s:supports_floating = exists('*nvim_open_win')
+let s:win = v:false
+
+function! lsp#ui#vim#output#closepreview() abort
+  if win_getid() == s:win
+    " Don't close if window got focus
+    return
+  endif
+  pclose
+  let s:win = v:false
+  autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
+endfunction
+
+function! s:get_float_positioning(height, width)
+    let l:height = a:height
+    let l:width = a:width
+    " For a start show it below/above the cursor
+    " TODO: add option to configure it 'docked' at the bottom/top/right
+    let l:y = winline()
+    if l:y + l:height >= &lines
+      " Float does not fit
+      if l:y - 2 > l:height
+        " Fits above
+        let l:y = winline() - l:height
+      elseif l:y - 2 > &lines - l:y
+        " Take space above cursor
+        let l:y = 1
+        let l:height = winline()-2
+      else
+        " Take space below cursor
+        let l:height = &lines -l:y
+      endif
+    endif
+    let l:col = col(".")
+    " Positioning is not window but screen relative
+    let l:opts = {
+          \ 'relative': 'win',
+          \ 'row': l:y,
+          \ 'col': l:col,
+          \ 'width': l:width,
+          \ 'height': l:height,
+          \ }
+    return l:opts
+endfunction
+
+function! lsp#ui#vim#output#floatingpreview(data) abort
+    let l:buf = nvim_create_buf(v:false, v:true)
+    call setbufvar(l:buf, '&signcolumn', 'no')
+
+    " Try to get as much pace right-bolow the cursor, but at least 10x10
+    let l:width = max([float2nr(&columns - col(".") - 10), 10])
+    let l:height = max([&lines - winline() + 1, 10])
+
+    let l:opts = s:get_float_positioning(l:height, l:width)
+
+    let s:win = nvim_open_win(buf, v:true, l:opts)
+    call nvim_win_set_option(s:win, 'winhl', "Normal:Pmenu,NormalNC:Pmenu")
+    call nvim_win_set_option(s:win, 'foldenable', v:false)
+    call nvim_win_set_option(s:win, 'wrap', v:true)
+    call nvim_win_set_option(s:win, 'statusline', '')
+    call nvim_win_set_option(s:win, 'number', v:false)
+    call nvim_win_set_option(s:win, 'relativenumber', v:false)
+    call nvim_win_set_option(s:win, 'cursorline', v:false)
+    " Enable closing the preview with esc, but map only in the scratch buffer
+    nmap <buffer><silent> <esc> :pclose<cr>
+    return s:win
+endfunction
+
 function! lsp#ui#vim#output#preview(data) abort
     " Close any previously opened preview window
     pclose
 
     let l:current_window_id = win_getid()
 
-    execute &previewheight.'new'
+    if s:supports_floating && g:lsp_preview_float
+      call lsp#ui#vim#output#floatingpreview(a:data)
+    else
+      execute &previewheight.'new'
+    endif
+    let s:win = win_getid()
 
     let l:ft = s:append(a:data)
     " Delete first empty line
@@ -13,6 +86,9 @@ function! lsp#ui#vim#output#preview(data) abort
     setlocal readonly nomodifiable
 
     let &l:filetype = l:ft . '.lsp-hover'
+    " Get size information while still having the buffer active
+    let l:bufferlines = line("$")
+    let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
 
     if g:lsp_preview_keep_focus
       " restore focus to the previous window
@@ -21,6 +97,17 @@ function! lsp#ui#vim#output#preview(data) abort
 
     echo ''
 
+    if s:supports_floating && s:win && g:lsp_preview_float
+      let l:win_config = {}
+      let l:height = min([winheight(s:win), l:bufferlines])
+      let l:width = min([winwidth(s:win), l:maxwidth])
+      let l:win_config = s:get_float_positioning(l:height, l:width)
+      call nvim_win_set_config(s:win, l:win_config )
+      augroup lsp_float_preview_close
+        autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
+        autocmd CursorMoved,CursorMovedI,VimResized * call lsp#ui#vim#output#closepreview()
+      augroup END
+    endif
     return ''
 endfunction
 

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -40,7 +40,7 @@ function! s:get_float_positioning(height, width) abort
       " Float does not fit
       if l:y - 2 > l:height
         " Fits above
-        let l:y = winline() - l:height
+        let l:y = winline() - l:height -1
       elseif l:y - 2 > winheight(0) - l:y
         " Take space above cursor
         let l:y = 1

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -11,7 +11,7 @@ function! lsp#ui#vim#output#closepreview() abort
   autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
 endfunction
 
-function! s:get_float_positioning(height, width)
+function! s:get_float_positioning(height, width) abort
     let l:height = a:height
     let l:width = a:width
     " For a start show it below/above the cursor
@@ -31,7 +31,7 @@ function! s:get_float_positioning(height, width)
         let l:height = &lines -l:y
       endif
     endif
-    let l:col = col(".")
+    let l:col = col('.')
     " Positioning is not window but screen relative
     let l:opts = {
           \ 'relative': 'win',
@@ -48,13 +48,13 @@ function! lsp#ui#vim#output#floatingpreview(data) abort
     call setbufvar(l:buf, '&signcolumn', 'no')
 
     " Try to get as much pace right-bolow the cursor, but at least 10x10
-    let l:width = max([float2nr(&columns - col(".") - 10), 10])
+    let l:width = max([float2nr(&columns - col('.') - 10), 10])
     let l:height = max([&lines - winline() + 1, 10])
 
     let l:opts = s:get_float_positioning(l:height, l:width)
 
     let s:win = nvim_open_win(buf, v:true, l:opts)
-    call nvim_win_set_option(s:win, 'winhl', "Normal:Pmenu,NormalNC:Pmenu")
+    call nvim_win_set_option(s:win, 'winhl', 'Normal:Pmenu,NormalNC:Pmenu')
     call nvim_win_set_option(s:win, 'foldenable', v:false)
     call nvim_win_set_option(s:win, 'wrap', v:true)
     call nvim_win_set_option(s:win, 'statusline', '')
@@ -87,7 +87,7 @@ function! lsp#ui#vim#output#preview(data) abort
 
     let &l:filetype = l:ft . '.lsp-hover'
     " Get size information while still having the buffer active
-    let l:bufferlines = line("$")
+    let l:bufferlines = line('$')
     let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
 
     if g:lsp_preview_keep_focus

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -10,12 +10,13 @@ function! lsp#ui#vim#output#closepreview() abort
   "closing floats in vim8.1 must use popup_close() (nvim could use nvim_win_close but pclose
   "works)
   if s:supports_floating && s:winid && g:lsp_preview_float && !has('nvim')
-    " TODO: 
     call popup_close(s:winid)
   else
     pclose 
   endif
   let s:winid = v:false
+  augroup lsp_float_preview_close
+  augroup end
   autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
   doautocmd User lsp_float_closed
 endfunction
@@ -122,7 +123,17 @@ function! s:setcontent(lines, ft) abort
   if s:supports_floating && g:lsp_preview_float && !has('nvim')
     " vim popup
     call setbufline(winbufnr(s:winid), 1, a:lines)
+    let l:lightline_toggle = v:false
+    if exists('#lightline') && !has("nvim")
+      " Lightline does not work in popups but does not recognize it yet.
+      " It is ugly to have an check for an other plugin here, better fix lightline...
+      let l:lightline_toggle = v:true
+      call lightline#disable()
+    endif
     call win_execute(s:winid, 'setlocal filetype=' . a:ft . '.lsp-hover')
+    if l:lightline_toggle
+      call lightline#enable()
+    endif
   else
     " nvim floating
     call setline(1, a:lines)

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -11,15 +11,15 @@ function! lsp#ui#vim#output#closepreview() abort
   autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
 endfunction
 
-function! s:bufwidth()
+function! s:bufwidth() abort
   let width = winwidth(0)
   let numberwidth = max([&numberwidth, strlen(line('$'))+1])
   let numwidth = (&number || &relativenumber)? numberwidth : 0
   let foldwidth = &foldcolumn
 
-  if &signcolumn == 'yes'
+  if &signcolumn ==? 'yes'
     let signwidth = 2
-  elseif &signcolumn == 'auto'
+  elseif &signcolumn ==? 'auto'
     let signs = execute(printf('sign place buffer=%d', bufnr('')))
     let signs = split(signs, "\n")
     let signwidth = len(signs)>2? 2: 0
@@ -63,7 +63,7 @@ function! s:get_float_positioning(height, width) abort
 endfunction
 
 function! lsp#ui#vim#output#floatingpreview(data) abort
-  if has("nvim")
+  if has('nvim')
     let l:buf = nvim_create_buf(v:false, v:true)
     call setbufvar(l:buf, '&signcolumn', 'no')
 
@@ -93,9 +93,8 @@ function! lsp#ui#vim#output#floatingpreview(data) abort
 endfunction
 
 function! s:setcontent(lines, ft) abort
-  if s:supports_floating && g:lsp_preview_float && !has("nvim")
+  if s:supports_floating && g:lsp_preview_float && !has('nvim')
     " vim popup
-    echom "Vimp Popup SetContent"
     call setbufline(winbufnr(s:win), 1, a:lines)
     call win_execute(s:win, 'setlocal filetype=' . a:ft . '.lsp-hover')
   else
@@ -107,7 +106,7 @@ function! s:setcontent(lines, ft) abort
 endfunction
 
 function! s:adjust_float_placement(bufferlines, maxwidth) abort
-    if has("nvim")
+    if has('nvim')
       let l:win_config = {}
       let l:height = min([winheight(s:win), a:bufferlines])
       let l:width = min([winwidth(s:win), a:maxwidth])
@@ -151,7 +150,7 @@ function! lsp#ui#vim#output#preview(data) abort
 
     echo ''
 
-    if s:supports_floating && s:win && g:lsp_preview_float && has("nvim")
+    if s:supports_floating && s:win && g:lsp_preview_float && has('nvim')
       call s:adjust_float_placement(l:bufferlines, l:maxwidth)
       call s:add_float_closing_hooks()
     endif

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -13,6 +13,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_diagnostics_enabled             |g:lsp_diagnostics_enabled|
       g:lsp_auto_enable                     |g:lsp_auto_enable|
       g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
+      g:lsp_preview_float		    |g:lsp_preview_float|
       g:lsp_insert_text_enabled             |g:lsp_insert_text_enabled|
       g:lsp_text_edit_enabled               |g:lsp_text_edit_enabled|
       g:lsp_diagnostics_echo_cursor         |g:lsp_diagnostics_echo_cursor|
@@ -153,6 +154,23 @@ g:lsp_preview_keep_focus                         *g:lsp_preview_keep_focus*
 	let g:lsp_preview_keep_focus = 0
 
     * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
+
+g:lsp_preview_float                         *g:lsp_preview_float*
+    Type: |Number|
+    Default: `1`
+
+    If set and nvim_win_open() is available, hover information are shown in a
+    floating window as |preview-window| at the cursor position.
+    The |preview-window| is closed automatically on cursor moves, unless it is
+    focused. While focused it may be closed with <esc>.
+    This feature requires neovim 0.4.0 (current master).
+
+    Example:
+	" Opens preview windows as floating
+	let g:lsp_preview_float = 1
+
+	" Opens preview windows as normal windows
+	let g:lsp_preview_float = 0
 
 g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
     Type: |Number|
@@ -566,6 +584,9 @@ Gets the hover information and displays it in the |preview-window|.
  * |preview-window| can be closed using the default vim mapping - `<c-w><c-z>`.
  * To control the default focus of |preview-window| for |LspHover|
    configure |g:lsp_preview_keep_focus|.
+ * If using neovim with nvim_win_open() available, |g:lsp_preview_float| can be
+   set to enable a floating preview at the cursor which is closed automatically
+   on cursormove if not focused and can be closed with <esc> if focused.
 
 
 LspNextError						     *LspNextError*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -14,6 +14,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_auto_enable                     |g:lsp_auto_enable|
       g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
       g:lsp_preview_float		    |g:lsp_preview_float|
+      g:lsp_preview_autoclose		    |g:lsp_preview_autoclose|
       g:lsp_insert_text_enabled             |g:lsp_insert_text_enabled|
       g:lsp_text_edit_enabled               |g:lsp_text_edit_enabled|
       g:lsp_diagnostics_echo_cursor         |g:lsp_diagnostics_echo_cursor|
@@ -54,6 +55,9 @@ CONTENTS                                                  *vim-lsp-contents*
     Autocommands                          |vim-lsp-autocommands|
       lsp_complete_done                     |lsp_complete_done|
     Mappings                              |vim-lsp-mappings|
+       <plug>(lsp-preview-close)            |<plug>(lsp-preview-close)|
+       <plug>(lsp-preview-focus)            |<plug>(lsp-preview-focus)|
+
     Autocomplete                          |vim-lsp-autocomplete|
       omnifunc                              |vim-lsp-omnifunc|
       asyncomplete.vim                      |vim-lsp-asyncomplete|
@@ -171,6 +175,23 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 
 	" Opens preview windows as normal windows
 	let g:lsp_preview_float = 0
+
+g:lsp_preview_autoclose                         *g:lsp_preview_autoclose*
+    Type: |Number|
+    Default: `1`
+
+    Indicates if an opened floating preview shall be automatically closed upon
+    movement of the cursor. If set to 1, the window will close automatically if
+    the cursor is moved and the preview is not focused. If set to 0, it will
+    remain open until explicitly closed (e.g. with <plug>(lsp-preview-close),
+    or <ESC> when focused).
+
+    Example:
+	" Preview closes on cursor move
+	let g:lsp_preview_autoclose = 1
+
+	" Preview remains open and waits for an explicit call
+	let g:lsp_preview_autoclose = 0
 
 g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
     Type: |Number|
@@ -661,6 +682,8 @@ Available plug mappings are following:
   (lsp-hover)
   (lsp-next-error)
   (lsp-next-reference)
+  (lsp-preview-close)
+  (lsp-preview-focus)
   (lsp-previous-error)
   (lsp-previous-reference)
   (lsp-references)
@@ -674,6 +697,16 @@ Available plug mappings are following:
 
 See also |vim-lsp-commands|
 
+<plug>(lsp-preview-close)	         	     *<plug>(lsp-preview-close)*
+
+Closes an opened preview window
+
+<plug>(lsp-preview-focus)	         	     *<plug>(lsp-preview-focus)*
+
+Transfers focus to an opened preview window or back to the previous window if
+focus is already on the preview window.
+
+  
 ===============================================================================
 Autocomplete                                          *vim-lsp-autocomplete*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -15,6 +15,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
       g:lsp_preview_float		    |g:lsp_preview_float|
       g:lsp_preview_autoclose		    |g:lsp_preview_autoclose|
+      g:lsp_preview_doubletap		    |g:lsp_preview_doubletap|
       g:lsp_insert_text_enabled             |g:lsp_insert_text_enabled|
       g:lsp_text_edit_enabled               |g:lsp_text_edit_enabled|
       g:lsp_diagnostics_echo_cursor         |g:lsp_diagnostics_echo_cursor|
@@ -202,6 +203,24 @@ g:lsp_preview_autoclose                         *g:lsp_preview_autoclose*
 
 	" Preview remains open and waits for an explicit call
 	let g:lsp_preview_autoclose = 0
+
+g:lsp_preview_doubletap                         *g:lsp_preview_doubletap*
+    Type: |List|
+    Default: `[function('lsp#ui#vim#output#focuspreview')]`
+
+    When preview is called twice with the same data while the preview is still
+    open, the function in `lsp_preview_doubletap` is called instead. To disable
+    this and just "refresh" the preview, set to ´0´.
+
+    Example:
+	" Focus preview on repeated preview (does not work for vim8.1 popups)
+	let g:lsp_preview_doubletap = [function('lsp#ui#vim#output#focuspreview')]
+
+	" Closes the preview window on the second call to preview
+	let g:lsp_preview_doubletap = [function('lsp#ui#vim#output#closepreview')]
+
+	" Disables double tap feature; refreshes the preview on consecutive taps
+	let g:lsp_preview_doubletap = 0
 
 g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
     Type: |Number|

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -163,11 +163,16 @@ g:lsp_preview_float                         *g:lsp_preview_float*
     Type: |Number|
     Default: `1`
 
-    If set and nvim_win_open() is available, hover information are shown in a
-    floating window as |preview-window| at the cursor position.
+    If set and nvim_win_open() or popup_create is available, hover information
+    are shown in a floating window as |preview-window| at the cursor position.
     The |preview-window| is closed automatically on cursor moves, unless it is
     focused. While focused it may be closed with <esc>.
-    This feature requires neovim 0.4.0 (current master).
+    After opening an autocmd User event lsp_float_opened is issued, as well as
+    and lsp_float_closed upon closing. This can be used to alter the preview
+    window (using lsp#ui#vim#output#getpreviewwinid() to get the window id), or
+    setup custom bindings while a preview is open.
+    This feature requires neovim 0.4.0 (current master) or
+    Vim8.1 with has('patch-8.1.1517').
 
     Example:
 	" Opens preview windows as floating
@@ -175,6 +180,11 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 
 	" Opens preview windows as normal windows
 	let g:lsp_preview_float = 0
+
+	" Close preview window with <esc>
+	autocmd User lsp_float_opened nmap <buffer> <silent> <esc>
+		      \ <Plug>(lsp-preview-close)
+	autocmd User lsp_float_closed nunmap <buffer> <esc>
 
 g:lsp_preview_autoclose                         *g:lsp_preview_autoclose*
     Type: |Number|

--- a/ftplugin/lsp-hover.vim
+++ b/ftplugin/lsp-hover.vim
@@ -1,6 +1,11 @@
 " No usual did_ftplugin header here as we NEED to run this always
 
-setlocal previewwindow buftype=nofile bufhidden=wipe noswapfile nobuflisted
+if has('patch-8.1.1517') && g:lsp_preview_float && !has('nvim')
+  " Can not set buftype or popup_close will fail with 'not a popup window'
+  setlocal previewwindow bufhidden=wipe noswapfile nobuflisted
+else
+  setlocal previewwindow buftype=nofile bufhidden=wipe noswapfile nobuflisted
+endif
 setlocal nocursorline nofoldenable
 
 if has('syntax')

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -25,6 +25,7 @@ let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('p
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
+let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -26,6 +26,7 @@ let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))
 let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
 let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
+let g:lsp_preview_autoclose = get(g:, 'lsp_preview_autoclose', 1)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
@@ -65,6 +66,8 @@ nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition()<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
 nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#ui#vim#diagnostics#document_diagnostics()<cr>
 nnoremap <plug>(lsp-hover) :<c-u>call lsp#ui#vim#hover#get_hover_under_cursor()<cr>
+nnoremap <plug>(lsp-preview-close) :<c-u>call lsp#ui#vim#output#closepreview()<cr>
+nnoremap <plug>(lsp-preview-focus) :<c-u>call lsp#ui#vim#output#focuspreview()<cr>
 nnoremap <plug>(lsp-next-error) :<c-u>call lsp#ui#vim#diagnostics#next_error()<cr>
 nnoremap <plug>(lsp-previous-error) :<c-u>call lsp#ui#vim#diagnostics#previous_error()<cr>
 nnoremap <plug>(lsp-references) :<c-u>call lsp#ui#vim#references()<cr>

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -27,6 +27,7 @@ let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.14
 let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabled', 1)
 let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
 let g:lsp_preview_autoclose = get(g:, 'lsp_preview_autoclose', 1)
+let g:lsp_preview_doubletap = get(g:, 'lsp_preview_doubletap', [function('lsp#ui#vim#output#focuspreview')])
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])


### PR DESCRIPTION
Uses floating window support of nvim 0.4.0 to show hover information in an unobtrusive way.

Implemented it and then found #347 . While it is good work I did create a  pull request anyway as I saw some flaws in other request.

* It contains some code duplication ("rendering text")
* It does remap <esc> globally and then unmaps it
* It is quite obstusive as it grabs focus
* It uses quite some script globals

Thought about commenting on #347, but the last activity has been some time.

My approach does not aim at only hover, but at preview (yeah I know only hover uses it).
It is Implemented such that most of the code for preview is used, including "text rendering",
filetype/syntax and the option for keeping focus.

If the hover is not focused, it is closed on cursor move. If it is focused, it may be closed with
<esc>, which is only mapped in the scratch buffer.
This makes it a lot less obstusive and does not intrude the workflow.

As #347 seems to stand still currently, I offer to create any fusion of the two approached which
works best and fits the most with vim-lsp. So any comment is welcome.