### PR TITLE
Fix tagstack

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -419,31 +419,31 @@ function! s:handle_symbol(server, last_req_id, type, data) abort
 endfunction
 
 function! s:update_tagstack() abort
-    let bufnr = bufnr('%')
-    let item = {'bufnr': bufnr, 'from': [bufnr, line('.'), col('.'), 0], 'tagname': expand('<cword>')}
-    let winid = win_getid()
+    let l:bufnr = bufnr('%')
+    let l:item = {'bufnr': l:bufnr, 'from': [l:bufnr, line('.'), col('.'), 0], 'tagname': expand('<cword>')}
+    let l:winid = win_getid()
 
-    let stack = gettagstack(winid)
-    if stack['length'] == stack['curidx']
+    let l:stack = gettagstack(l:winid)
+    if l:stack['length'] == l:stack['curidx']
         " Replace the last items with item.
-        let action = 'r'
-        let stack['items'][stack['curidx']-1] = item
-    elseif stack['length'] > stack['curidx']
+        let l:action = 'r'
+        let l:stack['items'][l:stack['curidx']-1] = l:item
+    elseif l:stack['length'] > l:stack['curidx']
         " Replace items after used items with item.
-        let action = 'r'
-        if stack['curidx'] > 1
-            let stack['items'] = add(stack['items'][:stack['curidx']-2], item)
+        let l:action = 'r'
+        if l:stack['curidx'] > 1
+            let l:stack['items'] = add(l:stack['items'][:l:stack['curidx']-2], l:item)
         else
-            let stack['items'] = [item]
+            let l:stack['items'] = [l:item]
         endif
     else
         " Append item.
-        let action = 'a'
-        let stack['items'] = [item]
+        let l:action = 'a'
+        let l:stack['items'] = [l:item]
     endif
-    let stack['curidx'] += 1
+    let l:stack['curidx'] += 1
 
-    call settagstack(winid, stack, action)
+    call settagstack(l:winid, l:stack, l:action)
 endfunction
 
 function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list, jump_if_one, last_req_id, in_preview}

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -438,7 +438,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
             if exists('*gettagstack') && exists('*settagstack')
                 let from = [bufnr('%'), line('.'), col('.'), 0]
                 let tagname = expand('<cword>')
-                let item = {'from': from, 'tagname': tagname}
+                let item = {'bufnr': from[0], 'from': from, 'tagname': tagname}
                 let winid = win_getid()
                 let stack = gettagstack(winid)
                 if stack['length'] == stack['curidx']

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -419,10 +419,10 @@ function! s:handle_symbol(server, last_req_id, type, data) abort
 endfunction
 
 function! s:update_tagstack() abort
-    let from = [bufnr('%'), line('.'), col('.'), 0]
-    let tagname = expand('<cword>')
-    let item = {'bufnr': from[0], 'from': from, 'tagname': tagname}
+    let bufnr = bufnr('%')
+    let item = {'bufnr': bufnr, 'from': [bufnr, line('.'), col('.'), 0], 'tagname': expand('<cword>')}
     let winid = win_getid()
+
     let stack = gettagstack(winid)
     if stack['length'] == stack['curidx']
         " Replace the last items with item.
@@ -442,6 +442,7 @@ function! s:update_tagstack() abort
         let stack['items'] = [item]
     endif
     let stack['curidx'] += 1
+
     call settagstack(winid, stack, action)
 endfunction
 


### PR DESCRIPTION
The tagstack introduced in #435 has no feature to cleanup items.
For example, the following case will unexpected results.

```vim
:LspDefinition
:LspDefinition
:pop
:pop
:LspDefinition
:pop

" Expect the tagstack to be at the bottom.
" But possible to go back somewhere when next :pop.
```

In addition, set `bufnr` of the item.
