### PR TITLE
Support more document symbol kinds

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -59,6 +59,14 @@ let s:symbol_kinds = {
     \ '16': 'number',
     \ '17': 'boolean',
     \ '18': 'array',
+    \ '19': 'object',
+    \ '20': 'key',
+    \ '21': 'null',
+    \ '22': 'enum member',
+    \ '23': 'struct',
+    \ '24': 'event',
+    \ '25': 'operator',
+    \ '26': 'type parameter',
     \ }
 
 let s:diagnostic_severity = {


### PR DESCRIPTION
Include additional symbol kinds defined by LSP 3 for `textDocument/documentSymbol`. See https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol