### PR TITLE
Fix unable to jump unloaded buffer

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -15,17 +15,18 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
                 let l:line = l:location['range']['start']['line'] + 1
                 let l:col = l:location['range']['start']['character'] + 1
                 let l:index = l:line - 1
-                let l:bufnr = bufnr(l:path)
 
                 if has_key(l:cache, l:path)
                     let l:text = l:cache[l:path][l:index]
-                elseif l:bufnr >= 0 && !empty(getbufline(l:bufnr, 1, 2))
-                    let l:contents = getbufline(l:bufnr, 1, '$')
-                    let l:text = l:contents[l:index]
                 else
-                    let l:contents = readfile(l:path)
-                    let l:cache[l:path] = l:contents
-                    let l:text = l:contents[l:index]
+                    let l:contents = getbufline(l:path, 1, '$')
+                    if !empty(l:contents)
+                        let l:text = l:contents[l:index]
+                    else
+                        let l:contents = readfile(l:path)
+                        let l:cache[l:path] = l:contents
+                        let l:text = l:contents[l:index]
+                    endif
                 endif
                 call add(l:list, {
                     \ 'filename': l:path,

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -19,7 +19,7 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
 
                 if has_key(l:cache, l:path)
                     let l:text = l:cache[l:path][l:index]
-                elseif l:bufnr >= 0
+                elseif l:bufnr >= 0 && !empty(getbufline(l:bufnr, 1, 2))
                     let l:contents = getbufline(l:bufnr, 1, '$')
                     let l:text = l:contents[l:index]
                 else


### PR DESCRIPTION
Hello, I'm using vim-lsp with clangd, I get this error when use `LspDefinition`

```
Thu Aug 22 22:53:32 2019:["<---",1,"clangd",{"response":{"id":68,"jsonrpc":"2.0","result":[{"uri":"file:///Users/weicheng/playground/leveldb/include/leveldb/db.h","range":{"end":{"character":23,"line":45},"start":{"character":21,"line":45}}}]},"request":{"id":68,"jsonrpc":"2.0","method":"textDocument/definition","params":{"textDocument":{"uri":"file:///Users/weicheng/playground/leveldb/db/db_impl.h"},"position":{"character":22,"line":28}}}}]
Thu Aug 22 22:53:32 2019:["s:on_stdout client request on_notification() error","Vim(let):E684: list index out of range: 45","function <SNR>80_out_cb[2]..<SNR>79_on_stdout[79]..<lambda>615[1]..<SNR>91_handle_location[10]..lsp#ui#vim#utils#locations_to_loc_list, line 23"]
```

This seems to be because vim function `getbufline` only work for loaded buffers, but `bufnr` work with unloaded buffer, when `bufnr` return a unloaded buffer will make this error.