### PR TITLE
Clear all vim_lsp signs when disabling

### DIFF
--- a/autoload/lsp/ui/vim/signs.vim
+++ b/autoload/lsp/ui/vim/signs.vim
@@ -65,11 +65,19 @@ endfunction
 
 function! lsp#ui#vim#signs#disable() abort
     if s:enabled
-        " TODO: clear all vim_lsp signs
+        call s:clear_all_signs()
         call s:undefine_signs()
         let s:enabled = 0
         call lsp#log('vim-lsp signs disabled')
     endif
+endfunction
+
+function! s:clear_all_signs() abort
+    if !s:supports_signs | return | endif
+    for l:server_name in lsp#get_server_names()
+        let l:sign_group = s:get_sign_group(l:server_name)
+        call sign_unplace(l:sign_group)
+    endfor
 endfunction
 
 function! s:undefine_signs() abort


### PR DESCRIPTION
Implemented `TODO: clear all vim_lsp signs`.