### PR TITLE
Refactor workspace and document symbol functions

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -63,32 +63,28 @@ let s:diagnostic_severity = {
     \ 4: 'Hint',
     \ }
 
-function! lsp#ui#vim#utils#symbols_to_loc_list(result) abort
-    if !has_key(a:result['response'], 'result')
-        return []
-    endif
-
+" Convert symbols to location list.
+function! lsp#ui#vim#utils#symbols_to_loc_list(symbols) abort
     let l:list = []
 
-    let l:locations = type(a:result['response']['result']) == type({}) ? [a:result['response']['result']] : a:result['response']['result']
+    " Iterate over symbols
+    for l:symbol in a:symbols
+        let l:location = l:symbol['location']
 
-    if !empty(l:locations) " some servers also return null so check to make sure it isn't empty
-        for l:symbol in a:result['response']['result']
-            let l:location = l:symbol['location']
-            if s:is_file_uri(l:location['uri'])
-                let l:path = lsp#utils#uri_to_path(l:location['uri'])
-                let l:bufnr = bufnr(l:path)
-                let l:line = l:location['range']['start']['line'] + 1
-                let l:col = l:location['range']['start']['character'] + 1
-                call add(l:list, {
-                    \ 'filename': l:path,
-                    \ 'lnum': l:line,
-                    \ 'col': l:col,
-                    \ 'text': s:get_symbol_text_from_kind(l:symbol['kind']) . ' : ' . l:symbol['name'],
-                    \ })
-            endif
-        endfor
-    endif
+        if s:is_file_uri(l:location['uri'])
+            let l:path = lsp#utils#uri_to_path(l:location['uri'])
+            let l:bufnr = bufnr(l:path)
+            let l:line = l:location['range']['start']['line'] + 1
+            let l:col = l:location['range']['start']['character'] + 1
+
+            call add(l:list, {
+                \ 'filename': l:path,
+                \ 'lnum': l:line,
+                \ 'col': l:col,
+                \ 'text': s:get_symbol_text_from_kind(l:symbol['kind']) . ' : ' . l:symbol['name'],
+                \ })
+        endif
+    endfor
 
     return l:list
 endfunction


### PR DESCRIPTION
I refactored the functions `lsp#ui#vim#workspace_symbol`, `lsp#ui#document_symbol`, `s:handle_symbol` and `lsp#ui#vim#utils#symbols_to_loc_list`.

- I made `s:handle_symbol` extract the symbols for the response. This results in actually feeding `lsp#ui#vim#utils#symbols_to_loc_list` a list of symbols as argument, instead of the server response.
- The specification tells us that the response will always be a list or null. This enables us to remove the original checks in `s:handle_symbol`.