### PR TITLE
Add LspPeekDefinition

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For more information, refer to the readme and documentation of the respective pl
 |--|--|
 |`:LspCodeAction`| Gets a list of possible commands that can be applied to a file so it can be fixed (quick fix) |
 |`:LspDeclaration`| Go to declaration |
-|`:LspDefinition`| Go to definition |
+|`:LspDefinition`| Go to the definition of the word under the cursor, and open in the current window |
 |`:LspDocumentDiagnostics`| Get current document diagnostics information |
 |`:LspDocumentFormat`| Format entire document |
 |`:LspDocumentRangeFormat`| Format document selection |
@@ -72,6 +72,7 @@ For more information, refer to the readme and documentation of the respective pl
 |`:LspImplementation` | Show implementation of interface |
 |`:LspNextError`| jump to next error |
 |`:LspNextReference`| jump to next reference to the symbol under cursor |
+|`:LspPeekDefinition`| Go to the definition of the word under the cursor, but open in preview window |
 |`:LspPreviousError`| jump to previous error |
 |`:LspPreviousReference`| jump to previous reference to the symbol under cursor |
 |`:LspReferences`| Find references |

--- a/README.md
+++ b/README.md
@@ -62,23 +62,26 @@ For more information, refer to the readme and documentation of the respective pl
 | Command | Description|
 |--|--|
 |`:LspCodeAction`| Gets a list of possible commands that can be applied to a file so it can be fixed (quick fix) |
-|`:LspDeclaration`| Go to declaration |
+|`:LspDeclaration`| Go to the declaration of the word under the cursor, and open in the current window |
 |`:LspDefinition`| Go to the definition of the word under the cursor, and open in the current window |
 |`:LspDocumentDiagnostics`| Get current document diagnostics information |
 |`:LspDocumentFormat`| Format entire document |
 |`:LspDocumentRangeFormat`| Format document selection |
 |`:LspDocumentSymbol`| Show document symbols |
 |`:LspHover`| Show hover information |
-|`:LspImplementation` | Show implementation of interface |
+|`:LspImplementation` | Show implementation of interface in the current window |
 |`:LspNextError`| jump to next error |
 |`:LspNextReference`| jump to next reference to the symbol under cursor |
+|`:LspPeekDeclaration`| Go to the declaration of the word under the cursor, but open in preview window |
 |`:LspPeekDefinition`| Go to the definition of the word under the cursor, but open in preview window |
+|`:LspPeekImplementation`| Go to the implementation of an interface, but open in preview window |
+|`:LspPeekTypeDefinition`| Go to the type definition of the word under the cursor, but open in preview window |
 |`:LspPreviousError`| jump to previous error |
 |`:LspPreviousReference`| jump to previous reference to the symbol under cursor |
 |`:LspReferences`| Find references |
 |`:LspRename`| Rename symbol |
 |`:LspStatus` | Show the status of the language server |
-|`:LspTypeDefinition`| Go to type definition |
+|`:LspTypeDefinition`| Go to the type definition of the word under the cursor, and open in the current window |
 |`:LspWorkspaceSymbol`| Search/Show workspace symbol |
 
 ### Diagnostics

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -4,7 +4,7 @@ function! s:not_supported(what) abort
     return lsp#utils#error(a:what.' not supported for '.&filetype)
 endfunction
 
-function! lsp#ui#vim#implementation() abort
+function! lsp#ui#vim#implementation(in_preview) abort
     let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_implementation_provider(v:val)')
     let s:last_req_id = s:last_req_id + 1
     call setqflist([])
@@ -13,7 +13,7 @@ function! lsp#ui#vim#implementation() abort
         call s:not_supported('Retrieving implementation')
         return
     endif
-    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': 0 }
+    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': a:in_preview }
     for l:server in l:servers
         call lsp#send_request(l:server, {
             \ 'method': 'textDocument/implementation',
@@ -28,7 +28,7 @@ function! lsp#ui#vim#implementation() abort
     echo 'Retrieving implementation ...'
 endfunction
 
-function! lsp#ui#vim#type_definition() abort
+function! lsp#ui#vim#type_definition(in_preview) abort
     let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_type_definition_provider(v:val)')
     let s:last_req_id = s:last_req_id + 1
     call setqflist([])
@@ -37,7 +37,7 @@ function! lsp#ui#vim#type_definition() abort
         call s:not_supported('Retrieving type definition')
         return
     endif
-    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': 0 }
+    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': a:in_preview }
     for l:server in l:servers
         call lsp#send_request(l:server, {
             \ 'method': 'textDocument/typeDefinition',
@@ -52,7 +52,7 @@ function! lsp#ui#vim#type_definition() abort
     echo 'Retrieving type definition ...'
 endfunction
 
-function! lsp#ui#vim#declaration() abort
+function! lsp#ui#vim#declaration(in_preview) abort
     let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_declaration_provider(v:val)')
     let s:last_req_id = s:last_req_id + 1
     call setqflist([])
