### PR TITLE
Use "P" instead of "p" to insert text

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -199,7 +199,7 @@ function! s:generate_sub_cmd_replace(text_edit) abort
     if len(l:new_text) == 0
         let l:sub_cmd .= 'x'
     elseif l:start_character == 0 && l:end_character == 0
-        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"
+        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>P"
     else
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText'].'?'\<CR>gph\"_x"
     endif

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -167,7 +167,7 @@ function! s:generate_sub_cmd_insert(text_edit) abort
     let l:sub_cmd .= s:generate_move_start_cmd(l:start_line, l:start_character)
 
     if l:start_character >= strchars(getline(l:start_line))
-        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>p"
+        let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText']\<CR>P"
     else
         let l:sub_cmd .= "\"=l:merged_text_edit['merged']['newText'].'?'\<CR>gPh\"_x"
     endif

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -551,6 +551,42 @@ Describe lsp#utils#text_edit
             Assert Equals(l:buffer_text, ['x', 'y', 'z', 'b', ''])
         End
 
+        It adds imports correctly
+            call s:set_text(['package main', '', 'import java.util.ArrayList;', '', 'public class Main {}'])
+
+            call lsp#utils#text_edit#apply_text_edits(
+                \ expand('%'),
+                \ [{
+                \     "range": {
+                \       "start": {
+                \         "character": 0,
+                \         "line": 2
+                \       },
+                \       "end": {
+                \         "character": 0,
+                \         "line": 3
+                \       }
+                \     },
+                \     "newText": ""
+                \   },
+                \   {
+                \     "range": {
+                \       "start": {
+                \         "character": 0,
+                \         "line": 2
+                \       },
+                \       "end": {
+                \         "character": 0,
+                \         "line": 2
+                \       }
+                \     },
+                \     "newText": "import java.util.ArrayList;\n"
+                \   }
+                \ ])
+
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['package main', '', 'import java.util.ArrayList;', '', 'public class Main {}', ''])
+        End
     End
 End
 


### PR DESCRIPTION
When running `:LspDocumentFormat` on a Java file, it rewrote the imports
of this source:

    package my_package

    import java.util.ArrayList;
    import java.util.List;

    public class MyClass {
        // ...
    }

to this:

    package my_package

    import java.util.ArrayList;
    import java.util.List;
    public class MyClass {
        // ...
    }

I first dug in to the implementation of `textDocument/formatting` on the
Java server side, and it appeared to be calculating the location to
insert the text correctly, yet it was being pushed down an extra line.

With this change, the new set of imports gets inserted at the correct
location.