### PR TITLE
Allow setting popup max width

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -204,6 +204,19 @@ function! lsp#ui#vim#output#preview(data) abort
     let l:ft = s:append(a:data, l:lines)
     call s:setcontent(l:lines, l:ft)
 
+    " Set maximum width of floating window, if specified
+    if g:lsp_popup_max_width > 0 && s:supports_floating && s:winid && g:lsp_preview_float && has('nvim')
+        let &l:textwidth = g:lsp_popup_max_width
+
+        let &l:readonly = 0
+        let &l:modifiable = 1
+
+        normal! gggqGgg
+
+        let &l:readonly = 1
+        let &l:modifiable = 0
+    endif
+
     " Get size information while still having the buffer active
     let l:bufferlines = line('$')
     let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -118,8 +118,8 @@ function! lsp#ui#vim#output#floatingpreview(data) abort
                 \ 'border': [1, 1, 1, 1],
                 \ }
 
-    if g:lsp_popup_max_width > 0
-        let l:options['maxwidth'] = g:lsp_popup_max_width
+    if g:lsp_preview_max_width > 0
+        let l:options['maxwidth'] = g:lsp_preview_max_width
     endif
 
     let s:winid = popup_atcursor('...', l:options)
@@ -147,8 +147,8 @@ function! s:setcontent(lines, ft) abort
     call setline(1, a:lines)
 
     " Set maximum width of floating window, if specified
-    if g:lsp_popup_max_width > 0
-        let &l:textwidth = g:lsp_popup_max_width
+    if g:lsp_preview_max_width > 0
+        let &l:textwidth = g:lsp_preview_max_width
         normal! gggqGgg
     endif
 

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -145,6 +145,13 @@ function! s:setcontent(lines, ft) abort
   else
     " nvim floating
     call setline(1, a:lines)
+
+    " Set maximum width of floating window, if specified
+    if g:lsp_popup_max_width > 0
+        let &l:textwidth = g:lsp_popup_max_width
+        normal! gggqGgg
+    endif
+
     setlocal readonly nomodifiable
     let &l:filetype = a:ft . '.lsp-hover'
   endif
@@ -203,19 +210,6 @@ function! lsp#ui#vim#output#preview(data) abort
     let l:lines = []
     let l:ft = s:append(a:data, l:lines)
     call s:setcontent(l:lines, l:ft)
-
-    " Set maximum width of floating window, if specified
-    if g:lsp_popup_max_width > 0 && s:supports_floating && s:winid && g:lsp_preview_float && has('nvim')
-        let &l:textwidth = g:lsp_popup_max_width
-
-        let &l:readonly = 0
-        let &l:modifiable = 1
-
-        normal! gggqGgg
-
-        let &l:readonly = 1
-        let &l:modifiable = 0
-    endif
 
     " Get size information while still having the buffer active
     let l:bufferlines = line('$')

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -113,10 +113,16 @@ function! lsp#ui#vim#output#floatingpreview(data) abort
     " Enable closing the preview with esc, but map only in the scratch buffer
     nmap <buffer><silent> <esc> :pclose<cr>
   else
-    let s:winid = popup_atcursor('...', {
-        \  'moved': 'any',
-		    \  'border': [1, 1, 1, 1],
-		\})
+    let l:options = {
+                \ 'moved': 'any',
+                \ 'border': [1, 1, 1, 1],
+                \ }
+
+    if g:lsp_popup_max_width > 0
+        let l:options['maxwidth'] = g:lsp_popup_max_width
+    endif
+
+    let s:winid = popup_atcursor('...', l:options)
   endif
   return s:winid
 endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -27,6 +27,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
       g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
+      g:lsp_popup_max_width		    |g:lsp_popup_max_width|
     Functions                             |vim-lsp-functions|
       enable                                |vim-lsp-enable|
       disable                               |vim-lsp-disable|
@@ -381,6 +382,15 @@ g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     Note: You can obtain the default supported capabilities of vim-lsp by
     calling `lsp#omni#default_get_supported_capabilities` from within your
     function.