@@ -62,7 +62,7 @@ function! lsp#ui#vim#declaration() abort
         return
     endif
 
-    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': 0 }
+    let l:ctx = { 'counter': len(l:servers), 'list':[], 'last_req_id': s:last_req_id, 'jump_if_one': 1, 'in_preview': a:in_preview }
     for l:server in l:servers
         call lsp#send_request(l:server, {
             \ 'method': 'textDocument/declaration',

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -453,28 +453,12 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 echo 'Retrieved ' . a:type
                 botright copen
             else
-                " Close any preview window that is open already
-                pclose
-
-                " Save current window
-                let l:current_window = win_getid()
-
-                " Open preview window with correct file
-                execute &previewheight . 'new'
-                execute 'edit ' . fnameescape(l:loc['filename'])
-
-                " Move cursor to specified position
-                execute printf('call cursor(%d, %d)', l:loc['lnum'], l:loc['col'])
-
-                " Set window properties
-                let &l:previewwindow = 1
-                let &l:statusline = ' LSP Peek ' . a:type
-
-                " Centre screen on location
-                normal! zz
-
-                " Restore current window
-                call win_gotoid(l:current_window)
+                let l:lines = readfile(fnameescape(l:loc['filename']))
+                call lsp#ui#vim#output#preview(l:lines, {
+                            \   'statusline': ' LSP Peek ' . a:type,
+                            \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': 'center' },
+                            \   'filetype': &filetype
+                            \ })
             endif
         endif
     endif

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -456,7 +456,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 let l:lines = readfile(fnameescape(l:loc['filename']))
                 call lsp#ui#vim#output#preview(l:lines, {
                             \   'statusline': ' LSP Peek ' . a:type,
-                            \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': 'center' },
+                            \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },
                             \   'filetype': &filetype
                             \ })
             endif

--- a/autoload/lsp/ui/vim/hover.vim
+++ b/autoload/lsp/ui/vim/hover.vim
@@ -35,7 +35,7 @@ function! s:handle_hover(server, data) abort
     endif
 
     if !empty(a:data['response']['result']) && !empty(a:data['response']['result']['contents'])
-        call lsp#ui#vim#output#preview(a:data['response']['result']['contents'])
+        call lsp#ui#vim#output#preview(a:data['response']['result']['contents'], {'statusline': ' LSP Hover'})
         return
     else
         call lsp#utils#error('No hover information found')

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -198,7 +198,6 @@ function! s:set_cursor(current_window_id, options) abort
       let &scrolloff = l:old_scrolloff
     elseif s:supports_floating && g:lsp_preview_float && !has('nvim')
       " Vim popups
-      call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
       function! AlignVimPopup(timer) closure
           call s:align_preview(a:options)
       endfunction

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -206,7 +206,16 @@ function! s:align_preview(options) abort
     let l:align = a:options['cursor']['align']
 
     if s:supports_floating && g:lsp_preview_float && !has('nvim')
-        call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
+        let l:pos = popup_getpos(s:winid)
+        let l:height = l:pos['core_height']
+
+        if l:align ==? 'top'
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
+        elseif l:align ==? 'center'
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height / 2})
+        elseif l:align ==? 'bottom'
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height})
+        endif
     else
         if l:align ==? 'top'
             normal! zt

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -222,7 +222,12 @@ function! s:align_preview(options) abort
     if s:supports_floating && g:lsp_preview_float && !has('nvim')
         " Vim popups
         let l:pos = popup_getpos(s:winid)
