### PR TITLE
[WIP] Refactor workspace and document symbol functions

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -281,56 +281,6 @@ function! lsp#ui#vim#document_range_format() abort
     return s:document_format_range(0)
 endfunction
 
-function! lsp#ui#vim#workspace_symbol() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
-    let s:last_req_id = s:last_req_id + 1
-
-    call setqflist([])
-
-    if len(l:servers) == 0
-        call s:not_supported('Retrieving workspace symbols')
-        return
-    endif
-
-    let l:query = input('query>')
-
-    for l:server in l:servers
-        call lsp#send_request(l:server, {
-            \ 'method': 'workspace/symbol',
-            \ 'params': {
-            \   'query': l:query,
-            \ },
-            \ 'on_notification': function('s:handle_symbol', [l:server, s:last_req_id, 'workspaceSymbol']),
-            \ })
-    endfor
-
-    echo 'Retrieving workspace symbols ...'
-endfunction
-
-function! lsp#ui#vim#document_symbol() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
-    let s:last_req_id = s:last_req_id + 1
-
-    call setqflist([])
-
-    if len(l:servers) == 0
-        call s:not_supported('Retrieving symbols')
-        return
-    endif
-
-    for l:server in l:servers
-        call lsp#send_request(l:server, {
-            \ 'method': 'textDocument/documentSymbol',
-            \ 'params': {
-            \   'textDocument': lsp#get_text_document_identifier(),
-            \ },
-            \ 'on_notification': function('s:handle_symbol', [l:server, s:last_req_id, 'documentSymbol']),
-            \ })
-    endfor
-
-    echo 'Retrieving document symbols ...'
-endfunction
-
 " Returns currently selected range. If nothing is selected, returns empty
 " dictionary.
 "
@@ -396,26 +346,108 @@ function! lsp#ui#vim#code_action() abort
     echo 'Retrieving code actions ...'
 endfunction
 
+" Send request with the 'workspace/symbol' method.
+" The server responds with SymbolInformation[] or null.
+"
+" Documentation
+" - https://microsoft.github.io/language-server-protocol/specification#workspace_symbol
+function! lsp#ui#vim#workspace_symbol() abort
+    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
+
+    let s:last_req_id = s:last_req_id + 1
+
+    if len(l:servers) == 0
+        call s:not_supported('Retrieving workspace symbols')
+        return
+    endif
+
+    let l:query = input('query>')
+
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'workspace/symbol',
+            \ 'params': {
+            \   'query': l:query,
+            \ },
+            \ 'on_notification': function('s:handle_symbol', [l:server, s:last_req_id, 'workspaceSymbol']),
+            \ })
+    endfor
+
+    echo 'Retrieving workspace symbols ...'
+endfunction
+
+" Send request with the 'textDocument/documentSymbol' method.
+" The server responds with DocumentSymbol[], SymbolInformation[] or null.
+"
+" Documentation
+" - https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
+function! lsp#ui#vim#document_symbol() abort
+    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
+
+    let s:last_req_id = s:last_req_id + 1
+
+    if len(l:servers) == 0
+        call s:not_supported('Retrieving document symbols')
+        return
+    endif
+
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'textDocument/documentSymbol',
+            \ 'params': {
+            \   'textDocument': lsp#get_text_document_identifier(),
+            \ },
+            \ 'on_notification': function('s:handle_symbol', [l:server, s:last_req_id, 'documentSymbol']),
+            \ })
+    endfor
+
+    echo 'Retrieving document symbols ...'
+endfunction
+
+" Handles the response of the 'workspace/symbol' and
+" 'textDocument/documentSymbol' methods.
+"
+" Documentation
+" - https://microsoft.github.io/language-server-protocol/specification#workspace_symbol
+" - https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
 function! s:handle_symbol(server, last_req_id, type, data) abort
+    " Ignore old requests
     if a:last_req_id != s:last_req_id
         return
     endif
 
