### PR TITLE
Update SymbolKind to latest specification

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -62,11 +62,11 @@ let s:symbol_kinds = {
     \ '19': 'object',
     \ '20': 'key',
     \ '21': 'null',    
-    \ '22': 'enumMember',    
+    \ '22': 'enum member',    
     \ '23': 'struct',    
     \ '24': 'event',    
     \ '25': 'operator',    
-    \ '26': 'typeParameter',    
+    \ '26': 'type parameter',    
     \ }
 
 let s:diagnostic_severity = {

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -59,6 +59,14 @@ let s:symbol_kinds = {
     \ '16': 'number',
     \ '17': 'boolean',
     \ '18': 'array',
+    \ '19': 'object',
+    \ '20': 'key',
+    \ '21': 'null',    
+    \ '22': 'enumMember',    
+    \ '23': 'struct',    
+    \ '24': 'event',    
+    \ '25': 'operator',    
+    \ '26': 'typeParameter',    
     \ }
 
 let s:diagnostic_severity = {


### PR DESCRIPTION
closes #477

(Fields start with uppercase in specification but in lowercase in the vim-lsp enum; I haven't changed that. Note that two new fields are in camel case: `enumMember` and `typeParameter`; the first looks strange in all lowercase, so I also changed the second for consistency.)