### PR TITLE
Support utf16 position

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -729,7 +729,7 @@ function! lsp#get_text_document_identifier(...) abort
 endfunction
 
 function! lsp#get_position(...) abort
-    return { 'line': line('.') - 1, 'character': col('.') -1 }
+    return { 'line': line('.') - 1, 'character': lsp#utils#col('.') - 1 }
 endfunction
 
 function! s:get_text_document_identifier(buf) abort

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -185,3 +185,19 @@ function! lsp#utils#echo_with_truncation(msg) abort
 
     exec 'echo l:msg'
 endfunction
+
+function! lsp#utils#count_utf16_code_units(str) abort
+    let l:rs = split(a:str, '\zs')
+    let l:len = len(l:rs)
+    return l:len + len(filter(l:rs, 'char2nr(v:val)>=0x10000'))
+endfunction
+
+function! lsp#utils#col(expr) abort
+    let l:line = getline(a:expr)
+    let l:vim_col = col(a:expr)
+    let l:vim_len = strlen(l:line)
+    let l:utf16_len = lsp#utils#count_utf16_code_units(l:line[0 : min([l:vim_len, l:vim_col]) - 1])
+    let l:utf16_len = l:utf16_len + max([0, l:vim_col - l:vim_len]) " fix for virtual-edit or end-of-line in insert-mode.
+    return l:utf16_len
+endfunction
+

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -7,18 +7,17 @@
 "
 " Finds a single change between the common prefix, and common postfix.
 function! lsp#utils#diff#compute(old, new) abort
-  let [l:start_line, l:start_char] = s:FirstDifference(a:old, a:new)
-  let [l:end_line, l:end_char] =
-      \ s:LastDifference(a:old[l:start_line :], a:new[l:start_line :], l:start_char)
+  let [l:start_line, l:start_char, l:start_offset] = lsp#utils#diff#first_difference(a:old, a:new)
+  let [l:end_line, l:end_char, l:end_offset] = lsp#utils#diff#last_difference(a:old[l:start_line :], a:new[l:start_line :], l:start_char, l:start_offset)
 
-  let l:text = s:ExtractText(a:new, l:start_line, l:start_char, l:end_line, l:end_char)
-  let l:length = s:Length(a:old, l:start_line, l:start_char, l:end_line, l:end_char)
+  let l:text = lsp#utils#diff#extract_text(a:new, l:start_line, l:start_char, l:end_line, l:end_char)
+  let l:length = lsp#utils#diff#length(a:old, l:start_line, l:start_char, l:end_line, l:end_char)
 
-  let l:adj_end_line = len(a:old) + l:end_line
-  let l:adj_end_char = l:end_line == 0 ? 0 : strchars(a:old[l:end_line]) + l:end_char + 1
+  let l:adj_end_line =  len(a:old) == 0 ? 0 : len(a:old) + l:end_line
+  let l:adj_end_offset = len(a:old) == 0 ? 0 : l:end_offset
 
-  let l:result = { 'range': {'start': {'line': l:start_line, 'character': l:start_char},
-      \ 'end': {'line': l:adj_end_line, 'character': l:adj_end_char}},
+  let l:result = { 'range': {'start': {'line': l:start_line, 'character': l:start_offset},
+      \ 'end': {'line': l:adj_end_line, 'character': l:adj_end_offset}},
       \ 'text': l:text,
       \ 'rangeLength': l:length,
       \}
@@ -28,93 +27,132 @@ endfunction
 
 " Finds the line and character of the first different character between two
 " list of Strings.
-function! s:FirstDifference(old, new) abort
+function! lsp#utils#diff#first_difference(old, new) abort
   let l:line_count = min([len(a:old), len(a:new)])
-  if l:line_count == 0 | return [0, 0] | endif
-  let l:i = 0
-  while l:i < l:line_count
-    if a:old[l:i] !=# a:new[l:i] | break | endif
-    let l:i += 1
-  endwhile
-  if l:i >= l:line_count
-    return [l:line_count - 1, strchars(a:old[l:line_count - 1])]
+  if l:line_count == 0
+    return [0, 0, 0]
   endif
-  let l:old_line = a:old[l:i]
-  let l:new_line = a:new[l:i]
+
+  let l:first_diff_line = 0
+  while l:first_diff_line < l:line_count
+    if a:old[l:first_diff_line] !=# a:new[l:first_diff_line] | break | endif
+    let l:first_diff_line += 1
+  endwhile
+
+  if l:first_diff_line >= l:line_count
+    return [l:line_count - 1, strchars(a:old[l:line_count - 1]), lsp#utils#count_utf16_code_units(a:old[l:line_count - 1])]
+  endif
+  let l:old_line = a:old[l:first_diff_line]
+  let l:new_line = a:new[l:first_diff_line]
   let l:length = min([strchars(l:old_line), strchars(l:new_line)])
   let l:j = 0
+  let l:offset = 0
   while l:j < l:length
-    if strgetchar(l:old_line, l:j) != strgetchar(l:new_line, l:j) | break | endif
+    if strgetchar(l:old_line, l:j) != strgetchar(l:new_line, l:j)
+      break
+    endif
+    let l:offset += lsp#utils#count_utf16_code_units(nr2char(strgetchar(l:old_line, l:j)))
     let l:j += 1
   endwhile
-  return [l:i, l:j]
+  return [l:first_diff_line, l:j, l:offset]
 endfunction
 
-function! s:LastDifference(old, new, start_char) abort
-  let l:line_count = min([len(a:old), len(a:new)])
-  if l:line_count == 0 | return [0, 0] | endif
-  let l:i = -1
-  while l:i >= -1 * l:line_count
-    if a:old[l:i] !=# a:new[l:i] | break | endif
-    let l:i -= 1
-  endwhile
-  if l:i <= -1 * l:line_count
-    let l:i = -1 * l:line_count
-    let l:old_line = strcharpart(a:old[l:i], a:start_char)
-    let l:new_line = strcharpart(a:new[l:i], a:start_char)
-  else
-    let l:old_line = a:old[l:i]
-    let l:new_line = a:new[l:i]
+" Find last difference position
+" It returns array
+" 0 - -1 based line index, -1 is last line.
+" 1 - -1 based char index, -1 is last character. it is not exclusive.
+" 2 - 0 based utf16 code unit, 0 is first character. is is exclusive.
+"
+" @see https://github.com/Microsoft/language-server-protocol/blob/gh-pages/specification.md#range
+function! lsp#utils#diff#last_difference(old, new, start_char, start_offset) abort
+  if len(a:old) == 0
+    return [-1, -1, 0]
   endif
+  if len(a:new) == 0
+    return [-1, -1, lsp#utils#count_utf16_code_units(a:old[-1])]
+  endif
+
+  let l:line_count = min([len(a:old), len(a:new)])
+  let l:last_diff_line = -1
+  while l:last_diff_line >= -1 * l:line_count
+    if a:old[l:last_diff_line] !=# a:new[l:last_diff_line] | break | endif
+    let l:last_diff_line -= 1
+  endwhile
+
+  let l:start_offset = a:start_offset
+  if l:last_diff_line <= -1 * l:line_count
+    let l:last_diff_line = -1 * l:line_count
+    let l:old_line = strcharpart(a:old[l:last_diff_line], a:start_char)
+    let l:new_line = strcharpart(a:new[l:last_diff_line], a:start_char)
+  else
+    let l:old_line = a:old[l:last_diff_line]
+    let l:new_line = a:new[l:last_diff_line]
+    let l:start_offset = 0
+  endif
+
   let l:old_line_length = strchars(l:old_line)
   let l:new_line_length = strchars(l:new_line)
   let l:length = min([l:old_line_length, l:new_line_length])
+
   let l:j = -1
+  let l:offset = 0
   while l:j >= -1 * l:length
-    if  strgetchar(l:old_line, l:old_line_length + l:j) !=
-        \ strgetchar(l:new_line, l:new_line_length + l:j)
+    if strgetchar(l:old_line, l:old_line_length + l:j) != strgetchar(l:new_line, l:new_line_length + l:j)
       break
     endif
+    let l:offset += lsp#utils#count_utf16_code_units(nr2char(strgetchar(l:old_line, l:old_line_length + l:j)))
     let l:j -= 1
   endwhile
-  return [l:i, l:j]
+
+  return [l:last_diff_line, l:j, (lsp#utils#count_utf16_code_units(l:old_line) - l:offset) + l:start_offset]
 endfunction
 
-function! s:ExtractText(lines, start_line, start_char, end_line, end_char) abort
-  if a:start_line == len(a:lines) + a:end_line
-    if a:end_line == 0 | return '' | endif
-    let l:line = a:lines[a:start_line]
-    let l:length = strchars(l:line) + a:end_char - a:start_char + 1
-    return strcharpart(l:line, a:start_char, l:length)
+function! lsp#utils#diff#extract_text(new_lines, start_line, start_char, end_line, end_char) abort
+  if len(a:new_lines) == 0
+     return ''
   endif
-  let l:result = strcharpart(a:lines[a:start_line], a:start_char) . "\n"
-  for l:line in a:lines[a:start_line + 1:a:end_line - 1]
+
+  let l:adj_end_line = len(a:new_lines) + a:end_line
+
+  if a:start_line == l:adj_end_line
+    let l:line = a:new_lines[a:start_line]
+    let l:adj_end_char = (strchars(l:line) + a:end_char) + 1
+    return strcharpart(l:line, a:start_char, l:adj_end_char - a:start_char)
+  endif
+
+  let l:result = strcharpart(a:new_lines[a:start_line], a:start_char) . "\n"
+  for l:line in a:new_lines[a:start_line + 1 : a:end_line - 1]
     let l:result .= l:line . "\n"
   endfor
   if a:end_line != 0
-    let l:line = a:lines[a:end_line]
+    let l:line = a:new_lines[a:end_line]
     let l:length = strchars(l:line) + a:end_char + 1
     let l:result .= strcharpart(l:line, 0, l:length)
   endif
   return l:result
 endfunction
 
-function! s:Length(lines, start_line, start_char, end_line, end_char) abort
-  let l:adj_end_line = len(a:lines) + a:end_line
-  if l:adj_end_line >= len(a:lines)
-    let l:adj_end_char = a:end_char - 1
+function! lsp#utils#diff#length(old_lines, start_line, start_char, end_line, end_char) abort
+  if len(a:old_lines) == 0
+     return 0
+  endif
+
+  let l:adj_end_line = len(a:old_lines) + a:end_line
+  if l:adj_end_line >= len(a:old_lines)
+    let l:adj_end_char = a:end_char + 1
   else
-    let l:adj_end_char = strchars(a:lines[l:adj_end_line]) + a:end_char
+    let l:adj_end_char = strchars(a:old_lines[l:adj_end_line]) + a:end_char + 1
   endif
+
   if a:start_line == l:adj_end_line
-    return l:adj_end_char - a:start_char + 1
+    return lsp#utils#count_utf16_code_units(strcharpart(a:old_lines[a:start_line], a:start_char, l:adj_end_char - a:start_char))
   endif
-  let l:result = strchars(a:lines[a:start_line]) - a:start_char + 1
-  let l:line = a:start_line + 1
-  while l:line < l:adj_end_line
-    let l:result += strchars(a:lines[l:line]) + 1
-    let l:line += 1
-  endwhile
-  let l:result += l:adj_end_char + 1
+
+  let l:result = lsp#utils#count_utf16_code_units(strcharpart(a:old_lines[a:start_line], a:start_char)) + 1
+  for l:line in a:old_lines[a:start_line + 1 : l:adj_end_line - 1]
+    let l:result += lsp#utils#count_utf16_code_units(l:line) + 1
+  endfor
+  let l:result += lsp#utils#count_utf16_code_units(strcharpart(a:old_lines[l:adj_end_line], 0, l:adj_end_char))
   return l:result
 endfunction
+

--- a/test/lsp/utils/diff.vimspec
+++ b/test/lsp/utils/diff.vimspec
@@ -1,4 +1,313 @@
 Describe lsp#utils#diff
+    Describe lsp#utils#diff#first_difference
+        It should return first difference when all new text
+            let lines1 = [
+            \]
+            let lines2 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [0, 0, 0])
+        End
+
+        It should return first difference when remove all text
+            let lines1 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [0, 0, 0])
+        End
+
+        It should return first difference when changed first line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [0, 2, 3])
+        End
+
+        It should return first difference when changed second line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bAr',
+            \  'ä𐐀baz',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [1, 3, 4])
+        End
+
+        It should return first difference when changed last line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baZ',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [2, 4, 5])
+        End
+
+        It should return first difference when append part of text
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bara',
+            \  'ä𐐀baz',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [1, 5, 6])
+        End
+
+        It should return first difference when remove part of text
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀ba',
+            \  'ä𐐀baz',
+            \]
+            Assert Equals(lsp#utils#diff#first_difference(lines1, lines2),
+                        \ [1, 4, 5])
+        End
+    End
+
+    Describe lsp#utils#diff#last_difference
+        It should return last difference when all new text
+            let lines1 = [
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            Assert Equals(lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2]),
+                        \ [-1, -1, 0])
+        End
+
+        It should return last difference when remove all text
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            Assert Equals(lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2]),
+                        \ [-1, -1, 6])
+        End
+
+        It should return last difference when changed first line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀𐐀oo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            Assert Equals(lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2]),
+                        \ [-3, -3, 4])
+        End
+
+        It should return last difference when changed second line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀baR',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            Assert Equals(lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2]),
+                        \ [-2, -1, 6])
+        End
+
+        It should return last difference when changed last line character
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baZ',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            Assert Equals(lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2]),
+                        \ [-1, -1, 6])
+        End
+    End
+
+    Describe lsp#utils#diff#extract_text
+        It should return difference text when change one character in first line
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀𐐀oo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#extract_text(lines2, first[0], first[1], last[0], last[1]),
+                        \ join([
+                        \   '𐐀'
+                        \ ], "\n"))
+        End
+
+        It should return difference text when change one character in second line
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀baR',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#extract_text(lines2, first[0], first[1], last[0], last[1]),
+                        \ join([
+                        \   'R'
+                        \ ], "\n"))
+        End
+
+        It should return difference text when change one character in last line
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baZ',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#extract_text(lines2, first[0], first[1], last[0], last[1]),
+                        \ join([
+                        \   'Z'
+                        \ ], "\n"))
+        End
+
+        It should return difference text when change range of text
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baZ',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#extract_text(lines2, first[0], first[1], last[0], last[1]),
+                        \ join([
+                        \   'Foo',
+                        \  'ä𐐀bar',
+                        \  'ä𐐀baZ',
+                        \ ], "\n"))
+        End
+    End
+
+    Describe lsp#utils#diff#length
+        It should return modified length when first line changed
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#length(lines1, first[0], first[1], last[0], last[1]),
+                        \ 1)
+        End
+
+        It should return modified length when multibyte changed
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'äafoo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#length(lines1, first[0], first[1], last[0], last[1]),
+                        \ 2)
+        End
+
+        It should return modified length when range changed
+            let lines1 = [
+            \  'ä𐐀foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baz',
+            \]
+            let lines2 = [
+            \  'ä𐐀Foo',
+            \  'ä𐐀bar',
+            \  'ä𐐀baZ',
+            \]
+            let first = lsp#utils#diff#first_difference(lines1, lines2)
+            let last = lsp#utils#diff#last_difference(lines1, lines2, first[1], first[2])
+            Assert Equals(lsp#utils#diff#length(lines1, first[0], first[1], last[0], last[1]),
+                        \ 17)
+        End
+    End
 
     Describe lsp#utils#diff#compute
         It should return diff of one letter
