### PR TITLE
Fix hover breaking on missing filetype

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -156,7 +156,10 @@ function! s:setcontent(lines, ft) abort
     endif
 
     setlocal readonly nomodifiable
-    let &l:filetype = a:ft . '.lsp-hover'
+    try
+        let &l:filetype = a:ft . '.lsp-hover'
+    catch
+    endtry
   endif
 endfunction
 


### PR DESCRIPTION
Fixes #442.
Apparently, the issue was that the `set filetype` threw an exception because typescript syntax files were not found.