### PR TITLE
Handle error if the user hits escape before complete() is done

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -141,8 +141,6 @@ endfunction
 function! s:display_completions(timer) abort
     if mode() is# 'i'
 		call complete(s:start_pos + 1, s:completion['matches'])
-    else
-        return 1
     endif
 endfunction
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -140,9 +140,9 @@ endfunction
 
 function! s:display_completions(timer) abort
 	try
-       call complete(s:start_pos + 1, s:completion['matches'])
-	catch /^Vim(call):E785: complete() can only be used in Insert mode/
-	endtry
+        call complete(s:start_pos + 1, s:completion['matches'])
+    catch /^Vim(call):E785: complete() can only be used in Insert mode/
+    endtry
 endfunction
 
 function! s:handle_omnicompletion(server_name, complete_counter, data) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -139,7 +139,10 @@ function! s:contains_filter(item, last_typed_word) abort
 endfunction
 
 function! s:display_completions(timer) abort
-    call complete(s:start_pos + 1, s:completion['matches'])
+	try
+       call complete(s:start_pos + 1, s:completion['matches'])
+	catch /^Vim(call):E785: complete() can only be used in Insert mode/
+	endtry
 endfunction
 
 function! s:handle_omnicompletion(server_name, complete_counter, data) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -88,19 +88,10 @@ function! lsp#omni#complete(findstart, base) abort
 
             let s:completion['status'] = ''
 
-    		if s:should_skip() | return | endif
             call timer_start(0, function('s:display_completions'))
 
             return exists('v:none') ? v:none : []
         endif
-    endif
-endfunction
-
-function! s:should_skip()
-    if mode() isnot# 'i'
-        return 1
-    else
-        return 0
     endif
 endfunction
 
@@ -148,10 +139,11 @@ function! s:contains_filter(item, last_typed_word) abort
 endfunction
 
 function! s:display_completions(timer) abort
-	try
-        call complete(s:start_pos + 1, s:completion['matches'])
-    catch /^Vim(call):E785: complete() can only be used in Insert mode/
-    endtry
+    if mode() is# 'i'
+		call complete(s:start_pos + 1, s:completion['matches'])
+    else
+        return 1
+    endif
 endfunction
 
 function! s:handle_omnicompletion(server_name, complete_counter, data) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -140,7 +140,7 @@ endfunction
 
 function! s:display_completions(timer) abort
     if mode() is# 'i'
-		call complete(s:start_pos + 1, s:completion['matches'])
+        call complete(s:start_pos + 1, s:completion['matches'])
     endif
 endfunction
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -97,7 +97,7 @@ function! lsp#omni#complete(findstart, base) abort
 endfunction
 
 function! s:should_skip()
-	   if mode() isnot# 'i'
+    if mode() isnot# 'i'
         return 1
     else
         return 0

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -88,10 +88,19 @@ function! lsp#omni#complete(findstart, base) abort
 
             let s:completion['status'] = ''
 
+    		if s:should_skip() | return | endif
             call timer_start(0, function('s:display_completions'))
 
             return exists('v:none') ? v:none : []
         endif
+    endif
+endfunction
+
+function! s:should_skip()
+	   if mode() isnot# 'i'
+        return 1
+    else
+        return 0
     endif
 endfunction
 


### PR DESCRIPTION
when using omni complete for lsp completion the user could leave insert mode before the the completion menu is ready. this causes the error `E785: complete() can only be used in Insert mode`. 
