### PR TITLE
Use locationLink for definition preview

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -390,7 +390,16 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \              'valueSet': lsp#omni#get_completion_item_kinds()
     \           }
     \       },
+    \       'declaration': {
+    \           'linkSupport' : v:true
+    \       },
     \       'definition': {
+    \           'linkSupport' : v:true
+    \       },
+    \       'typeDefinition': {
+    \           'linkSupport' : v:true
+    \       },
+    \       'implementation': {
     \           'linkSupport' : v:true
     \       },
     \       'documentSymbol': {

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -390,6 +390,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \              'valueSet': lsp#omni#get_completion_item_kinds()
     \           }
     \       },
+    \       'definition': {
+    \           'linkSupport' : v:true
+    \       },
     \       'documentSymbol': {
     \           'symbolKind': {
     \              'valueSet': lsp#ui#vim#utils#get_symbol_kinds()

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -488,10 +488,8 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 botright copen
             else
                 if has_key(l:loc,'viewstart') " locationLink
-                    let l:viewstart = l:loc['viewstart']
-                    let l:viewend = l:loc['viewend']
                     let l:lines = readfile(fnameescape(l:loc['filename']))
-                    let l:view = l:lines[l:viewstart : l:viewend]
+                    let l:view = l:lines[l:loc['viewstart'] : l:loc['viewend']]
                     call lsp#ui#vim#output#preview(a:server, l:view, {
                                 \   'statusline': ' LSP Peek ' . a:type,
                                 \   'filetype': &filetype

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -488,10 +488,11 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 botright copen
             else
                 if has_key(l:loc,'viewstart') " locationLink
-                    let viewstart = l:loc['viewstart']
-                    let viewend = l:loc['viewend']
+                    let l:viewstart = l:loc['viewstart']
+                    let l:viewend = l:loc['viewend']
                     let l:lines = readfile(fnameescape(l:loc['filename']))
-                    call lsp#ui#vim#output#preview(a:server, l:lines[viewstart:viewend], {
+                    let l:view = l:lines[l:viewstart : l:viewend]
+                    call lsp#ui#vim#output#preview(a:server, l:view, {
                                 \   'statusline': ' LSP Peek ' . a:type,
                                 \   'filetype': &filetype
                                 \ })

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -487,15 +487,14 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 echo 'Retrieved ' . a:type
                 botright copen
             else
-                if has_key(l:loc,'viewstart') " locationLink
-                    let l:lines = readfile(fnameescape(l:loc['filename']))
+                let l:lines = readfile(fnameescape(l:loc['filename']))
+                if has_key(l:loc,'viewstart') " showing a locationLink
                     let l:view = l:lines[l:loc['viewstart'] : l:loc['viewend']]
                     call lsp#ui#vim#output#preview(a:server, l:view, {
                                 \   'statusline': ' LSP Peek ' . a:type,
                                 \   'filetype': &filetype
                                 \ })
-                else
-                    let l:lines = readfile(fnameescape(l:loc['filename']))
+                else " showing a location
                     call lsp#ui#vim#output#preview(a:server, l:lines, {
                                 \   'statusline': ' LSP Peek ' . a:type,
                                 \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -487,12 +487,23 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 echo 'Retrieved ' . a:type
                 botright copen
             else
-                let l:lines = readfile(fnameescape(l:loc['filename']))
-                call lsp#ui#vim#output#preview(a:server, l:lines, {
-                            \   'statusline': ' LSP Peek ' . a:type,
-                            \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },
-                            \   'filetype': &filetype
-                            \ })
+                if has_key(l:loc,'viewstart') " locationLink
+                    let viewstart = l:loc['viewstart']
+                    let viewend = l:loc['viewend']
+                    let l:lines = readfile(fnameescape(l:loc['filename']))
+                    call lsp#ui#vim#output#preview(a:server, l:lines[viewstart:viewend], {
+                                \   'statusline': ' LSP Peek ' . a:type,
+                                \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },
+                                \   'filetype': &filetype
+                                \ })
+                else
+                    let l:lines = readfile(fnameescape(l:loc['filename']))
+                    call lsp#ui#vim#output#preview(a:server, l:lines, {
+                                \   'statusline': ' LSP Peek ' . a:type,
+                                \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },
+                                \   'filetype': &filetype
+                                \ })
+                endif
             endif
         endif
     endif

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -493,7 +493,6 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                     let l:lines = readfile(fnameescape(l:loc['filename']))
                     call lsp#ui#vim#output#preview(a:server, l:lines[viewstart:viewend], {
                                 \   'statusline': ' LSP Peek ' . a:type,
