### PR TITLE
Remove clobbering of quickfix list

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -446,6 +446,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
         execute printf('edit %d', l:loc['filename'])
     endif
     call cursor(l:loc['lnum'], l:loc['col'])
+    redraw
 endfunction
 
 function! s:handle_rename_prepare(server, last_req_id, type, data) abort


### PR DESCRIPTION
Hi.  Thank you for vim-lsp.

I'm creating this PR very tentatively to see what you think.  These are the changes I made to make it work with [AsyncRun](https://github.com/skywind3000/asyncrun.vim).  The problem is that whenever I use `:LspDefinition`, vim-lsp clobbers quickfix list that AsyncRun populates and that I need preserved.  This PR removes clearing the quickfix list by `:LspDefinition`.  I also think there should be a separation of cecerns and vim-lsp shouldn't manage opening the quickfix list (`:copen`), so I removed it.  I much prefer to follow [AsyncRun's Quickfix Best Practice](https://github.com/skywind3000/asyncrun.vim/wiki/Quickfix-Best-Practice).