### PR TITLE
Fix LspDocumentFormat not working as expected

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -185,7 +185,16 @@ function! s:generate_sub_cmd_replace(text_edit) abort
 
     let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
     let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character) " move to the first position
-    let l:sub_cmd .= 'v'
+
+    " If start and end position are 0, we are selecting a range of lines.
+    " Thus, we can use linewise-visual mode, which avoids some inconsistencies
+    " when applying text edits.
+    if l:start_character == 0 && l:end_character == 0
+        let l:sub_cmd .= 'V'
+    else
+        let l:sub_cmd .= 'v'
+    endif
+
     let l:sub_cmd .= s:generate_move_end_cmd(l:end_line, l:end_character) " move to the last position
 
     if len(l:new_text) == 0

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -71,7 +71,7 @@ nnoremap <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename()<cr>
 nnoremap <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition()<cr>
 nnoremap <plug>(lsp-workspace-symbol) :<c-u>call lsp#ui#vim#workspace_symbol()<cr>
 nnoremap <plug>(lsp-document-format) :<c-u>call lsp#ui#vim#document_format()<cr>
-vnoremap <plug>(lsp-document-format) :call lsp#ui#vim#document_range_format()<cr>
+vnoremap <plug>(lsp-document-format) :<Home>silent <End>call lsp#ui#vim#document_range_format()<cr>
 nnoremap <plug>(lsp-implementation) :<c-u>call lsp#ui#vim#implementation()<cr>
 nnoremap <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
 nnoremap <plug>(lsp-next-reference) :<c-u>call lsp#ui#vim#references#jump(+1)<cr>

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -367,6 +367,29 @@ Describe lsp#utils#text_edit
             Assert Equals(l:buffer_text, ['fr', 'baz', ''])
         End
 
+        It replaces entire buffer correctly
+            call s:set_text(['foo', 'bar', 'baz'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                    \ expand('%'),
+                    \ [{
+                    \   'range': {
+                    \       'start': {
+                    \           'line': 0,
+                    \           'character': 0
+                    \       },
+                    \       'end': {
+                    \           'line': 3,
+                    \           'character': 0
+                    \       }
+                    \   },
+                    \   'newText': "x\ny\nz\n"
+                    \ }])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['x', 'y', 'z', ''])
+        End
+
         It preserves v:completed_item
             " Add some text to buffer
             call s:set_text(['foo', 'bar'])


### PR DESCRIPTION
Fixes #394.

The problem was that putting in visual mode is actually implemented as (see `:h v_p`):
1. Put the register contents after the visual selection
2. Delete the original selection

As such, applying text edits that change several lines (or the entire document) gave weird results.
To solve this, I switch to linewise-visual mode whenever the text edit is over a set of lines, indicated by `start_char == end_char == 0`.