-        let l:height = min([l:pos['core_height'], winheight(0) - winline() - 2])
+        let l:below = l:pos['core_line'] < winline()
+        if l:below
+            let l:height = min([l:pos['core_height'], winheight(0) - winline() - 2])
+        else
+            let l:height = min([l:pos['core_height'], winline() - 3])
+        endif
         let l:width = l:pos['core_width']
 
         let l:options = {

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -114,28 +114,10 @@ function! lsp#ui#vim#output#floatingpreview(data, options) abort
     " Enable closing the preview with esc, but map only in the scratch buffer
     nmap <buffer><silent> <esc> :pclose<cr>
   else
-    let l:options = {
-                \ 'moved': 'any',
-                \ 'border': [1, 1, 1, 1],
-                \ }
-
-    if has_key(a:options, 'cursor')
-      if has_key(a:options['cursor'], 'align')
-          let l:align = a:options['cursor']['align']
-
-          if l:align ==? 'top'
-              let l:options['firstline'] = a:options['cursor']['line']
-          elseif l:align ==? 'center'
-              " TODO
-              let l:options['firstline'] = a:options['cursor']['line']
-          elseif l:align ==? 'bottom'
-              " TODO
-              let l:options['firstline'] = a:options['cursor']['line']
-          endif
-      endif
-    endif
-
-    let s:winid = popup_atcursor('...', l:options)
+    let s:winid = popup_atcursor('...', {
+        \  'moved': 'any',
+		    \  'border': [1, 1, 1, 1],
+		\})
   endif
   return s:winid
 endfunction
@@ -216,9 +198,16 @@ function! s:set_cursor(current_window_id, options) abort
 endfunction
 
 function! s:align_preview(options) abort
-    if has_key(a:options['cursor'], 'align')
-        let l:align = a:options['cursor']['align']
+    if !has_key(a:options, 'cursor') ||
+     \ !has_key(a:options['cursor'], 'align')
+        return
+    endif
 
+    let l:align = a:options['cursor']['align']
+
+    if s:supports_floating && g:lsp_preview_float && !has('nvim')
+        call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
+    else
         if l:align ==? 'top'
             normal! zt
         elseif l:align ==? 'center'
@@ -284,9 +273,12 @@ function! lsp#ui#vim#output#preview(data, options) abort
         call s:adjust_float_placement(l:bufferlines, l:maxwidth)
         call s:set_cursor(l:current_window_id, a:options)
         call s:add_float_closing_hooks()
+      else
+        call s:align_preview(a:options)
       endif
       doautocmd User lsp_float_opened
     endif
+
 
     if !g:lsp_preview_keep_focus
       " set the focus to the preview window

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -198,7 +198,7 @@ function! s:set_cursor(current_window_id, options) abort
       let &scrolloff = l:old_scrolloff
     elseif s:supports_floating && g:lsp_preview_float && !has('nvim')
       " Vim popups
-      function! AlignVimPopup(timer) closure
+      function! AlignVimPopup(timer) closure abort
           call s:align_preview(a:options)
       endfunction
       call timer_start(0, function('AlignVimPopup'))

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -279,7 +279,17 @@ function! lsp#ui#vim#output#preview(data, options) abort
           let &scrolloff = 0
 
           call nvim_win_set_cursor(s:winid, [a:options['cursor']['line'], a:options['cursor']['col']])
-          normal! zt
+          if has_key(a:options['cursor'], 'align')
+              let l:align = a:options['cursor']['align']
+
+              if l:align == "top"
+                  normal! zt
+              elseif l:align == "center"
+                  normal! zz
+              elseif l:align == "bottom"
+                  normal! zb
+              endif
+          endif
 
           " Finally, go back to the original window
           call win_gotoid(l:current_window_id)

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -241,6 +241,7 @@ function! s:align_preview(options) abort
         endif
 
         call popup_setoptions(s:winid, l:options)
+        redraw!
     else
         " Preview and Neovim floats
         if l:align ==? 'top'

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -223,7 +223,7 @@ function! s:align_preview(options) abort
         " Vim popups
         let l:pos = popup_getpos(s:winid)
         let l:height = min([l:pos['core_height'], winheight(0) - winline() - 2])
-        let l:width = 40
+        let l:width = l:pos['core_width']
 
         let l:options = {
                     \ 'minwidth': l:width,

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -128,12 +128,12 @@ function! lsp#ui#vim#output#floatingpreview(data, options) abort
       if has_key(a:options['cursor'], 'align')
           let l:align = a:options['cursor']['align']
 
-          if l:align == "top"
+          if l:align ==? 'top'
               let l:options['firstline'] = a:options['cursor']['line']
-          elseif l:align == "center"
+          elseif l:align ==? 'center'
               " TODO
               let l:options['firstline'] = a:options['cursor']['line']
-          elseif l:align == "bottom"
+          elseif l:align ==? 'bottom'
               " TODO
               let l:options['firstline'] = a:options['cursor']['line']
           endif
@@ -246,11 +246,11 @@ function! lsp#ui#vim#output#preview(data, options) abort
             if has_key(a:options['cursor'], 'align')
                 let l:align = a:options['cursor']['align']
 
-                if l:align == "top"
+                if l:align ==? 'top'
                     normal! zt
-                elseif l:align == "center"
+                elseif l:align ==? 'center'
                     normal! zz
-                elseif l:align == "bottom"
+                elseif l:align ==? 'bottom'
                     normal! zb
                 endif
             endif
@@ -282,11 +282,11 @@ function! lsp#ui#vim#output#preview(data, options) abort
           if has_key(a:options['cursor'], 'align')
               let l:align = a:options['cursor']['align']
 
-              if l:align == "top"
+              if l:align ==? 'top'
                   normal! zt
-              elseif l:align == "center"
+              elseif l:align ==? 'center'
                   normal! zz
-              elseif l:align == "bottom"
+              elseif l:align ==? 'bottom'
                   normal! zb
               endif
           endif

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -196,6 +196,9 @@ function! s:set_cursor(current_window_id, options) abort
 
       let &scrolloff = l:old_scrolloff
     else
+      " Don't use 'scrolloff', it might mess up the cursor's position
+      let &l:scrolloff = 0
+
       call cursor(a:options['cursor']['line'], a:options['cursor']['col'])
     endif
 endfunction
@@ -261,10 +264,7 @@ function! lsp#ui#vim#output#preview(data, options) abort
     let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
 
     if !s:supports_floating || !g:lsp_preview_float
-        " Don't use 'scrolloff', it might mess up the cursor's position
-        let &l:scrolloff = 0
-
-        " Set options of preview window
+        " Set statusline
         if has_key(a:options, 'statusline')
             let &l:statusline = a:options['statusline']
         endif

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -198,7 +198,11 @@ function! s:set_cursor(current_window_id, options) abort
       let &scrolloff = l:old_scrolloff
     elseif s:supports_floating && g:lsp_preview_float && !has('nvim')
       " Vim popups
-      call s:align_preview(a:options)
+      call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
+      function! AlignVimPopup(timer) closure
+          call s:align_preview(a:options)
+      endfunction
+      call timer_start(0, function('AlignVimPopup'))
     else
       " Preview
       " Don't use 'scrolloff', it might mess up the cursor's position
@@ -222,11 +226,11 @@ function! s:align_preview(options) abort
         let l:height = l:pos['core_height']
 
         if l:align ==? 'top'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line']})
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'], 'maxheight': l:height})
         elseif l:align ==? 'center'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height / 2})
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - (l:height - 1) / 2, 'maxheight': l:height})
         elseif l:align ==? 'bottom'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height})