+
+g:lsp_popup_max_width                               *g:lsp_popup_max_width*
+    Type: |Number|
+    Default: `-1`
+
+    If positive, determines the maximum width of the popup window in
+    characters. Lines longer than `g:lsp_popup_max_width` will be wrapped to
+    fit in the popup window. Use a value of `-1` to disable setting a maximum
+    width.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*
@@ -750,7 +760,7 @@ Closes an opened preview window
 Transfers focus to an opened preview window or back to the previous window if
 focus is already on the preview window.
 
-  
+
 ===============================================================================
 Autocomplete                                          *vim-lsp-autocomplete*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -27,7 +27,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
       g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
-      g:lsp_popup_max_width		    |g:lsp_popup_max_width|
+      g:lsp_popup_max_width                 |g:lsp_popup_max_width|
     Functions                             |vim-lsp-functions|
       enable                                |vim-lsp-enable|
       disable                               |vim-lsp-disable|

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -387,10 +387,10 @@ g:lsp_preview_max_width                           *g:lsp_preview_max_width*
     Type: |Number|
     Default: `-1`
 
-    If positive, determines the maximum width of the popup window in
+    If positive, determines the maximum width of the preview window in
     characters. Lines longer than `g:lsp_preview_max_width` will be wrapped to
-    fit in the popup window. Use a value of `-1` to disable setting a maximum
-    width.
+    fit in the preview window. Use a value of `-1` to disable setting a
+    maximum width.
 
 ===============================================================================
 FUNCTIONS	                                        *vim-lsp-functions*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -27,7 +27,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
       g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
-      g:lsp_popup_max_width                 |g:lsp_popup_max_width|
+      g:lsp_preview_max_width               |g:lsp_preview_max_width|
     Functions                             |vim-lsp-functions|
       enable                                |vim-lsp-enable|
       disable                               |vim-lsp-disable|
@@ -383,12 +383,12 @@ g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     calling `lsp#omni#default_get_supported_capabilities` from within your
     function.
 
-g:lsp_popup_max_width                               *g:lsp_popup_max_width*
+g:lsp_preview_max_width                           *g:lsp_preview_max_width*
     Type: |Number|
     Default: `-1`
 
     If positive, determines the maximum width of the popup window in
-    characters. Lines longer than `g:lsp_popup_max_width` will be wrapped to
+    characters. Lines longer than `g:lsp_preview_max_width` will be wrapped to
     fit in the popup window. Use a value of `-1` to disable setting a maximum
     width.
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -28,6 +28,7 @@ let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabl
 let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
 let g:lsp_preview_autoclose = get(g:, 'lsp_preview_autoclose', 1)
 let g:lsp_preview_doubletap = get(g:, 'lsp_preview_doubletap', [function('lsp#ui#vim#output#focuspreview')])
+let g:lsp_popup_max_width = get(g:, 'lsp_popup_max_width', -1)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -28,7 +28,7 @@ let g:lsp_highlight_references_enabled = get(g:, 'lsp_highlight_references_enabl
 let g:lsp_preview_float = get(g:, 'lsp_preview_float', 1)
 let g:lsp_preview_autoclose = get(g:, 'lsp_preview_autoclose', 1)
 let g:lsp_preview_doubletap = get(g:, 'lsp_preview_doubletap', [function('lsp#ui#vim#output#focuspreview')])
-let g:lsp_popup_max_width = get(g:, 'lsp_popup_max_width', -1)
+let g:lsp_preview_max_width = get(g:, 'lsp_preview_max_width', -1)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])


### PR DESCRIPTION
In response to: https://github.com/prabirshrestha/vim-lsp/pull/395#issuecomment-505783230.
Tested with `Vim 8.1.1592` and `NVIM v0.4.0-1149-g8b263c7a6`.

Note that Vim and Neovim have slightly different behaviour, Vim wraps on every character:
![Screenshot from 2019-06-26 13-21-47](https://user-images.githubusercontent.com/10748726/60176308-3953b380-9816-11e9-8fd8-b2f9cd24b559.png)

whereas Neovim only wraps at whitespace:
![Screenshot from 2019-06-26 13-22-14](https://user-images.githubusercontent.com/10748726/60176323-41abee80-9816-11e9-9781-59350f26a849.png)

Should I try to change it so both Vim and Neovim behave the same?