@@ -59,7 +368,7 @@ Describe lsp#utils#diff
             \    'start': { 'line': 0, 'character': 0 },
             \    'end': { 'line': 0, 'character': 0, }
             \  },
-            \  'text': "foo\nbar\nbaz\n",
+            \  'text': "foo\nbar\nbaz",
             \  "rangeLength": 0
             \}
             let got = lsp#utils#diff#compute(lines1, lines2)
@@ -74,10 +383,46 @@ Describe lsp#utils#diff
             let want = {
             \  'range': {
             \    'start': { 'line': 0, 'character': 0 },
-            \    'end': { 'line': 3, 'character': 0, }
+            \    'end': { 'line': 2, 'character': 3, }
             \  },
             \  'text': '',
-            \  "rangeLength": 12
+            \  "rangeLength": 11
+            \}
+            let got = lsp#utils#diff#compute(lines1, lines2)
+            Assert Equals(got, want)
+        End
+
+        It should return diff familier with utf-16 surrogate pairs
+            let lines1 = [
+            \  'foo',
+            \]
+            let lines2 = [
+            \  'f𐐀o',
+            \]
+            let want = {
+            \  'range': {
+            \    'start': { 'line': 0, 'character': 1 },
+            \    'end': { 'line': 0, 'character': 2 }
+            \  },
+            \  'text': '𐐀',
+            \  "rangeLength": 1
+            \}
+            let got = lsp#utils#diff#compute(lines1, lines2)
+            Assert Equals(got, want)
+
+            let lines1 = [
+            \  'f𐐀o',
+            \]
+            let lines2 = [
+            \  'foo',
+            \]
+            let want = {
+            \  'range': {
+            \    'start': { 'line': 0, 'character': 1 },
+            \    'end': { 'line': 0, 'character': 3 }
+            \  },
+            \  'text': 'o',
+            \  "rangeLength": 2
             \}
             let got = lsp#utils#diff#compute(lines1, lines2)
             Assert Equals(got, want)


### PR DESCRIPTION
I tried to support utf16 character position.

Currently, It used to get position of diff or column (Sorry, highlight positioning is not support now).

In my environment, I checked below case and works well.

1. open empty ts file.
```ts
```

2. add character that is 2 code units.
```ts
const obj = { '𐐀': [] as string[] };
obj['𐐀'].#
```
※ `#` is cursor position.

3. should be display right completion results.
- `reduce`, `forEach` etc...

4. And remove all lines.

This use mattn's utf16 code units counting function.

Thanks mattn.