### PR TITLE
Fix g:lsp_preview_max_width for Neovim

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -295,9 +295,10 @@ function! lsp#ui#vim#output#preview(data, options) abort
     call s:setcontent(l:lines, l:ft)
 
     " Get size information while still having the buffer active
+    let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
     if g:lsp_preview_max_width > 0
       let l:bufferlines = 0
-      let l:maxwidth = g:lsp_preview_max_width
+      let l:maxwidth = min([g:lsp_preview_max_width, l:maxwidth])
 
       " Determine, for each line, how many "virtual" lines it spans, and add
       " these together for all lines in the buffer
@@ -307,7 +308,6 @@ function! lsp#ui#vim#output#preview(data, options) abort
       endfor
     else
       let l:bufferlines = line('$')
-      let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
     endif
 
     if !s:supports_floating || !g:lsp_preview_float

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -146,12 +146,6 @@ function! s:setcontent(lines, ft) abort
     " nvim floating
     call setline(1, a:lines)
 
-    " Set maximum width of floating window, if specified
-    if g:lsp_preview_max_width > 0
-        let &l:textwidth = g:lsp_preview_max_width
-        normal! gggqGgg
-    endif
-
     setlocal readonly nomodifiable
     let &l:filetype = a:ft . '.lsp-hover'
   endif
@@ -301,8 +295,20 @@ function! lsp#ui#vim#output#preview(data, options) abort
     call s:setcontent(l:lines, l:ft)
 
     " Get size information while still having the buffer active
-    let l:bufferlines = line('$')
-    let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
+    if g:lsp_preview_max_width > 0
+      let l:bufferlines = 0
+      let l:maxwidth = g:lsp_preview_max_width
+
+      " Determine, for each line, how many "virtual" lines it spans, and add
+      " these together for all lines in the buffer
+      for l:line in getline(1, '$')
+        let l:num_lines = str2nr(string(ceil(strdisplaywidth(l:line) * 1.0 / g:lsp_preview_max_width)))
+        let l:bufferlines += max([l:num_lines, 1])
+      endfor
+    else
+      let l:bufferlines = line('$')
+      let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
+    endif
 
     if !s:supports_floating || !g:lsp_preview_float
         " Set statusline


### PR DESCRIPTION
In response to https://github.com/prabirshrestha/vim-lsp/pull/416#issuecomment-513576062.

I decided to try a different approach. Rather than hard wrapping the text using `gq` and `'textwidth'`, I softwrap by setting the maxwidth.
The only problem with this, is that we need to explicitly calculate the height of the floating window (as far as I can tell, anyway; if someone know a way where we can avoid this, let me know).

To accomplish this, I iterate over all lines and sum `ceil(line_width / max_width)` (i.e. the number of "virtual" lines needed to show this line).