+            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height + 1, 'maxheight': l:height})
         endif
     else
         " Preview and Neovim floats

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -178,21 +178,25 @@ function! s:open_preview(data) abort
 endfunction
 
 function! s:set_cursor(current_window_id, options) abort
-    if has_key(a:options, 'cursor')
-      if has('nvim')
-        " Go back to the preview window to set the cursor
-        call win_gotoid(s:winid)
-        let l:old_scrolloff = &scrolloff
-        let &scrolloff = 0
+    if !has_key(a:options, 'cursor')
+        return
+    endif
 
-        call nvim_win_set_cursor(s:winid, [a:options['cursor']['line'], a:options['cursor']['col']])
-        call s:align_preview(a:options)
+    if has('nvim')
+      " Go back to the preview window to set the cursor
+      call win_gotoid(s:winid)
+      let l:old_scrolloff = &scrolloff
+      let &scrolloff = 0
 
-        " Finally, go back to the original window
-        call win_gotoid(a:current_window_id)
+      call nvim_win_set_cursor(s:winid, [a:options['cursor']['line'], a:options['cursor']['col']])
+      call s:align_preview(a:options)
 
-        let &scrolloff = l:old_scrolloff
-      endif
+      " Finally, go back to the original window
+      call win_gotoid(a:current_window_id)
+
+      let &scrolloff = l:old_scrolloff
+    else
+      call cursor(a:options['cursor']['line'], a:options['cursor']['col'])
     endif
 endfunction
 
@@ -265,10 +269,8 @@ function! lsp#ui#vim#output#preview(data, options) abort
             let &l:statusline = a:options['statusline']
         endif
 
-        if has_key(a:options, 'cursor')
-            call cursor(a:options['cursor']['line'], a:options['cursor']['col'])
-            call s:align_preview(a:options)
-        endif
+        call s:set_cursor(-1, a:options)
+        call s:align_preview(a:options)
     endif
 
     " Go to the previous window to adjust positioning

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -235,7 +235,7 @@ function! s:align_preview(options) abort
     if s:supports_floating && g:lsp_preview_float && !has('nvim')
         " Vim popups
         let l:pos = popup_getpos(s:winid)
-        let l:below = l:pos['core_line'] < winline()
+        let l:below = winline() < winheight(0) / 2
         if l:below
             let l:height = min([l:pos['core_height'], winheight(0) - winline() - 2])
         else
@@ -247,7 +247,9 @@ function! s:align_preview(options) abort
                     \ 'minwidth': l:width,
                     \ 'maxwidth': l:width,
                     \ 'minheight': l:height,
-                    \ 'maxheight': l:height
+                    \ 'maxheight': l:height,
+                    \ 'pos': l:below ? 'topleft' : 'botleft',
+                    \ 'line': l:below ? 'cursor+1' : 'cursor-1'
                     \ }
 
         if l:align ==? 'top'

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -287,12 +287,10 @@ function! lsp#ui#vim#output#preview(data, options) abort
       doautocmd User lsp_float_opened
     endif
 
-
     if !g:lsp_preview_keep_focus
       " set the focus to the preview window
       call win_gotoid(s:winid)
     endif
-
     return ''
 endfunction
 

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -201,6 +201,20 @@ function! s:open_preview(data, options) abort
     return l:winid
 endfunction
 
+function! s:align_preview(options) abort
+    if has_key(a:options['cursor'], 'align')
+        let l:align = a:options['cursor']['align']
+
+        if l:align ==? 'top'
+            normal! zt
+        elseif l:align ==? 'center'
+            normal! zz
+        elseif l:align ==? 'bottom'
+            normal! zb
+        endif
+    endif
+endfunction
+
 function! lsp#ui#vim#output#preview(data, options) abort
     if s:winid && type(s:preview_data) == type(a:data)
        \ && s:preview_data == a:data
