### PR TITLE
Allow custom server-specific symbol and completion item kind

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -98,7 +98,7 @@ function! s:handle_omnicompletion(server_name, complete_counter, data) abort
         return
     endif
 
-    let l:result = s:get_completion_result(a:server_name,a:data)
+    let l:result = s:get_completion_result(a:server_name, a:data)
     let l:matches = l:result['matches']
 
     if g:lsp_async_completion
@@ -109,20 +109,21 @@ function! s:handle_omnicompletion(server_name, complete_counter, data) abort
     endif
 endfunction
 
-function! lsp#omni#get_completion_item_kind_text(server, completion_item) abort
-    if empty(a:server) 
+function! lsp#omni#get_kind_text(completion_item, ...) abort
+    let l:server = get(a:, 1, '')
+    if empty(l:server) " server name 
         let l:completion_item_kinds = s:default_completion_item_kinds
     else
-        if !has_key(s:completion_item_kinds, a:server)
-            let l:server_info = lsp#get_server_info(a:server)
+        if !has_key(s:completion_item_kinds, l:server)
+            let l:server_info = lsp#get_server_info(l:server)
             if has_key (l:server_info, 'config') && has_key(l:server_info['config'], 'completion_item_kinds')
-                let s:completion_item_kinds[a:server] = 
-                            \ extend(s:default_completion_item_kinds, l:server_info['config']['completion_item_kinds'])
+                let s:completion_item_kinds[l:server] = s:default_completion_item_kinds
+                call extend(s:completion_item_kinds[l:server] , l:server_info['config']['completion_item_kinds'])
             else
-                let s:completion_item_kinds[a:server] = s:default_completion_item_kinds
+                let s:completion_item_kinds[l:server] = s:default_completion_item_kinds
             endif
         endif
-        let l:completion_item_kinds = s:completion_item_kinds[a:server]
+        let l:completion_item_kinds = s:completion_item_kinds[l:server]
     endif
 
     return has_key(a:completion_item, 'kind') && has_key(l:completion_item_kinds, a:completion_item['kind']) 
@@ -219,7 +220,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         let l:word = s:remove_typed_part(l:word)
     endif
 
-    let l:kind = lsp#omni#get_completion_item_kind_text(l:server_name, a:item)
+    let l:kind = lsp#omni#get_kind_text(a:item, l:server_name)
 
     let l:completion = {
                 \ 'word': l:word,

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -408,7 +408,7 @@ function! s:handle_symbol(server, last_req_id, type, data) abort
         return
     endif
 
-    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:data)
+    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:server, a:data)
 
     call setqflist(l:list)
 

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -182,12 +182,13 @@ function! s:get_symbol_text_from_kind(server, kind) abort
     if !has_key(s:symbol_kinds, a:server)
         let l:server_info = lsp#get_server_info(a:server)
         if has_key (l:server_info, 'config') && has_key(l:server_info['config'], 'symbol_kinds')
-            let s:symbol_kinds[a:server] = extend(s:default_symbol_kinds, l:server_info['config']['symbol_kinds'])
+            let s:symbol_kinds[a:server] = s:default_symbol_kinds
+            call extend(s:symbol_kinds[a:server], l:server_info['config']['symbol_kinds'])
         else
             let s:symbol_kinds[a:server] = s:default_symbol_kinds
         endif
     endif
-        let l:symbol_kinds = s:symbol_kinds[a:server]
+    let l:symbol_kinds = s:symbol_kinds[a:server]
     return has_key(l:symbol_kinds, a:kind) ? l:symbol_kinds[a:kind] : 'unknown symbol ' . a:kind
 endfunction
 

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -65,7 +65,7 @@ function! lsp#ui#vim#utils#locations_to_loc_list(result) abort
     return l:list
 endfunction
 
