### PR TITLE
Avoid wrong buffer open

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -782,11 +782,12 @@ function! s:get_versioned_text_document_identifier(buf, buffer_info) abort
 endfunction
 
 function! lsp#send_request(server_name, request) abort
+    let l:bufnr = get(a:request, 'bufnr', bufnr('%'))
     let l:Cb = has_key(a:request, 'on_notification') ? a:request['on_notification'] : function('s:Noop')
     let l:request = copy(a:request)
     let l:request['on_notification'] = {id, data, event->l:Cb(data)}
     call lsp#utils#step#start([
-        \ {s->s:ensure_flush(bufnr('%'), a:server_name, s.callback)},
+        \ {s->s:ensure_flush(l:bufnr, a:server_name, s.callback)},
         \ {s->s:is_step_error(s) ? l:Cb(s.result[0]) : s:send_request(a:server_name, l:request) },
         \ ])
 endfunction

--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -61,7 +61,8 @@ function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort
                 \   'textDocument': lsp#get_text_document_identifier(a:buf)
                 \ },
                 \ 'on_notification': function('s:handle_fold_request', [a:server_name]),
-                \ 'sync': a:sync
+                \ 'sync': a:sync,
+                \ 'bufnr': a:buf
                 \ })
 endfunction
 


### PR DESCRIPTION
Avoiding wrong buffer sending to server.

I met problems when open and change `typescript` buffer and swich to other `not typescript` buffer quickly. (`not typescript` buffer will be red all lines)

The problem's reason is sending "not typescript" buffer as `typescript` source.

I think it occurs in following flow.

1. Open typescript buffer and changes.
2. Run `s:on_text_document_did_change()` by autocmd.
    - `bufnr('%')` is save to variable... `A`
3. After timer tick, call `s:ensure_flush`.
4. Call `lsp#ui#vim#folding#send_request` in `s:ensure_flush`.
    - Somtimes `bufnr('%')` are not same for `A`.

The solution of this PR is adding `bufnr` argument for `lsp#send_request`.

I worry to change `lsp#send_request` it is very common api...