@@ -242,18 +256,7 @@ function! lsp#ui#vim#output#preview(data, options) abort
 
         if has_key(a:options, 'cursor')
             execute printf('call cursor(%d, %d)', a:options['cursor']['line'], a:options['cursor']['col'])
-
-            if has_key(a:options['cursor'], 'align')
-                let l:align = a:options['cursor']['align']
-
-                if l:align ==? 'top'
-                    normal! zt
-                elseif l:align ==? 'center'
-                    normal! zz
-                elseif l:align ==? 'bottom'
-                    normal! zb
-                endif
-            endif
+            call s:align_preview(a:options)
         endif
     endif
 
@@ -279,17 +282,7 @@ function! lsp#ui#vim#output#preview(data, options) abort
           let &scrolloff = 0
 
           call nvim_win_set_cursor(s:winid, [a:options['cursor']['line'], a:options['cursor']['col']])
-          if has_key(a:options['cursor'], 'align')
-              let l:align = a:options['cursor']['align']
-
-              if l:align ==? 'top'
-                  normal! zt
-              elseif l:align ==? 'center'
-                  normal! zz
-              elseif l:align ==? 'bottom'
-                  normal! zb
-              endif
-          endif
+          call s:align_preview(a:options)
 
           " Finally, go back to the original window
           call win_gotoid(l:current_window_id)

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -250,7 +250,7 @@ function! lsp#ui#vim#output#preview(data, options) abort
         endif
 
         if has_key(a:options, 'cursor')
-            execute printf('call cursor(%d, %d)', a:options['cursor']['line'], a:options['cursor']['col'])
+            call cursor(a:options['cursor']['line'], a:options['cursor']['col'])
             call s:align_preview(a:options)
         endif
     endif

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -91,7 +91,7 @@ function! s:get_float_positioning(height, width) abort
     return l:opts
 endfunction
 
-function! lsp#ui#vim#output#floatingpreview(data, options) abort
+function! lsp#ui#vim#output#floatingpreview(data) abort
   if has('nvim')
     let l:buf = nvim_create_buf(v:false, v:true)
     call setbufvar(l:buf, '&signcolumn', 'no')
@@ -110,7 +110,6 @@ function! lsp#ui#vim#output#floatingpreview(data, options) abort
     call nvim_win_set_option(s:winid, 'number', v:false)
     call nvim_win_set_option(s:winid, 'relativenumber', v:false)
     call nvim_win_set_option(s:winid, 'cursorline', v:false)
-
     " Enable closing the preview with esc, but map only in the scratch buffer
     nmap <buffer><silent> <esc> :pclose<cr>
   else
@@ -168,9 +167,9 @@ function! lsp#ui#vim#output#getpreviewwinid() abort
     return s:winid
 endfunction
 
-function! s:open_preview(data, options) abort
+function! s:open_preview(data) abort
     if s:supports_floating && g:lsp_preview_float
-      let l:winid = lsp#ui#vim#output#floatingpreview(a:data, a:options)
+      let l:winid = lsp#ui#vim#output#floatingpreview(a:data)
     else
       execute &previewheight.'new'
       let l:winid = win_getid()
@@ -241,7 +240,7 @@ function! lsp#ui#vim#output#preview(data, options) abort
 
     let l:current_window_id = win_getid()
 
-    let s:winid = s:open_preview(a:data, a:options)
+    let s:winid = s:open_preview(a:data)
 
     let s:preview_data = a:data
     let l:lines = []

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -2,13 +2,8 @@ let s:supports_floating = exists('*nvim_open_win') || has('patch-8.1.1517')
 let s:winid = v:false
 let s:prevwin = v:false
 let s:preview_data = v:false
-let s:suppress_close = v:false
 
 function! lsp#ui#vim#output#closepreview() abort
-  if s:suppress_close
-    return
-  endif
-
   if win_getid() == s:winid
     " Don't close if window got focus
     return
@@ -268,11 +263,8 @@ function! lsp#ui#vim#output#preview(data, options) abort
     if s:supports_floating && s:winid && g:lsp_preview_float
       if has('nvim')
         call s:adjust_float_placement(l:bufferlines, l:maxwidth)
-        call s:add_float_closing_hooks()
 
         if has_key(a:options, 'cursor')
-          let s:suppress_close = v:true
-
           " Go back to the preview window to set the cursor
           call win_gotoid(s:winid)
           let l:old_scrolloff = &scrolloff
@@ -285,8 +277,9 @@ function! lsp#ui#vim#output#preview(data, options) abort
           call win_gotoid(l:current_window_id)
 
           let &scrolloff = l:old_scrolloff
-          let s:suppress_close = v:false
         endif
