### PR TITLE
Fix `lsp#disable()` to disable all ui features

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -65,6 +65,9 @@ function! lsp#disable() abort
         return
     endif
     call lsp#ui#vim#signs#disable()
+    call lsp#ui#vim#virtual#disable()
+    call lsp#ui#vim#highlights#disable()
+    call lsp#ui#vim#diagnostics#textprop#disable()
     call s:unregister_events()
     let s:enabled = 0
 endfunction


### PR DESCRIPTION
`lsp#disable()` should call all `lsp#ui#vim#*#disable()`.