### PR TITLE
Implement workspace/configuration

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -375,7 +375,8 @@ endfunction
 function! lsp#default_get_supported_capabilities(server_info) abort
     return {
     \   'workspace': {
-    \       'applyEdit': v:true
+    \       'applyEdit': v:true,
+    \       'configuration': v:true
     \   }
     \ }
 endfunction
@@ -627,6 +628,9 @@ function! s:on_request(server_name, id, request) abort
     if a:request['method'] ==# 'workspace/applyEdit'
         call lsp#utils#workspace_edit#apply_workspace_edit(a:request['params']['edit'])
         call s:send_response(a:server_name, { 'id': a:request['id'], 'result': { 'applied': v:true } })
+    elseif a:request['method'] ==# 'workspace/configuration'
+        let l:response_items = map(a:request['params']['items'], { key, val -> lsp#utils#workspace_config#get_value(a:server_name, val) })
+        call s:send_response(a:server_name, { 'id': a:request['id'], 'result': l:response_items })
     else
         " Error returned according to json-rpc specification.
         call s:send_response(a:server_name, { 'id': a:request['id'], 'error': { 'code': -32601, 'message': 'Method not found' } })

--- a/autoload/lsp/utils/workspace_config.vim
+++ b/autoload/lsp/utils/workspace_config.vim
@@ -1,0 +1,14 @@
+function! lsp#utils#workspace_config#get_value(server_name, item) abort
+    try
+        let l:server_info = lsp#get_server_info(a:server_name)
+        let l:config = l:server_info['workspace_config']
+
+        for section in split(a:item['section'], '\.')
+            let l:config = l:config[l:section]
+        endfor
+
+        return l:config
+    catch
+        return v:null
+    endtry
+endfunction


### PR DESCRIPTION
Fixes #426 

Example:
```vim
autocmd User lsp_setup call lsp#register_server({
    \ 'name': 'texlab',
    \ 'cmd': {server_info->['texlab']},
    \ 'whitelist': ['tex'],
    \ 'workspace_config': { 'latex': { 'lint': { 'onSave': v:true } } }
    \ })
```