### PR TITLE
add line num args to prop_remove

### DIFF
--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -31,7 +31,7 @@ function! s:set_textprops(buf) abort
     silent! call prop_type_add(s:textprop_name, {'bufnr': a:buf})
 
     " First, clear all markers from the previous run
-    call prop_remove({'type': s:textprop_name, 'bufnr': a:buf})
+    call prop_remove({'type': s:textprop_name, 'bufnr': a:buf}, 1, line('$'))
 
     " Add markers to each line
     let l:i = 1


### PR DESCRIPTION
Thank you for creating greate plugins.
I use Vim 8.1.0875 at Debian Buster. 
"Not enough arguments for function: prop_remove" error occurs when I use this plugins.
Newer version of Vim solved this problems but Buster's package have a litter older.
I added line number args to the function.
Dose this change work?