### PR TITLE
Avoid double tap feature in insert-mode

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -292,6 +292,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
        \ && type(g:lsp_preview_doubletap) == 3
        \ && len(g:lsp_preview_doubletap) >= 1
        \ && type(g:lsp_preview_doubletap[0]) == 2
+       \ && mode()[0] !=# 'i'
         echo ''
         return call(g:lsp_preview_doubletap[0], [])
     endif


### PR DESCRIPTION
This PR aims to solve #548.

My repro steps are below.

1. disable lexima.
2. open `*.vim` file.
3. insert `call get(`.
4. keeping press the `,` key.
5. cursor unexpectedly moves to signature help window.

I think, popup-win's double tap feature is not needed in insert-mode.