### PR TITLE
Cygwin code actions

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -178,7 +178,6 @@ function! s:generate_sub_cmd_insert(text_edit) abort
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>P"
     endif
 
-    echomsg "RETURNING " . l:sub_cmd
     return l:sub_cmd
 endfunction
 

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -70,6 +70,7 @@ function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
 
             set virtualedit=onemore
 
+            let g:var=l:merged_text_edit['merged']['newText']
             silent execute l:cmd
         finally
             let &paste = l:was_paste
@@ -165,7 +166,11 @@ function! s:generate_sub_cmd_insert(text_edit) abort
     let l:new_text = s:parse(a:text_edit['newText'])
 
     let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
-    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
+    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line - 1, l:start_character)
+
+    if has('win32unix')
+      l:merged_text_edit['merged']['newText'] = substitute(l:merged_text_edit['merged']['newText'], '\r', '', 'g')
+    endif
 
     if l:start_character >= len(getline(l:start_line))
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -166,18 +166,19 @@ function! s:generate_sub_cmd_insert(text_edit) abort
     let l:new_text = s:parse(a:text_edit['newText'])
 
     let l:sub_cmd = s:preprocess_cmd(a:text_edit['range'])
-    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line - 1, l:start_character)
+    let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
 
     if has('win32unix')
-      l:merged_text_edit['merged']['newText'] = substitute(l:merged_text_edit['merged']['newText'], '\r', '', 'g')
+      let l:merged_text_edit['merged']['newText'] = substitute(l:merged_text_edit['merged']['newText'], '\r', '', 'g')
     endif
 
-    if l:start_character >= len(getline(l:start_line))
+    if l:start_character >= len(getline(l:start_line)) && getline(l:start_line) != ''
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"
     else
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>P"
     endif
 
+    echomsg "RETURNING " . l:sub_cmd
     return l:sub_cmd
 endfunction
 


### PR DESCRIPTION
In cygwin, the code actions will have unix ending line. This pull requests removes those. 

Also, when doing imports in typescript, if it's a new import (not adding to an existing list of imports), the cursor will lang usually on an empty line. For example, let's say I have this code:

```
import {m1, m2, m3} from 'first-module';

class MyClass {
  public prop: NewType;
}
```

Notice the empty line between the last import and the class. Now, if we put the cursor on top of `NewType` and we call `LspCodeActions`, assuming that `NewType` is part of `second-module`, the cursor initially would land on second empty line. There, doing `p` and not `P` will paste the new content under the empty line, resulting in this:

```
import {m1, m2, m3} from 'first-module';

import {NewType} from 'second-module';
class MyClass
...
```

This is why I have the second check, and if the landing line is an empty line, is better to do a `P`, rather than a `p`. Then, we would land in this situation, which is desirable in my opinion:

```
import {m1, m2, m3} from 'first-module';
import {NewType} from 'second-module';

class MyClass
...
```