-                                \   'cursor': { 'line': l:loc['lnum'], 'col': l:loc['col'], 'align': g:lsp_peek_alignment },
                                 \   'filetype': &filetype
                                 \ })
                 else

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -20,42 +20,44 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
     if !empty(l:locations) " some servers also return null so check to make sure it isn't empty
         let l:cache={}
         for l:location in l:locations
-            let l:path = lsp#utils#uri_to_path(l:location[l:uri])
-            let l:line = l:location[l:range]['start']['line'] + 1
-            let l:char = l:location[l:range]['start']['character']
-            let l:col = lsp#utils#to_col(l:path, l:line, l:char)
+            if s:is_file_uri(l:location[l:uri])
+                let l:path = lsp#utils#uri_to_path(l:location[l:uri])
+                let l:line = l:location[l:range]['start']['line'] + 1
+                let l:char = l:location[l:range]['start']['character']
+                let l:col = lsp#utils#to_col(l:path, l:line, l:char)
 
-            let l:index = l:line - 1
-            if has_key(l:cache, l:path)
-                let l:text = l:cache[l:path][l:index]
-            else
-                let l:contents = getbufline(l:path, 1, '$')
-                if !empty(l:contents)
-                    let l:text = l:contents[l:index]
+                let l:index = l:line - 1
+                if has_key(l:cache, l:path)
+                    let l:text = l:cache[l:path][l:index]
                 else
-                    let l:contents = readfile(l:path)
-                    let l:cache[l:path] = l:contents
-                    let l:text = l:contents[l:index]
+                    let l:contents = getbufline(l:path, 1, '$')
+                    if !empty(l:contents)
+                        let l:text = l:contents[l:index]
+                    else
+                        let l:contents = readfile(l:path)
+                        let l:cache[l:path] = l:contents
+                        let l:text = l:contents[l:index]
+                    endif
                 endif
-            endif
-            if l:use_link
-                let l:viewstart = l:location['targetRange']['start']['line']
-                let l:viewend = l:location['targetRange']['end']['line'] 
-                call add(l:list, {
-                            \ 'filename': l:path,
-                            \ 'lnum': l:line,
-                            \ 'col': l:col,
-                            \ 'text': l:text,
-                            \ 'viewstart': l:viewstart,
-                            \ 'viewend': l:viewend
-                            \ })
-            else
-                call add(l:list, {
-                            \ 'filename': l:path,
-                            \ 'lnum': l:line,
-                            \ 'col': l:col,
-                            \ 'text': l:text,
-                            \ })
+                if l:use_link
+                    let l:viewstart = l:location['targetRange']['start']['line']
+                    let l:viewend = l:location['targetRange']['end']['line'] 
+                    call add(l:list, {
+                                \ 'filename': l:path,
+                                \ 'lnum': l:line,
+                                \ 'col': l:col,
+                                \ 'text': l:text,
+                                \ 'viewstart': l:viewstart,
+                                \ 'viewend': l:viewend
+                                \ })
+                else
+                    call add(l:list, {
+                                \ 'filename': l:path,
+                                \ 'lnum': l:line,
+                                \ 'col': l:col,
+                                \ 'text': l:text,
+                                \ })
+                endif
             endif
         endfor
     endif

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -9,34 +9,69 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
 
     if !empty(l:locations) " some servers also return null so check to make sure it isn't empty
         let l:cache={}
