### PR TITLE
Hotfix for #455

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -194,7 +194,7 @@ function! s:on_text_document_did_save() abort
         " We delay the callback by one loop iteration as calls to ensure_flush
         " can introduce mmap'd file locks that linger on Windows and collide
         " with the second lang server call preventing saves (see #455)
-        call s:ensure_flush(l:buf, l:server_name, {result->timer_start(0, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})})
+        call s:ensure_flush(l:buf, l:server_name, {result->timer_start(0, {timer->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})})
     endfor
 endfunction
 


### PR DESCRIPTION
Fixed a small bug which was a result of #455

From https://github.com/jackguo380/vim-lsp-cxx-highlight/issues/12#issuecomment-539872380
> Thanks, I investigated the issue and its just a bug on vim-lsp's part. I took a closer look at that commit ([prabirshrestha/vim-lsp#455](https://github.com/prabirshrestha/vim-lsp/pull/455)) it turns out the fix is quite simple:
> 
> A lambda is being passed into `timer_start()` but that function calls the lambda and passes in a timer handle which is not what the lambda expects. The fix is to have `result` come from the outer lambda where `result` is the JSON message.
> 
> ```diff
> diff --git a/autoload/lsp.vim b/autoload/lsp.vim
> index ee6f568daf0a7c56e0e1d2b9f3ed823b5f336119..25d97670cc137719b98877a2fd51cfb2885315f0 100644
> --- a/autoload/lsp.vim
> +++ b/autoload/lsp.vim
> @@ -194,7 +194,7 @@ function! s:on_text_document_did_save() abort
>          " We delay the callback by one loop iteration as calls to ensure_flush
>          " can introduce mmap'd file locks that linger on Windows and collide
>          " with the second lang server call preventing saves (see #455)
> -        call s:ensure_flush(l:buf, l:server_name, {result->timer_start(0, {result->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})})
> +        call s:ensure_flush(l:buf, l:server_name, {result->timer_start(0, {timer->s:call_did_save(l:buf, l:server_name, result, function('s:Noop'))})})
>      endfor
>  endfunction
>  
> ```