+
+        call s:add_float_closing_hooks()
       endif
       doautocmd User lsp_float_opened
     endif

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -222,15 +222,25 @@ function! s:align_preview(options) abort
     if s:supports_floating && g:lsp_preview_float && !has('nvim')
         " Vim popups
         let l:pos = popup_getpos(s:winid)
-        let l:height = l:pos['core_height']
+        let l:height = min([l:pos['core_height'], winheight(0) - winline() - 2])
+        let l:width = 40
+
+        let l:options = {
+                    \ 'minwidth': l:width,
+                    \ 'maxwidth': l:width,
+                    \ 'minheight': l:height,
+                    \ 'maxheight': l:height
+                    \ }
 
         if l:align ==? 'top'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'], 'maxheight': l:height})
+            let l:options['firstline'] = a:options['cursor']['line']
         elseif l:align ==? 'center'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - (l:height - 1) / 2, 'maxheight': l:height})
+            let l:options['firstline'] = a:options['cursor']['line'] - (l:height - 1) / 2
         elseif l:align ==? 'bottom'
-            call popup_setoptions(s:winid, {'firstline': a:options['cursor']['line'] - l:height + 1, 'maxheight': l:height})
+            let l:options['firstline'] = a:options['cursor']['line'] - l:height + 1
         endif
+
+        call popup_setoptions(s:winid, l:options)
     else
         " Preview and Neovim floats
         if l:align ==? 'top'

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -581,7 +581,7 @@ Jump to the next reference of the symbol under cursor.
 
 LspPeekDefinition                                        *LspPeekDefinition*
 
-Like |LspDefinition|, but opens the definition in the preview window instead
+Like |LspDefinition|, but opens the definition in the |preview-window| instead
 of the current window.
 
 LspPreviousError					 *LspPreviousError*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -43,6 +43,7 @@ CONTENTS                                                  *vim-lsp-contents*
       LspHover                              |LspHover|
       LspNextError                          |LspNextError|
       LspNextReference                      |LspNextReference|
+      LspPeekDefinition                     |LspPeekDefinition|
       LspPreviousError                      |LspPreviousError|
       LspPreviousReference                  |LspPreviousReference|
       LspImplementation                     |LspImplementation|
@@ -537,6 +538,8 @@ LspDefinition						     *LspDefinition*
 
 Go to definition.
 
+Also see |LspPeekDefinition|.
+
 LspDocumentFormat					 *LspDocumentFormat*
 
 Format the entire document.
@@ -575,6 +578,11 @@ Jump to Next err diagnostics
 LspNextReference                                          *LspNextReference*
 
 Jump to the next reference of the symbol under cursor.
+
+LspPeekDefinition                                        *LspPeekDefinition*
+
+Like |LspDefinition|, but opens the definition in the preview window instead
+of the current window.
 
 LspPreviousError					 *LspPreviousError*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -27,6 +27,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
       g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
+      g:lsp_peek_alignment                  |g:lsp_peek_alignment|
     Functions                             |vim-lsp-functions|
       enable                                |vim-lsp-enable|
       disable                               |vim-lsp-disable|
@@ -383,6 +384,15 @@ g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     calling `lsp#omni#default_get_supported_capabilities` from within your
     function.
 
+g:lsp_peek_alignment                                 *g:lsp_peek_alignment*
+    Type: |String|
+    Default: `"center"`
+
+    Determines how to align the location of interest for e.g.
+    |LspPeekDefinition|. Three values are possible: `"top"`, `"center"` and
+    `"bottom"`, which place the location of interest at the first, middle and
+    last lines of the preview/popup/floating window, respectively.
+
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*
 
@@ -670,6 +680,8 @@ LspPeekDefinition                                        *LspPeekDefinition*
 Like |LspDefinition|, but opens the definition in the |preview-window| instead
 of the current window.
 
+Also see |g:lsp_peek_alignment|.
+
 LspPreviousError					 *LspPreviousError*
 
 Jump to Previous err diagnostics
@@ -759,7 +771,7 @@ Closes an opened preview window
 Transfers focus to an opened preview window or back to the previous window if
 focus is already on the preview window.
 
-  
+
 ===============================================================================
 Autocomplete                                          *vim-lsp-autocomplete*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -49,7 +49,10 @@ CONTENTS                                                  *vim-lsp-contents*
       LspHover                              |LspHover|
       LspNextError                          |LspNextError|
       LspNextReference                      |LspNextReference|
+      LspPeekDeclaration                    |LspPeekDeclaration|
       LspPeekDefinition                     |LspPeekDefinition|
+      LspPeekImplementation                 |LspPeekImplementation|
+      LspPeekTypeDefinition                 |LspPeekTypeDefinition|
       LspPreviousError                      |LspPreviousError|
       LspPreviousReference                  |LspPreviousReference|
       LspImplementation                     |LspImplementation|
@@ -627,6 +630,8 @@ LspDeclaration						    *LspDeclaration*
 Go to declaration. Useful for languages such as C/C++ where there is a clear
 distinction between declaration and definition.
 
