### PR TITLE
Fix float position with g:lsp_preview_keep_focus=0

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -202,10 +202,8 @@ function! lsp#ui#vim#output#preview(data) abort
     let l:bufferlines = line('$')
     let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
 
-    if g:lsp_preview_keep_focus
-      " restore focus to the previous window
-      call win_gotoid(l:current_window_id)
-    endif
+    " restore focus to the previous window
+    call win_gotoid(l:current_window_id)
 
     echo ''
 
@@ -215,6 +213,11 @@ function! lsp#ui#vim#output#preview(data) abort
         call s:add_float_closing_hooks()
       endif
       doautocmd User lsp_float_opened
+    endif
+
+    if !g:lsp_preview_keep_focus
+      " set the focus to the preview window
+      call win_gotoid(s:winid)
     endif
     return ''
 endfunction


### PR DESCRIPTION
> > Floating window for neovim always located top left corner, is it by design or a bug?
> 
> Bug. Should be at the cursor. Can you provide a minimal config where it happens, as I can't reproduce it.

Found that `let g:lsp_preview_keep_focus = 0` cause the issue.
With `let g:lsp_preview_keep_focus = 1` all good.

_Originally posted by @edganiukov in https://github.com/prabirshrestha/vim-lsp/pull/395#issuecomment-505799076_

Fixed it.