### PR TITLE
fix error on switching the buffer with longer lines

### DIFF
--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -30,15 +30,24 @@ function! s:set_textprops(buf) abort
     " Create text property, if not already defined
     silent! call prop_type_add(s:textprop_name, {'bufnr': a:buf})
 
+    let l:line_count = s:get_line_count_buf(a:buf)
+
     " First, clear all markers from the previous run
-    call prop_remove({'type': s:textprop_name, 'bufnr': a:buf}, 1, line('$'))
+    call prop_remove({'type': s:textprop_name, 'bufnr': a:buf}, 1, l:line_count)
 
     " Add markers to each line
     let l:i = 1
-    while l:i <= line('$')
+    while l:i <= l:line_count
         call prop_add(l:i, 1, {'bufnr': a:buf, 'type': s:textprop_name, 'id': l:i})
         let l:i += 1
     endwhile
+endfunction
+
+function! s:get_line_count_buf(buf) abort
+    if !has('patch-8.1.1967')
+        return line('$')
+    endif
+    return line('$', bufwinid(a:buf))
 endfunction
 
 function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort


### PR DESCRIPTION
This pull request fixes the following error.

### Error
```
Error detected while processing function <SNR>100_send_didchange_queue[7]..<SNR>100_ensure_flush[1]..lsp#utils#step#start[1]..<SNR>134_next[9]..<lambda>59845[1]..<SNR>100_ensure_sta
rt[15]..<SNR>134_callback[1]..<SNR>134_next[9]..<lambda>59846[1]..<SNR>100_ensure_init[6]..<SNR>134_callback[1]..<SNR>134_next[9]..<lambda>59847[1]..<SNR>100_ensure_conf[14]..<SNR>1
34_callback[1]..<SNR>134_next[9]..<lambda>59848[1]..<SNR>100_ensure_open[16]..<SNR>134_callback[1]..<SNR>134_next[9]..<lambda>59849[1]..<SNR>100_ensure_changed[26]..lsp#ui#vim#foldi
ng#send_request[11]..<SNR>143_set_textprops:
line   19:
E966: Invalid line number: 6
```

### Reproducing steps

- Setup Go lsp configuration
- Open two Go files with vsp
- Edit the file with shorter lines and quickly switch to the another window
- now `line('$')` returns the line count of the buffer with longer lines but `a:buf` is the shorter buffer, so it fails to `set_textprops` with exceeding line number.

### Suggested Solution
- Get the proper line count against the given buffer number. There's the second argument for `line()` so use it.