### PR TITLE
Jump to next/previous diagnostics other than error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,18 @@ Also see `:h vim-lsp-folding`.
 |`:LspDocumentSymbol`| Show document symbols |
 |`:LspHover`| Show hover information |
 |`:LspImplementation` | Show implementation of interface in the current window |
+|`:LspNextDiagnostic`| jump to next diagnostic (all of error, warning, information, hint) |
 |`:LspNextError`| jump to next error |
 |`:LspNextReference`| jump to next reference to the symbol under cursor |
+|`:LspNextWarning`| jump to next warning |
 |`:LspPeekDeclaration`| Go to the declaration of the word under the cursor, but open in preview window |
 |`:LspPeekDefinition`| Go to the definition of the word under the cursor, but open in preview window |
 |`:LspPeekImplementation`| Go to the implementation of an interface, but open in preview window |
 |`:LspPeekTypeDefinition`| Go to the type definition of the word under the cursor, but open in preview window |
+|`:LspPreviousDiagnostic`| jump to previous diagnostic (all of error, warning, information, hint) |
 |`:LspPreviousError`| jump to previous error |
 |`:LspPreviousReference`| jump to previous reference to the symbol under cursor |
+|`:LspPreviousWarning`| jump to previous warning |
 |`:LspReferences`| Find references |
 |`:LspRename`| Rename symbol |
 |`:LspStatus` | Show the status of the language server |

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -88,15 +88,29 @@ endfunction
 function! lsp#ui#vim#diagnostics#next_error() abort
     let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
         \ {_, diagnostic -> diagnostic['severity'] ==# 1 })
-    if !len(l:diagnostics)
+    call s:next_diagnostic(l:diagnostics)
+endfunction
+
+function! lsp#ui#vim#diagnostics#next_warning() abort
+    let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
+        \ {_, diagnostic -> diagnostic['severity'] ==# 2 })
+    call s:next_diagnostic(l:diagnostics)
+endfunction
+
+function! lsp#ui#vim#diagnostics#next_diagnostic() abort
+    call s:next_diagnostic(s:get_all_buffer_diagnostics())
+endfunction
+
+function! s:next_diagnostic(diagnostics) abort
+    if !len(a:diagnostics)
         return
     endif
-    call sort(l:diagnostics, 's:compare_diagnostics')
+    call sort(a:diagnostics, 's:compare_diagnostics')
 
     let l:view = winsaveview()
     let l:next_line = 0
     let l:next_col = 0
-    for l:diagnostic in l:diagnostics
+    for l:diagnostic in a:diagnostics
         let l:line = l:diagnostic['range']['start']['line'] + 1
         let l:char = l:diagnostic['range']['start']['character']
         let l:col = lsp#utils#to_col('%', l:line, l:char)
@@ -110,8 +124,8 @@ function! lsp#ui#vim#diagnostics#next_error() abort
 
     if l:next_line == 0
         " Wrap to start
-        let l:next_line = l:diagnostics[0]['range']['start']['line'] + 1
-        let l:next_char = l:diagnostics[0]['range']['start']['character']
+        let l:next_line = a:diagnostics[0]['range']['start']['line'] + 1
+        let l:next_char = a:diagnostics[0]['range']['start']['character']
         let l:next_col = lsp#utils#to_col('%', l:next_line, l:next_char) - 1
     endif
 
@@ -134,18 +148,32 @@ endfunction
 function! lsp#ui#vim#diagnostics#previous_error() abort
     let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
         \ {_, diagnostic -> diagnostic['severity'] ==# 1 })
-    if !len(l:diagnostics)
+    call s:previous_diagnostic(l:diagnostics)
+endfunction
+
+function! lsp#ui#vim#diagnostics#previous_warning() abort
+    let l:diagnostics = filter(s:get_all_buffer_diagnostics(),
+        \ {_, diagnostic -> diagnostic['severity'] ==# 2 })
+    call s:previous_diagnostic(l:diagnostics)
+endfunction
+
+function! lsp#ui#vim#diagnostics#previous_diagnostic() abort
+    call s:previous_diagnostic(s:get_all_buffer_diagnostics())
+endfunction
+
+function! s:previous_diagnostic(diagnostics) abort
+    if !len(a:diagnostics)
         return
     endif
-    call sort(l:diagnostics, 's:compare_diagnostics')
+    call sort(a:diagnostics, 's:compare_diagnostics')
 
     let l:view = winsaveview()
     let l:next_line = 0
     let l:next_col = 0
-    let l:index = len(l:diagnostics) - 1
+    let l:index = len(a:diagnostics) - 1
     while l:index >= 0
-        let l:line = l:diagnostics[l:index]['range']['start']['line'] + 1
-        let l:char = l:diagnostics[l:index]['range']['start']['character']
+        let l:line = a:diagnostics[l:index]['range']['start']['line'] + 1
+        let l:char = a:diagnostics[l:index]['range']['start']['character']
         let l:col = lsp#utils#to_col('%', l:line, l:char)
         if l:line < l:view['lnum']
             \ || (l:line == l:view['lnum'] && l:col < l:view['col'])
@@ -158,8 +186,8 @@ function! lsp#ui#vim#diagnostics#previous_error() abort
 
     if l:next_line == 0
         " Wrap to end
-        let l:next_line = l:diagnostics[-1]['range']['start']['line'] + 1
-        let l:next_char = l:diagnostics[-1]['range']['start']['character']
+        let l:next_line = a:diagnostics[-1]['range']['start']['line'] + 1
+        let l:next_char = a:diagnostics[-1]['range']['start']['character']
         let l:next_col = lsp#utils#to_col('%', l:next_line, l:next_char) - 1
     endif
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -58,14 +58,18 @@ CONTENTS                                                  *vim-lsp-contents*
       LspDocumentRangeFormat                |LspDocumentRangeFormat|
       LspDocumentSymbol                     |LspDocumentSymbol|
       LspHover                              |LspHover|
+      LspNextDiagnostic                     |LspNextDiagnostic|
       LspNextError                          |LspNextError|
       LspNextReference                      |LspNextReference|
+      LspNextWarning                        |LspNextWarning|
       LspPeekDeclaration                    |LspPeekDeclaration|
       LspPeekDefinition                     |LspPeekDefinition|
       LspPeekImplementation                 |LspPeekImplementation|
       LspPeekTypeDefinition                 |LspPeekTypeDefinition|
+      LspPreviousDiagnostic                 |LspPreviousDiagnostic|
       LspPreviousError                      |LspPreviousError|
       LspPreviousReference                  |LspPreviousReference|
+      LspPreviousWarning                    |LspPreviousWarning|
       LspImplementation                     |LspImplementation|
       LspReferences                         |LspReferences|
       LspRename                             |LspRename|
@@ -914,6 +918,9 @@ Gets the hover information and displays it in the |preview-window|.
    set to enable a floating preview at the cursor which is closed automatically
    on cursormove if not focused and can be closed with <esc> if focused.
 
+LspNextDiagnostic					*LspNextDiagnostic*
+
+Jump to Next diagnostics including error, warning, information, hint.
 
 LspNextError						     *LspNextError*
 
@@ -922,6 +929,10 @@ Jump to Next err diagnostics
 LspNextReference                                          *LspNextReference*
 
 Jump to the next reference of the symbol under cursor.
+
+LspNextWarning						    *LspNextWarning*
+
+Jump to Next warning diagnostics
 
 LspPeekDeclaration                                      *LspPeekDeclaration*
 
@@ -951,6 +962,10 @@ Like |LspTypeDefinition|, but opens the type definition in the
 
 Also see |g:lsp_peek_alignment| and |g:lsp_preview_float|.
 
+LspPreviousDiagnostic				    *LspPreviousDiagnostic*
+
+Jump to Previous diagnostics including error, warning, information, hint.
+
 LspPreviousError					 *LspPreviousError*
 
 Jump to Previous err diagnostics
@@ -958,6 +973,10 @@ Jump to Previous err diagnostics
 LspPreviousReference                                  *LspPreviousReference*
 
 Jump to the previous reference of the symbol under cursor.
+
+LspPreviousWarning					*LspPreviousWarning*
+
+Jump to Previous warning diagnostics
 
 LspImplementation                                        *LspImplementation*
 
@@ -1019,12 +1038,16 @@ Available plug mappings are following:
   nnoremap <plug>(lsp-document-symbol)
   nnoremap <plug>(lsp-document-diagnostics)
   nnoremap <plug>(lsp-hover)
+  nnoremap <plug>(lsp-next-diagnostic)
   nnoremap <plug>(lsp-next-error)
   nnoremap <plug>(lsp-next-reference)
+  nnoremap <plug>(lsp-next-warning)
   nnoremap <plug>(lsp-preview-close)
   nnoremap <plug>(lsp-preview-focus)
+  nnoremap <plug>(lsp-previous-diagnostic)
   nnoremap <plug>(lsp-previous-error)
   nnoremap <plug>(lsp-previous-reference)
+  nnoremap <plug>(lsp-previous-warning)
   nnoremap <plug>(lsp-references)
   nnoremap <plug>(lsp-rename)
   nnoremap <plug>(lsp-workspace-symbol)

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -60,6 +60,10 @@ command! LspDocumentDiagnostics call lsp#ui#vim#diagnostics#document_diagnostics
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover#get_hover_under_cursor()
 command! LspNextError call lsp#ui#vim#diagnostics#next_error()
 command! LspPreviousError call lsp#ui#vim#diagnostics#previous_error()
+command! LspNextWarning call lsp#ui#vim#diagnostics#next_warning()
+command! LspPreviousWarning call lsp#ui#vim#diagnostics#previous_warning()
+command! LspNextDiagnostic call lsp#ui#vim#diagnostics#next_diagnostic()
+command! LspPreviousDiagnostic call lsp#ui#vim#diagnostics#previous_diagnostic()
 command! LspReferences call lsp#ui#vim#references()
 command! LspRename call lsp#ui#vim#rename()
 command! LspTypeDefinition call lsp#ui#vim#type_definition(0)
@@ -90,6 +94,10 @@ nnoremap <plug>(lsp-preview-close) :<c-u>call lsp#ui#vim#output#closepreview()<c
 nnoremap <plug>(lsp-preview-focus) :<c-u>call lsp#ui#vim#output#focuspreview()<cr>
 nnoremap <plug>(lsp-next-error) :<c-u>call lsp#ui#vim#diagnostics#next_error()<cr>
 nnoremap <plug>(lsp-previous-error) :<c-u>call lsp#ui#vim#diagnostics#previous_error()<cr>
+nnoremap <plug>(lsp-next-warning) :<c-u>call lsp#ui#vim#diagnostics#next_warning()<cr>
+nnoremap <plug>(lsp-previous-warning) :<c-u>call lsp#ui#vim#diagnostics#previous_warning()<cr>
+nnoremap <plug>(lsp-next-diagnostic) :<c-u>call lsp#ui#vim#diagnostics#next_diagnostic()<cr>
+nnoremap <plug>(lsp-previous-diagnostic) :<c-u>call lsp#ui#vim#diagnostics#previous_diagnostic()<cr>
 nnoremap <plug>(lsp-references) :<c-u>call lsp#ui#vim#references()<cr>
 nnoremap <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename()<cr>
 nnoremap <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition(0)<cr>


### PR DESCRIPTION
- add LspNextWarning, LspPreviousWarning commands to jump to warnings
- add LspNextDiagnostic, LspPreviousDiagnostic commands to jump to all kinds of diagnostics

Features in #586.

Currently only `LspNextWarning` is implemented as well as `LspNextError`, but we can easily implement `LspNextInformation` and `LspNextHint` if needed.