-        for l:location in l:locations
-            if s:is_file_uri(l:location['uri'])
-                let l:path = lsp#utils#uri_to_path(l:location['uri'])
-                let l:line = l:location['range']['start']['line'] + 1
-                let l:char = l:location['range']['start']['character']
-                let l:col = lsp#utils#to_col(l:path, l:line, l:char)
-                let l:index = l:line - 1
+        if has_key(l:locations[0],'uri') " server returns Locations
+            for l:location in l:locations
+                if s:is_file_uri(l:location['uri'])
+                    let l:path = lsp#utils#uri_to_path(l:location['uri'])
+                    let l:line = l:location['range']['start']['line'] + 1
+                    let l:char = l:location['range']['start']['character']
+                    let l:col = lsp#utils#to_col(l:path, l:line, l:char)
+                    let l:index = l:line - 1
 
-                if has_key(l:cache, l:path)
-                    let l:text = l:cache[l:path][l:index]
-                else
-                    let l:contents = getbufline(l:path, 1, '$')
-                    if !empty(l:contents)
-                        let l:text = l:contents[l:index]
+                    if has_key(l:cache, l:path)
+                        let l:text = l:cache[l:path][l:index]
                     else
-                        let l:contents = readfile(l:path)
-                        let l:cache[l:path] = l:contents
-                        let l:text = l:contents[l:index]
+                        let l:contents = getbufline(l:path, 1, '$')
+                        if !empty(l:contents)
+                            let l:text = l:contents[l:index]
+                        else
+                            let l:contents = readfile(l:path)
+                            let l:cache[l:path] = l:contents
+                            let l:text = l:contents[l:index]
+                        endif
                     endif
+                    call add(l:list, {
+                                \ 'filename': l:path,
+                                \ 'lnum': l:line,
+                                \ 'col': l:col,
+                                \ 'text': l:text,
+                                \ })
                 endif
-                call add(l:list, {
-                    \ 'filename': l:path,
-                    \ 'lnum': l:line,
-                    \ 'col': l:col,
-                    \ 'text': l:text,
-                    \ })
-            endif
-        endfor
+            endfor
+        elseif has_key(l:locations[0],'targetUri') " server returns LocationLinks
+            for l:location in l:locations
+                if s:is_file_uri(l:location['targetUri'])
+                    let l:path = lsp#utils#uri_to_path(l:location['targetUri'])
+                    let l:line = l:location['targetSelectionRange']['start']['line'] + 1
+                    let l:char = l:location['targetSelectionRange']['start']['character']
+                    let l:col = lsp#utils#to_col(l:path, l:line, l:char)
+                    let l:index = l:line - 1
+                    let l:viewstart = l:location['targetRange']['start']['line'] 
+                    let l:viewend = l:location['targetRange']['end']['line']
+
+                    if has_key(l:cache, l:path)
+                        let l:text = l:cache[l:path][l:index]
+                    else
+                        let l:contents = getbufline(l:path, 1, '$')
+                        if !empty(l:contents)
+                            let l:text = l:contents[l:index]
+                        else
+                            let l:contents = readfile(l:path)
+                            let l:cache[l:path] = l:contents
+                            let l:text = l:contents[l:index]
+                        endif
+                    endif
+                    call add(l:list, {
+                                \ 'filename': l:path,
+                                \ 'lnum': l:line,
+                                \ 'col': l:col,
+                                \ 'text': l:text,
+                                \ 'viewstart': l:viewstart,
+                                \ 'viewend': l:viewend
+                                \ })
+                endif
+            endfor
+        endif
     endif
 
     return l:list


### PR DESCRIPTION
This pull requests implements support for `locationLink` in addition to `location` for `PeekDefinition` (and similarly for `Declaration`, `TypeDefinition`, and `Implementation`), allowing the popup to only show exactly the environment the target symbol is contained in. (This is supported by, e.g., the texlab server.)

Closes #474.

### Changes

1. advertise `linkSupport` in capabilities
2. detect `locationLink` in `locations_to_loc_list` and extract and pass start and end line of `targetRange`
3. restrict lines passed to `preview` in `handle_location` to the `targetRange`
