### PR TITLE
Fix newlines in popup window

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -237,7 +237,7 @@ function! s:append(data, lines) abort
 
         return 'markdown'
     elseif type(a:data) == type({}) && has_key(a:data, 'kind')
-        call add(a:lines, a:data.value)
+        call extend(a:lines, split(a:data.value, '\n'))
 
         return a:data.kind ==? 'plaintext' ? 'text' : a:data.kind
     endif


### PR DESCRIPTION
I fixed newlines not working in the popup window in some cases (e.g. for `:LspHover` in `clangd`).

Before:
![before](https://user-images.githubusercontent.com/10748726/60133074-0faa7600-979d-11e9-8204-c614c6460406.png)

After fix:
![after](https://user-images.githubusercontent.com/10748726/60133093-15a05700-979d-11e9-83c5-8bcb92a5ab1d.png)