+Also see |LspPeekDeclaration|.
+
 LspDefinition						     *LspDefinition*
 
 Go to definition.
@@ -675,12 +680,33 @@ LspNextReference                                          *LspNextReference*
 
 Jump to the next reference of the symbol under cursor.
 
+LspPeekDeclaration                                      *LspPeekDeclaration*
+
+Like |LspDeclaration|, but opens the declaration in the |preview-window|
+instead of the current window.
+
+Also see |g:lsp_peek_alignment| and |g:lsp_preview_float|.
+
 LspPeekDefinition                                        *LspPeekDefinition*
 
 Like |LspDefinition|, but opens the definition in the |preview-window| instead
 of the current window.
 
-Also see |g:lsp_peek_alignment|.
+Also see |g:lsp_peek_alignment| and |g:lsp_preview_float|.
+
+LspPeekImplementation                               *LspPeekImplementation*
+
+Like |LspImplementation|, but opens the implementation in the |preview-window|
+instead of the current window.
+
+Also see |g:lsp_peek_alignment| and |g:lsp_preview_float|.
+
+LspPeekTypeDefinition                               *LspPeekTypeDefinition*
+
+Like |LspTypeDefinition|, but opens the type definition in the
+|preview-window| instead of the current window.
+
+Also see |g:lsp_peek_alignment| and |g:lsp_preview_float|.
 
 LspPreviousError					 *LspPreviousError*
 
@@ -694,6 +720,8 @@ LspImplementation                                        *LspImplementation*
 
 Find all implementation of interface.
 
+Also see |LspPeekImplementation|.
+
 LspReferences						     *LspReferences*
 
 Find all references.
@@ -705,6 +733,8 @@ Rename the symbol.
 LspTypeDefinition				  	 *LspTypeDefinition*
 
 Go to the type definition.
+
+Also see |LspPeekTypeDefinition|.
 
 LspWorkspaceSymbol					*LspWorkspaceSymbol*
 
@@ -740,6 +770,7 @@ Available plug mappings are following:
 
   (lsp-code-action)
   (lsp-declaration)
+  (lsp-peek-declaration)
   (lsp-definition)
   (lsp-peek-definition)
   (lsp-document-symbol)
@@ -757,7 +788,9 @@ Available plug mappings are following:
   (lsp-document-format)
   (lsp-document-format)
   (lsp-implementation)
+  (lsp-peek-implementation)
   (lsp-type-definition)
+  (lsp-peek-type-definition)
   (lsp-status)
 
 See also |vim-lsp-commands|

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -643,6 +643,7 @@ Available plug mappings are following:
   (lsp-code-action)
   (lsp-declaration)
   (lsp-definition)
+  (lsp-peek-definition)
   (lsp-document-symbol)
   (lsp-document-diagnostics)
   (lsp-hover)

--- a/ftplugin/lsp-hover.vim
+++ b/ftplugin/lsp-hover.vim
@@ -7,13 +7,13 @@ else
   setlocal previewwindow buftype=nofile bufhidden=wipe noswapfile nobuflisted
 endif
 setlocal nocursorline nofoldenable
+setlocal nonumber norelativenumber
 
 if has('syntax')
     setlocal nospell
 endif
 
-let &l:statusline = ' LSP Hover'
-
 let b:undo_ftplugin = 'setlocal pvw< bt< bh< swf< bl< cul< fen<' .
             \ (has('syntax') ? ' spell<' : '') .
+            \ ' number< relativenumber<' .
             \ ' | unlet! g:markdown_fenced_languages'

--- a/ftplugin/lsp-hover.vim
+++ b/ftplugin/lsp-hover.vim
@@ -6,8 +6,7 @@ if has('patch-8.1.1517') && g:lsp_preview_float && !has('nvim')
 else
   setlocal previewwindow buftype=nofile bufhidden=wipe noswapfile nobuflisted
 endif
-setlocal nocursorline nofoldenable
-setlocal nonumber norelativenumber
+setlocal nocursorline nofoldenable nonumber norelativenumber
 
 if has('syntax')
     setlocal nospell

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -41,7 +41,8 @@ if g:lsp_auto_enable
 endif
 
 command! -range LspCodeAction call lsp#ui#vim#code_action()
-command! LspDeclaration call lsp#ui#vim#declaration()
+command! LspDeclaration call lsp#ui#vim#declaration(0)
+command! LspPeekDeclaration call lsp#ui#vim#declaration(1)
 command! LspDefinition call lsp#ui#vim#definition(0)
 command! LspPeekDefinition call lsp#ui#vim#definition(1)
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
@@ -51,20 +52,23 @@ command! LspNextError call lsp#ui#vim#diagnostics#next_error()
 command! LspPreviousError call lsp#ui#vim#diagnostics#previous_error()
 command! LspReferences call lsp#ui#vim#references()
 command! LspRename call lsp#ui#vim#rename()