+    " Check if the server responded, if not with an error
     if lsp#client#is_error(a:data['response'])
         call lsp#utils#error('Failed to retrieve '. a:type . ' for ' . a:server . ': ' . lsp#client#error_message(a:data['response']))
         return
     endif
 
-    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:data)
+    " This member does not exist if there was an error invoking the method
+    if !has_key(a:data['response'], 'result')
+        return
+    endif
+
+    " Dictionary to contain all symbols
+    let l:symbols = a:data['response']['result']
+
+    " No symbols available
+    " - v:null
+    " - []
+    if empty(l:symbols)
+        call lsp#utils#error('No ' . a:type .' found')
+        return
+    endif
+
+    " Convert symbols to location list
+    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(l:symbols)
 
     call setqflist(l:list)
 
-    if empty(l:list)
-        call lsp#utils#error('No ' . a:type .' found')
-    else
-        echo 'Retrieved ' . a:type
-        botright copen
-    endif
+    echo 'Retrieved ' . a:type
+
+    " Open the symbol list at the bottom and occupy the full width of the Vim
+    " window
+    botright copen
 endfunction
 
 function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list, jump_if_one, last_req_id, in_preview}

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -63,32 +63,31 @@ let s:diagnostic_severity = {
     \ 4: 'Hint',
     \ }
 
-function! lsp#ui#vim#utils#symbols_to_loc_list(result) abort
-    if !has_key(a:result['response'], 'result')
-        return []
-    endif
-
+" Convert symbols to location list.
+function! lsp#ui#vim#utils#symbols_to_loc_list(symbols) abort
     let l:list = []
 
-    let l:locations = type(a:result['response']['result']) == type({}) ? [a:result['response']['result']] : a:result['response']['result']
+    " Iterate over symbols
+    for l:symbol in a:symbols
+        let l:location = l:symbol['location']
 
-    if !empty(l:locations) " some servers also return null so check to make sure it isn't empty
-        for l:symbol in a:result['response']['result']
-            let l:location = l:symbol['location']
-            if s:is_file_uri(l:location['uri'])
-                let l:path = lsp#utils#uri_to_path(l:location['uri'])
-                let l:bufnr = bufnr(l:path)
-                let l:line = l:location['range']['start']['line'] + 1
-                let l:col = l:location['range']['start']['character'] + 1
-                call add(l:list, {
-                    \ 'filename': l:path,
-                    \ 'lnum': l:line,
-                    \ 'col': l:col,
-                    \ 'text': s:get_symbol_text_from_kind(l:symbol['kind']) . ' : ' . l:symbol['name'],
-                    \ })
-            endif
-        endfor
-    endif
+        if s:is_file_uri(l:location['uri'])
+            let l:path = lsp#utils#uri_to_path(l:location['uri'])
+
+            let l:bufnr = bufnr(l:path)
+
+            let l:line = l:location['range']['start']['line'] + 1
+
+            let l:col = l:location['range']['start']['character'] + 1
+
+            call add(l:list, {
+                \ 'filename': l:path,
+                \ 'lnum': l:line,
+                \ 'col': l:col,
+                \ 'text': s:get_symbol_text_from_kind(l:symbol['kind']) . ' : ' . l:symbol['name'],
+                \ })
+        endif
+    endfor
 
     return l:list
 endfunction


### PR DESCRIPTION
I refactored the functions `lsp#ui#vim#workspace_symbol`, `lsp#ui#document_symbol`, `s:handle_symbol` and `lsp#ui#vim#utils#symbols_to_loc_list`.

1. I moved the functions closer to each other in the file
2. I made `s:handle_symbol` extract the symbols for the response. This results in actually feeding `lsp#ui#vim#utils#symbols_to_loc_list` a list of symbols as argument, instead of the server response.
3. The specification tells us that the response will always be a list or null. This enables us to remove the original checks in `s:handle_symbol`.