### PR TITLE
[WIP] Refactor neovim floats

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -386,6 +386,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \   },
     \   'textDocument': {
     \       'completion': {
+    \           'completionItem': {
+    \              'documentationFormat': ['plaintext']
+    \           },
     \           'completionItemKind': {
     \              'valueSet': lsp#omni#get_completion_item_kinds()
     \           }
@@ -695,6 +698,8 @@ function! s:handle_initialize(server_name, data) abort
     if g:lsp_signature_help_enabled
         call lsp#ui#vim#signature_help#setup()
     endif
+
+    call lsp#ui#vim#documentation#setup()
 
     doautocmd User lsp_server_init
 endfunction

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -248,8 +248,12 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     endif
 
     if has_key(a:item, 'documentation')
-        if type(a:item['documentation']) == type('')
+        if type(a:item['documentation']) == type('') " field is string
             let l:completion['info'] .= a:item['documentation']
+        elseif type(a:item['documentation']) == type({}) && 
+                    \ has_key(a:item['documentation'], 'value')
+            " field is MarkupContent (hopefully 'plaintext')
+            let l:completion['info'] .= a:item['documentation']['value']
         endif
     endif
 

--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -1,0 +1,75 @@
+let s:use_vim_popup = has('patch-8.1.1517') && !has('nvim')
+let s:use_nvim_float = exists('*nvim_open_win') && has('nvim')
+
+let s:last_popup_id = -1
+
+function! s:complete_done() abort
+    " Use a timer to avoid textlock (see :h textlock).
+    let l:event = deepcopy(v:event)
+    call timer_start(0, {-> s:show_documentation(l:event)})
+endfunction
+
+function! s:show_documentation(event) abort
+    call s:close_popup()
+
+    if !has_key(a:event['completed_item'], 'info') || empty(a:event['completed_item']['info'])
+        return
+    endif
+
+    let l:right = wincol() < winwidth(0) / 2
+
+    " TODO: Neovim
+    if l:right
+        let l:line = a:event['row'] + 1
+        let l:col = a:event['col'] + a:event['width'] + 1 + (a:event['scrollbar'] ? 1 : 0)
+    else
+        let l:line = a:event['row'] + 1
+        let l:col = a:event['col'] - 1
+    endif
+
+    " TODO: Support markdown
+    let l:data = split(a:event['completed_item']['info'], '\n')
+    let l:lines = []
+    let l:syntax_lines = []
+    let l:ft = lsp#ui#vim#output#append(l:data, l:lines, l:syntax_lines)
+
+    let l:current_win_id = win_getid()
+
+    if s:use_vim_popup
+        let s:last_popup_id = popup_create('(no documentation available)', {'line': l:line, 'col': l:col, 'pos': l:right ? 'topleft' : 'topright', 'padding': [0, 1, 0, 1]})
+    elseif s:use_nvim_float
+        let l:height = winheight(0) - l:line + 1
+        let l:width = l:right ? winwidth(0) - l:col + 1 : l:col
+        let s:last_popup_id = lsp#ui#vim#output#floatingpreview([])
+        call nvim_win_set_config(s:last_popup_id, {'relative': 'win', 'anchor': l:right ? 'NW' : 'NE', 'row': l:line - 1, 'col': l:col - 1, 'height': l:height, 'width': l:width})
+    endif
+
+    call setbufvar(winbufnr(s:last_popup_id), 'lsp_syntax_highlights', l:syntax_lines)
+    call setbufvar(winbufnr(s:last_popup_id), 'lsp_do_conceal', 1)
+    call lsp#ui#vim#output#setcontent(s:last_popup_id, l:lines, l:ft)
+    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info()
+
+    call win_gotoid(l:current_win_id)
+
+    if s:use_nvim_float
+        call lsp#ui#vim#output#adjust_float_placement(l:bufferlines, l:maxwidth)
+        call nvim_win_set_config(s:last_popup_id, {'relative': 'win', 'row': l:line - 1, 'col': l:col - 1})
+    endif
+endfunction
+
+function! s:close_popup() abort
+    if s:last_popup_id >= 0
+        if s:use_vim_popup | call popup_close(s:last_popup_id) | endif
+        if s:use_nvim_float | call nvim_win_close(s:last_popup_id, 1) | endif
+
+        let s:last_popup_id = -1
+    endif
+endfunction
+
+function! lsp#ui#vim#documentation#setup() abort
+    augroup lsp_documentation_popup
+        autocmd!
+        autocmd CompleteChanged * call s:complete_done()
+        autocmd CompleteDone * call s:close_popup()
+    augroup end
+endfunction

--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -47,7 +47,7 @@ function! s:show_documentation(event) abort
     call setbufvar(winbufnr(s:last_popup_id), 'lsp_syntax_highlights', l:syntax_lines)
     call setbufvar(winbufnr(s:last_popup_id), 'lsp_do_conceal', 1)
     call lsp#ui#vim#output#setcontent(s:last_popup_id, l:lines, l:ft)
-    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info()
+    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info(getline(1, '$'))
 
     call win_gotoid(l:current_win_id)
 

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -288,16 +288,16 @@ function! s:align_preview(options) abort
     endif
 endfunction
 
-function! lsp#ui#vim#output#get_size_info() abort
+function! lsp#ui#vim#output#get_size_info(lines) abort
     " Get size information while still having the buffer active
-    let l:maxwidth = max(map(getline(1, '$'), 'strdisplaywidth(v:val)'))
+    let l:maxwidth = max(map(a:lines, 'strdisplaywidth(v:val)'))
     if g:lsp_preview_max_width > 0
       let l:bufferlines = 0
       let l:maxwidth = min([g:lsp_preview_max_width, l:maxwidth])
 
       " Determine, for each line, how many "virtual" lines it spans, and add
       " these together for all lines in the buffer
-      for l:line in getline(1, '$')
+      for l:line in a:lines
         let l:num_lines = str2nr(string(ceil(strdisplaywidth(l:line) * 1.0 / g:lsp_preview_max_width)))
         let l:bufferlines += max([l:num_lines, 1])
       endfor
@@ -344,7 +344,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
     call setbufvar(winbufnr(s:winid), 'lsp_do_conceal', l:do_conceal)
     call lsp#ui#vim#output#setcontent(s:winid, l:lines, l:ft)
 
-    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info()
+    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info(getlines(1, '$'))
 
     if s:use_preview
         " Set statusline

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -344,7 +344,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
     call setbufvar(winbufnr(s:winid), 'lsp_do_conceal', l:do_conceal)
     call lsp#ui#vim#output#setcontent(s:winid, l:lines, l:ft)
 
-    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info(getlines(1, '$'))
+    let [l:bufferlines, l:maxwidth] = lsp#ui#vim#output#get_size_info(getline(1, '$'))
 
     if s:use_preview
         " Set statusline

--- a/doc/float-api.txt
+++ b/doc/float-api.txt
@@ -57,7 +57,8 @@ show_cursor_tooltip({lines}, {syn-ranges}, {filetype}, {options})
     Returns the window ID of the created popup.
 
     {options} is a |dict| that can contain the following keys:
-    TODO
+    TODO: possibly add some options or maxwidth, close_on_cursor_move,
+    firstline, cursor_pos, cursor_alignment
 
 
 show_pum_tooltip({lines}, {syn-ranges}, {filetype}, {options})

--- a/doc/float-api.txt
+++ b/doc/float-api.txt
@@ -74,7 +74,8 @@ show_pum_tooltip({lines}, {syn-ranges}, {filetype}, {options})
     Returns the window ID of the created popup.
 
     {options} is a |dict| that can contain the following keys:
-    TODO
+    TODO: might not make sense to have options here, because everything is in
+    'completepopup' already?
 
 
 update_pum_tooltip({winid}, {lines}, {syn-ranges}, {filetype}, {options})

--- a/doc/float-api.txt
+++ b/doc/float-api.txt
@@ -41,6 +41,8 @@ All the following functions take the same initial arguments:
       the popup.
     - {syn-ranges}: A |list| of |dict|s, each representing a syntax highlight
       to be applied to the popup. See parse_lsp_response for more info.
+      You can pass an empty |list| `[]` if you don't want any additional
+      syntax highlighting (of course, the syntax of {filetype} still applies).
     - {filetype}: The |'filetype'| of the popup buffer. This determines the
       syntax highlighting of the entire buffer, which ftplugin is used, and so
       on.

--- a/doc/float-api.txt
+++ b/doc/float-api.txt
@@ -1,0 +1,123 @@
+==============================================================================
+LSP-SPECIFIC API                                            *lsp-specific-api*
+
+parse_lsp_response({data})
+
+    Parses a LSP response (be it a String, MarkedString, Markdown segment,
+    MarkupContent, ...; from hereon just {data}) to:
+
+        - A |list| of |String|s that represent the "stripped" content. E.g.
+          markdown `*bold*` strings will be converted to just `bold`, code
+          blocks will have the markers removed, etc. It's the "plain-text, no
+          colour" version of the {data}.
+
+        - A |list| of |Dicts| that add colour to the plaintext. Each entry
+          essentially says: highlight this character range using this Vim
+          syntax group. Can be used for displaying stripped `*bold*` in a bold
+          font, or to apply syntax highlighting to a region.
+
+          Example of an entry:
+            {
+                'range': {
+                    'start': {
+                        'line': 5,
+                        'character': 10
+                    },
+                    'end': {
+                        'line': 5,
+                        'character': 15
+                    }
+                },
+                'group': 'markdownBold'
+            }
+
+
+==============================================================================
+TOP-LEVEL API                                                  *top-level-api*
+
+All the following functions take the same initial arguments:
+
+    - {lines}: A |list| of |String|s that represents the plain-text content of
+      the popup.
+    - {syn-ranges}: A |list| of |dict|s, each representing a syntax highlight
+      to be applied to the popup. See parse_lsp_response for more info.
+    - {filetype}: The |'filetype'| of the popup buffer. This determines the
+      syntax highlighting of the entire buffer, which ftplugin is used, and so
+      on.
+
+
+show_cursor_tooltip({lines}, {syn-ranges}, {filetype}, {options})
+
+    Shows a tooltip at the current cursor position, either above or below,
+    depending on where there is enough space.
+
+    The preview's content is set depending on {lines}, {syn-ranges} and
+    {filetype}, see above.
+
+    Returns the window ID of the created popup.
+
+    {options} is a |dict| that can contain the following keys:
+    TODO
+
+
+show_pum_tooltip({lines}, {syn-ranges}, {filetype}, {options})
+
+    Shows a tooltip associated with the currently selected item in the popup
+    menu. It can be either to the left/right of the item, depending on where
+    there is enough space. Settings from |'completepopup'| is taken into
+    account.
+
+    The preview's content is set depending on {lines}, {syn-ranges} and
+    {filetype}, see above.
+
+    Returns the window ID of the created popup.
+
+    {options} is a |dict| that can contain the following keys:
+    TODO
+
+
+update_pum_tooltip({winid}, {lines}, {syn-ranges}, {filetype}, {options})
+
+    Changes the content of the tooltip associated with the currently selected
+    item in the popup menu. {winid} must be the value returned by
+    `show_pum_tooltip`.
+
+    For the meaning of {options}, see `show_pum_tooltip`.
+
+==============================================================================
+INTERMEDIATE-LEVEL API                                *intermediate-level-api*
+
+These functions will be backend specific (Vim popup/Nvim float).
+
+create_tooltip()
+
+    Creates a hidden floating window, with undefined position, and an empty
+    buffer associated with it.
+
+    Returns the created window ID.
+
+
+set_tooltip_contents({winid}, {lines})
+
+    Updates the contents of a given floating window, and unhides it. Also
+    retriggers size calculation.
+
+
+set_tooltip_position({winid}, {options})
+
+    Sets the position of the given floating window, be it cursor-relative,
+    pum-relative, etc. Also retriggers size calculation.
+
+    TODO: Which {options}?
+
+
+close_tooltip({winid})
+
+    Closes the tooltip with the ID {winid}.
+
+==============================================================================
+LOW-LEVEL API                                                  *low-level-api*
+
+To be determined.
+
+vim:tw=78:ts=4:ft=help:et


### PR DESCRIPTION
The purpose of this PR is to avoid entering the buffer opened with `nvim_open_win`, which triggers -- possibly very expensive -- `CursorMoved` autocommands on the original buffer, see #507.

This PR also contains commits from #500 and #507 in order to easily test the `Documentation` behavior; it should be removed before merging.

This is not quite working yet:
1. Documentation preview contents are right-aligned, so that the beginning rather than the end of long lines are truncated. (That's an issue with `documentation.vim` trying to put the float on the left side of the pum but failing for some reason.)
2. Hover doesn't show if triggered on the first line of the buffer.
3. PeekDefinition doesn't show for if the target range is too large, and if the buffer contains unsaved changes, these are not picked up.

@jerdna-regeiz @thomasfaingnaert I would appreciate feedback, since the interaction of the functions in `output.vim` isn't quite clear to me.