-let s:symbol_kinds = {
+let s:default_symbol_kinds = {
     \ '1': 'file',
     \ '2': 'module',
     \ '3': 'namespace',
@@ -94,6 +94,8 @@ let s:symbol_kinds = {
     \ '26': 'type parameter',    
     \ }
 
+let s:symbol_kinds = {}
+
 let s:diagnostic_severity = {
     \ 1: 'Error',
     \ 2: 'Warning',
@@ -101,7 +103,7 @@ let s:diagnostic_severity = {
     \ 4: 'Hint',
     \ }
 
-function! lsp#ui#vim#utils#symbols_to_loc_list(result) abort
+function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
     if !has_key(a:result['response'], 'result')
         return []
     endif
@@ -123,7 +125,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(result) abort
                     \ 'filename': l:path,
                     \ 'lnum': l:line,
                     \ 'col': l:col,
-                    \ 'text': s:get_symbol_text_from_kind(l:symbol['kind']) . ' : ' . l:symbol['name'],
+                    \ 'text': s:get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
                     \ })
             endif
         endfor
@@ -176,12 +178,21 @@ function! s:is_file_uri(uri) abort
     return stridx(a:uri, 'file:///') == 0
 endfunction
 
-function! s:get_symbol_text_from_kind(kind) abort
-    return has_key(s:symbol_kinds, a:kind) ? s:symbol_kinds[a:kind] : 'unknown symbol ' . a:kind
+function! s:get_symbol_text_from_kind(server, kind) abort
+    if !has_key(s:symbol_kinds, a:server)
+        let l:server_info = lsp#get_server_info(a:server)
+        if has_key (l:server_info, 'config') && has_key(l:server_info['config'], 'symbol_kinds')
+            let s:symbol_kinds[a:server] = extend(s:default_symbol_kinds, l:server_info['config']['symbol_kinds'])
+        else
+            let s:symbol_kinds[a:server] = s:default_symbol_kinds
+        endif
+    endif
+        let l:symbol_kinds = s:symbol_kinds[a:server]
+    return has_key(l:symbol_kinds, a:kind) ? l:symbol_kinds[a:kind] : 'unknown symbol ' . a:kind
 endfunction
 
 function! lsp#ui#vim#utils#get_symbol_kinds() abort
-    return map(keys(s:symbol_kinds), {idx, key -> str2nr(key)})
+    return map(keys(s:default_symbol_kinds), {idx, key -> str2nr(key)})
 endfunction
 
 function! s:get_diagnostic_severity_text(severity) abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -625,10 +625,18 @@ The vim |dict| containing information about the server.
 	'whitelist': ['*']
 	'blacklist': ['javascript', 'typescript']
 
+  * workspace_config:
+    optional vim |dict|
+    Used to pass workspace configuration to the server after
+    initialization. Configuration settings are language-server specific.
+
+    Example:
+	'workspace_config': {'pyls': {'plugins': \
+		{'pydocstyle': {'enabled': v:true}}}}
+
   * config:
     optional vim |dict|
-    Used to pass additional custom config. See |vim-lsp_hover_conceal|,
-    |vim-lsp_symbol_kinds|, and |vim-lsp_completion_item_kinds|.
+    Used to pass additional custom config. 
 
     For example:
 	'config': { 'prefer_local': 1 }
@@ -647,46 +655,39 @@ The vim |dict| containing information about the server.
 
 	    'cmd': function('s:myserver_cmd')
 
-  * workspace_config:
-    optional vim |dict|
-    Used to pass workspace configuration to the server after
-    initialization. Configuration settings are language-server specific.
+    The following per-server configuration options are supported by vim-lsp.
 
-    Example:
-	'workspace_config': {'pyls': {'plugins': \
-		{'pydocstyle': {'enabled': v:true}}}}
+	* hover_conceal      
+	    Type: |Boolean|
+	    Default: |g:lsp_hover_conceal|
 
-hover_conceal                                          *vim-lsp_hover_conceal*
-    Type: |Boolean|
-    Default: |g:lsp_hover_conceal|
+	    This takes precendence over the value of |g:lsp_hover_conceal|, to 
+	    allow overriding this setting per server.
 
-    This takes precendence over the value of |g:lsp_hover_conceal|, to allow
-    overriding this setting per server.
+	    Example:
+		'config': { 'hover_conceal': 1 }
 
-    Example:
-        'config': { 'hover_conceal': 1 }
+	* symbol_kinds                                            
+	    Type: |Dict|
+	    Default: |{}|
 
-symbol_kinds                                            *vim-lsp_symbol_kinds*
-    Type: |Dict|
-    Default: |{}|
+	    This allows overriding the default text mappings for symbol kinds
+	    (e.g., 'module', 'method') per server. Useful for abbreviating or 
+	    removing the kind text.
 
-    This allows overriding the default text mappings for symbol kinds
-    (e.g., 'module', 'method') per server. Useful for abbreviating or removing
-    the kind text.
+	    Example:
+		'config': { 'symbol_kinds': {'26': 'type' } }
 
-    Example:
-        'config': { 'symbol_kinds': {'26': 'type' } }
+	* completion_item_kinds                         
+	    Type: |Dict|
+	    Default: |{}|
 
-completion_item_kinds                         *vim-lsp_completion_item_kinds*
-    Type: |Dict|
-    Default: |{}|
+	    This allows overriding the default text mappings for completion item
+	    kinds (e.g., 'module', 'method') per server. Useful for abbreviating
+	    or removing the kind text.
 
-    This allows overriding the default text mappings for completion item kinds
-    (e.g., 'module', 'method') per server. Useful for abbreviating or removing
-    the kind text.
-
-    Example:
-        'config': { 'completion_item_kinds': {'26': 'type' } }
+	    Example:
+		'config': { 'completion_item_kinds': {'26': 'type' } }
 
 lsp#stop_server                                        *vim-lsp-stop_server*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -627,7 +627,8 @@ The vim |dict| containing information about the server.
 
   * config:
     optional vim |dict|
-    Used to pass additional custom config.
+    Used to pass additional custom config. See |vim-lsp_hover_conceal|,
+    |vim-lsp_symbol_kinds|, and |vim-lsp_completion_item_kinds|.
 
     For example:
 	'config': { 'prefer_local': 1 }
@@ -664,6 +665,28 @@ hover_conceal                                          *vim-lsp_hover_conceal*
 
     Example:
         'config': { 'hover_conceal': 1 }
+
+symbol_kinds                                            *vim-lsp_symbol_kinds*
+    Type: |Dict|
+    Default: |{}|
+
+    This allows overriding the default text mappings for symbol kinds
+    (e.g., 'module', 'method') per server. Useful for abbreviating or removing
+    the kind text.
+
+    Example:
+        'config': { 'symbol_kinds': {'26': 'type' } }
+
+completion_item_kinds                         *vim-lsp_completion_item_kinds*
+    Type: |Dict|
+    Default: |{}|
+
+    This allows overriding the default text mappings for completion item kinds
+    (e.g., 'module', 'method') per server. Useful for abbreviating or removing
+    the kind text.
+
+    Example:
+        'config': { 'completion_item_kinds': {'26': 'type' } }
 
 lsp#stop_server                                        *vim-lsp-stop_server*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -636,7 +636,7 @@ The vim |dict| containing information about the server.
 
   * config:
     optional vim |dict|
-    Used to pass additional custom config. 
+    Used to pass additional custom config.
 
     For example:
 	'config': { 'prefer_local': 1 }
@@ -657,28 +657,28 @@ The vim |dict| containing information about the server.
 
     The following per-server configuration options are supported by vim-lsp.
 
-	* hover_conceal      
+	* hover_conceal
 	    Type: |Boolean|
 	    Default: |g:lsp_hover_conceal|
 
-	    This takes precendence over the value of |g:lsp_hover_conceal|, to 
+	    This takes precendence over the value of |g:lsp_hover_conceal|, to
 	    allow overriding this setting per server.
 
 	    Example:
 		'config': { 'hover_conceal': 1 }
 
-	* symbol_kinds                                            
+	* symbol_kinds
 	    Type: |Dict|
 	    Default: |{}|
 
 	    This allows overriding the default text mappings for symbol kinds
-	    (e.g., 'module', 'method') per server. Useful for abbreviating or 
+	    (e.g., 'module', 'method') per server. Useful for abbreviating or
 	    removing the kind text.
 
 	    Example:
 		'config': { 'symbol_kinds': {'26': 'type' } }
 
-	* completion_item_kinds                         
+	* completion_item_kinds
 	    Type: |Dict|
 	    Default: |{}|
 


### PR DESCRIPTION
Fixes #486 

Replaces flat `s:kind_mappings` by a dictionary keyed on server name that is passed through the calls. Defaults to the standard mappings that can be overridden by a config key, e.g.,
```viml
'config': {
                \     'symbol_kinds': {
                \            '2': 'sec',
                \            '5': 'thm',
                \            '6': 'float',
                \            '7': 'PhD',
                \            '8': 'label',
                \            '11': 'misc',
                \            '12': 'cmd',
                \            '14': 'math',
                \            '22': 'item',
                \            '23': 'book',
                \            '24': 'artl',
                \            '25': 'part',
                \            '26': 'coll',
                \      }, 
\  }
``` 
Should not break current direct use of `default_get_completion_items` (tests pass, `ncm2-vim-lsp` works), but of course the override doesn't get picked up in this case (you need to pass `server_name` after `item`; I'll make a PR for `ncm2-vim-lsp` once this is merged).
