### PR TITLE
Open Neovim floating windows with "minimal" style

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -87,6 +87,7 @@ function! s:get_float_positioning(height, width) abort
       endif
     endif
     let l:col = col('.')
+    let l:style = 'minimal'
     " Positioning is not window but screen relative
     let l:opts = {
           \ 'relative': 'win',
@@ -94,6 +95,7 @@ function! s:get_float_positioning(height, width) abort
           \ 'col': l:col,
           \ 'width': l:width,
           \ 'height': l:height,
+          \ 'style': l:style,
           \ }
     return l:opts
 endfunction


### PR DESCRIPTION
I've been using `vim-lsp` a fair amount recently, and I noticed that a lot of completion popups didn't seem to set the width appropriately:

![Screen Shot 2019-10-25 at 9 54 13 AM](https://user-images.githubusercontent.com/929204/67581740-2a223b00-f70e-11e9-938c-3d2b5c2e71f9.png)

After digging in to this, I realized that the little gutter on the left-hand side of the popup was probably being counted by Neovim as part of the window's width, while `vim-lsp` was setting the width to the length of the longest line exactly.

To fix this, I discovered the `style` option for configuring popup windows:

```
 style : Configure the appearance of the window.
Currently only takes one non-empty value:
• "minimal" Nvim will display the window with
  many UI options disabled. This is useful
  when displaying a temporary float where the
  text should not be edited. Disables
  'number', 'relativenumber', 'cursorline',
  'cursorcolumn', 'foldcolumn', 'spell' and
  'list' options. 'signcolumn' is changed to
  auto . The end-of-buffer region is hidden
  by setting eob flag of 'fillchars' to a
  space char, and clearing the EndOfBuffer
  region in 'winhighlight'.
```

Here's what it looks like:

![Screen Shot 2019-10-25 at 9 55 33 AM](https://user-images.githubusercontent.com/929204/67581954-7bcac580-f70e-11e9-8a92-5e7c208553d3.png)

Note that the first line fits entirely in the window, rather than wrapping the final two characters to a new line.