### PR TITLE
Allow for MarkupContent in completion info

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -386,6 +386,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \   },
     \   'textDocument': {
     \       'completion': {
+    \           'completionItem': {
+    \              'documentationFormat': 'plaintext'
+    \           },
     \           'completionItemKind': {
     \              'valueSet': lsp#omni#get_completion_item_kinds()
     \           }

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -387,7 +387,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \   'textDocument': {
     \       'completion': {
     \           'completionItem': {
-    \              'documentationFormat': 'plaintext'
+    \              'documentationFormat': ['plaintext']
     \           },
     \           'completionItemKind': {
     \              'valueSet': lsp#omni#get_completion_item_kinds()

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -252,7 +252,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
             let l:completion['info'] .= a:item['documentation']
         elseif type(a:item['documentation']) == type({}) && 
                     \ has_key(a:item['documentation'], 'value')
-            " field is MarkupContent (string or markdown, we don't care)
+            " field is MarkupContent (hopefully 'plaintext')
             let l:completion['info'] .= a:item['documentation']['value']
         endif
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -250,7 +250,9 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     if has_key(a:item, 'documentation')
         if type(a:item['documentation']) == type('') " field is string
             let l:completion['info'] .= a:item['documentation']
-        elseif a:item['documentation']['kind'] == 'plaintext' " field is MarkupContent
+        elseif type(a:item['documentation']) == type({}) && 
+                    \ a:item['documentation']['kind'] == 'plaintext'
+            " field is MarkupContent
             let l:completion['info']['value'] .= a:item['documentation']
         endif
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -253,7 +253,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         elseif type(a:item['documentation']) == type({}) && 
                     \ has_key(a:item['documentation'], 'value')
             " field is MarkupContent (string or markdown, we don't care)
-            let l:completion['info']['value'] .= a:item['documentation']
+            let l:completion['info'] .= a:item['documentation']['value']
         endif
     endif
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -248,8 +248,10 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     endif
 
     if has_key(a:item, 'documentation')
-        if type(a:item['documentation']) == type('')
+        if type(a:item['documentation']) == type('') " field is string
             let l:completion['info'] .= a:item['documentation']
+        elseif a:item['documentation']['kind'] == 'plaintext' " field is MarkupContent
+            let l:completion['info']['value'] .= a:item['documentation']
         endif
     endif
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -251,8 +251,8 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         if type(a:item['documentation']) == type('') " field is string
             let l:completion['info'] .= a:item['documentation']
         elseif type(a:item['documentation']) == type({}) && 
-                    \ a:item['documentation']['kind'] == 'plaintext'
-            " field is MarkupContent
+                    \ has_key(a:item['documentation'], 'value')
+            " field is MarkupContent (string or markdown, we don't care)
             let l:completion['info']['value'] .= a:item['documentation']
         endif
     endif


### PR DESCRIPTION
According to the specification, the language server can provide a `documentation` field for a completion response either as a `string` or as a `MarkupContent`; vim-lsp only supported the former. This change also tests for `MarkupContent` in `plaintext` format (as opposed to `markdown`, which could be an image link) and sets the `info` field accordingly.