-command! LspTypeDefinition call lsp#ui#vim#type_definition()
+command! LspTypeDefinition call lsp#ui#vim#type_definition(0)
+command! LspPeekTypeDefinition call lsp#ui#vim#type_definition(1)
 command! LspWorkspaceSymbol call lsp#ui#vim#workspace_symbol()
 command! -range LspDocumentFormat call lsp#ui#vim#document_format()
 command! -range LspDocumentFormatSync call lsp#ui#vim#document_format_sync()
 command! -range LspDocumentRangeFormat call lsp#ui#vim#document_range_format()
 command! -range LspDocumentRangeFormatSync call lsp#ui#vim#document_range_format_sync()
-command! LspImplementation call lsp#ui#vim#implementation()
+command! LspImplementation call lsp#ui#vim#implementation(0)
+command! LspPeekImplementation call lsp#ui#vim#implementation(1)
 command! LspTypeDefinition call lsp#ui#vim#type_definition()
 command! -nargs=0 LspStatus echo lsp#get_server_status()
 command! LspNextReference call lsp#ui#vim#references#jump(+1)
 command! LspPreviousReference call lsp#ui#vim#references#jump(-1)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
-nnoremap <plug>(lsp-declaration) :<c-u>call lsp#ui#vim#declaration()<cr>
+nnoremap <plug>(lsp-declaration) :<c-u>call lsp#ui#vim#declaration(0)<cr>
+nnoremap <plug>(lsp-peek-declaration) :<c-u>call lsp#ui#vim#declaration(1)<cr>
 nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition(0)<cr>
 nnoremap <plug>(lsp-peek-definition) :<c-u>call lsp#ui#vim#definition(1)<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
@@ -76,11 +80,13 @@ nnoremap <plug>(lsp-next-error) :<c-u>call lsp#ui#vim#diagnostics#next_error()<c
 nnoremap <plug>(lsp-previous-error) :<c-u>call lsp#ui#vim#diagnostics#previous_error()<cr>
 nnoremap <plug>(lsp-references) :<c-u>call lsp#ui#vim#references()<cr>
 nnoremap <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename()<cr>
-nnoremap <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition()<cr>
+nnoremap <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition(0)<cr>
+nnoremap <plug>(lsp-peek-type-definition) :<c-u>call lsp#ui#vim#type_definition(1)<cr>
 nnoremap <plug>(lsp-workspace-symbol) :<c-u>call lsp#ui#vim#workspace_symbol()<cr>
 nnoremap <plug>(lsp-document-format) :<c-u>call lsp#ui#vim#document_format()<cr>
 vnoremap <plug>(lsp-document-format) :call lsp#ui#vim#document_range_format()<cr>
-nnoremap <plug>(lsp-implementation) :<c-u>call lsp#ui#vim#implementation()<cr>
+nnoremap <plug>(lsp-implementation) :<c-u>call lsp#ui#vim#implementation(0)<cr>
+nnoremap <plug>(lsp-peek-implementation) :<c-u>call lsp#ui#vim#implementation(1)<cr>
 nnoremap <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
 nnoremap <plug>(lsp-next-reference) :<c-u>call lsp#ui#vim#references#jump(+1)<cr>
 nnoremap <plug>(lsp-previous-reference) :<c-u>call lsp#ui#vim#references#jump(-1)<cr>

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -28,6 +28,7 @@ let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabl
 let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
 let g:lsp_preview_autoclose = get(g:, 'lsp_preview_autoclose', 1)
 let g:lsp_preview_doubletap = get(g:, 'lsp_preview_doubletap', [function('lsp#ui#vim#output#focuspreview')])
+let g:lsp_peek_alignment = get(g:, 'lsp_peek_alignment', 'center')
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -38,7 +38,8 @@ endif
 
 command! -range LspCodeAction call lsp#ui#vim#code_action()
 command! LspDeclaration call lsp#ui#vim#declaration()
-command! LspDefinition call lsp#ui#vim#definition()
+command! LspDefinition call lsp#ui#vim#definition(0)
+command! LspPeekDefinition call lsp#ui#vim#definition(1)
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
 command! LspDocumentDiagnostics call lsp#ui#vim#diagnostics#document_diagnostics()
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover#get_hover_under_cursor()
@@ -60,7 +61,8 @@ command! LspPreviousReference call lsp#ui#vim#references#jump(-1)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
 nnoremap <plug>(lsp-declaration) :<c-u>call lsp#ui#vim#declaration()<cr>
-nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition()<cr>
+nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition(0)<cr>
+nnoremap <plug>(lsp-peek-definition) :<c-u>call lsp#ui#vim#definition(1)<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
 nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#ui#vim#diagnostics#document_diagnostics()<cr>
 nnoremap <plug>(lsp-hover) :<c-u>call lsp#ui#vim#hover#get_hover_under_cursor()<cr>


### PR DESCRIPTION
Adds `:LspPeekDefinition`, which displays the definition in the preview window, similar to VSCode's peek definition.

Fixes #411 