### PR TITLE
If the hover response has only empty string content, we don't display anything

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -300,12 +300,18 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
 
     let l:current_window_id = win_getid()
 
-    let s:winid = s:open_preview(a:data)
-
     let s:preview_data = a:data
     let l:lines = []
     let l:syntax_lines = []
     let l:ft = s:append(a:data, l:lines, l:syntax_lines)
+
+    " If the server response is empty content, we don't display anything.
+    if empty(l:lines) && empty(l:syntax_lines)
+      echo ''
+      return
+    endif
+
+    let s:winid = s:open_preview(a:data)
 
     if has_key(a:options, 'filetype')
         let l:ft = a:options['filetype']
@@ -381,23 +387,29 @@ function! s:append(data, lines, syntax_lines) abort
 
         return 'markdown'
     elseif type(a:data) == type('')
-        call extend(a:lines, split(a:data, "\n", v:true))
+        if !empty(a:data)
+            call extend(a:lines, split(a:data, "\n", v:true))
+        endif
 
         return 'markdown'
     elseif type(a:data) == type({}) && has_key(a:data, 'language')
-        let l:new_lines = split(a:data.value, '\n')
+        if !empty(a:data.value)
+            let l:new_lines = split(a:data.value, '\n')
 
-        let l:i = 1
-        while l:i <= len(l:new_lines)
-            call add(a:syntax_lines, { 'line': len(a:lines) + l:i, 'language': a:data.language })
-            let l:i += 1
-        endwhile
+            let l:i = 1
+            while l:i <= len(l:new_lines)
+                call add(a:syntax_lines, { 'line': len(a:lines) + l:i, 'language': a:data.language })
+                let l:i += 1
+            endwhile
 
-        call extend(a:lines, l:new_lines)
+            call extend(a:lines, l:new_lines)
+        endif
 
         return 'markdown'
     elseif type(a:data) == type({}) && has_key(a:data, 'kind')
-        call extend(a:lines, split(a:data.value, '\n', v:true))
+        if !empty(a:data.value)
+              call extend(a:lines, split(a:data.value, '\n', v:true))
+        endif
 
         return a:data.kind ==? 'plaintext' ? 'text' : a:data.kind
     endif


### PR DESCRIPTION
If hover response has only empty string, we don't display anything.

### before hover
![2019_11_04_1611-1572851515_](https://user-images.githubusercontent.com/4556097/68104330-0638d380-ff1e-11e9-9703-eb5cd15cd449.png)

### on hover(Neovim)
![2019_11_04_1612-1572851552_](https://user-images.githubusercontent.com/4556097/68104337-0933c400-ff1e-11e9-8595-4dab213f66ae.png)

### on hover(Vim)
![2019_11_04_1613-1572851585_](https://user-images.githubusercontent.com/4556097/68104339-0b961e00-ff1e-11e9-8e9d-a90fa0ad34c9.png)


### Log
```
Mon 04 Nov 2019 02:40:31 PM JST:["<---", 5, "solargraph", {"response": {"id": 3, "jsonrpc": "2.0", "result": {"contents": {"kind": "markdown", "value": ""}}}, "request": {"id": 3, "jsonrpc": "2.0", "method": "textDocument/hover", "params": {"textDocument": {"uri": "file:///home/rubocop-hq/rubocop/lib/rubocop/runner.rb"}, "position": {"character": 29, "line": 161}}}}]
Mon 04 Nov 2019 02:40:31 PM JST:["s:on_stdout client request on_notification() error", "Vim(call):E5555: API call: 'width' key must be a positive Integer", "function <SNR>148_on_stdout[4]..<SNR>147_on_stdout[79]..<lambda>42[1]..<SNR>178_handle_hover[11]..lsp#ui#vim#output#preview[69]..<SNR>179_adjust_float_placement, line 7"]
```