### PR TITLE
Add lsp_buffer_enabled

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -155,6 +155,7 @@ endfunction
 function! s:register_events() abort
     augroup lsp
         autocmd!
+        autocmd BufNewFile * call s:on_text_document_did_open()
         autocmd BufReadPost * call s:on_text_document_did_open()
         autocmd BufWritePost * call s:on_text_document_did_save()
         autocmd BufWinLeave * call s:on_text_document_did_close()

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -28,7 +28,7 @@ augroup _lsp_silent_
     autocmd User lsp_complete_done silent
     autocmd User lsp_float_opened silent
     autocmd User lsp_float_closed silent
-    autocmd User lsp_enabled silent
+    autocmd User lsp_buffer_enabled silent
 augroup END
 
 function! lsp#log_verbose(...) abort
@@ -184,7 +184,7 @@ function! s:on_text_document_did_open() abort
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
     call lsp#log('s:on_text_document_did_open()', l:buf, &filetype, getcwd(), lsp#utils#get_buffer_uri(l:buf))
     for l:server_name in lsp#get_whitelisted_servers(l:buf)
-        call s:ensure_flush(l:buf, l:server_name, function('s:fire_lsp_enabled', [l:server_name, l:buf]))
+        call s:ensure_flush(l:buf, l:server_name, function('s:fire_lsp_buffer_enabled', [l:server_name, l:buf]))
     endfor
 endfunction
 
@@ -284,11 +284,11 @@ function! s:ensure_flush_all(buf, server_names) abort
     endfor
 endfunction
 
-function! s:fire_lsp_enabled(server_name, buf, ...) abort
+function! s:fire_lsp_buffer_enabled(server_name, buf, ...) abort
     if a:buf == bufnr('%')
-        doautocmd User lsp_enabled
+        doautocmd User lsp_buffer_enabled
     else
-        exec printf('autocmd BufEnter <buffer=%d> ++once doautocmd User lsp_enabled', a:buf)
+        exec printf('autocmd BufEnter <buffer=%d> ++once doautocmd User lsp_buffer_enabled', a:buf)
     endif
 endfunction
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -72,7 +72,15 @@ CONTENTS                                                  *vim-lsp-contents*
       LspTypeDefinition                     |:LspTypeDefinition|
       LspWorkspaceSymbol                    |:LspWorkspaceSymbol|
     Autocommands                          |vim-lsp-autocommands|
+      lsp_setup                             |lsp_setup|
       lsp_complete_done                     |lsp_complete_done|
+      lsp_float_opened                      |lsp_float_opened|
+      lsp_float_closed                      |lsp_float_closed|
+      lsp_register_server                   |lsp_register_server|
+      lsp_unregister_server                 |lsp_unregister_server|
+      lsp_server_init                       |lsp_server_init|
+      lsp_server_exit                       |lsp_server_exit|
+      lsp_buffer_enabled                    |lsp_buffer_enabled|
     Mappings                              |vim-lsp-mappings|
        <plug>(lsp-preview-close)            |<plug>(lsp-preview-close)|
        <plug>(lsp-preview-focus)            |<plug>(lsp-preview-focus)|
@@ -130,6 +138,22 @@ on pyls (https://github.com/palantir/python-language-server)
 	endif
 <
     For more details refer to |lsp#register_server()|.
+
+3. Configure your settings for the buffer
+   Use |lsp_buffer_enabled| autocommand to configure the buffer.
+>
+        function! s:lsp_install() abort
+            setlocal omnifunc=lsp#complete
+            setlocal signcolumn=yes
+            nmap <buffer> gd <plug>(lsp-definition)
+            nmap <buffer> <f2> <plug>(lsp-rename)
+       endfunction
+
+       augroup lsp_install
+            au!
+            autocmd User lsp_enabled call s:lsp_install()
+       augroup END
+<
 
 WIKI                                               *vim-lsp-configure-wiki*
 For documentation on how to configure other language servers refer
@@ -982,6 +1006,11 @@ Prints the status of all registered servers.
 ==============================================================================
 Autocommands                                          *vim-lsp-autocommands*
 
+lsp_setup                                                        *lsp_setup*
+
+This autocommand is run once after vim-lsp is enabled. The server should be
+registered when this event is triggered.
+
 lsp_complete_done                                        *lsp_complete_done*
 
 This autocommand is run after Insert mode completion is done, similar to
@@ -992,6 +1021,38 @@ expansion, or custom post processing of completed items. Just like
 |CompleteDone|, the Vim variable |v:completed_item| contains information about
 the completed item. It is guaranteed that vim-lsp does not change the content
 of this variable during its |CompleteDone| autocommands.
+
+lsp_float_opened                                          *lsp_float_opened*
+
+This autocommand is run after the floating window is shown for preview.
+See also |preview-window|
+
+lsp_float_closed                                          *lsp_float_closed*
+
+This autocommand is run after the floating window is closed.
+See also |preview-window|
+
+lsp_register_server                                    *lsp_register_server*
+
+This autocommand is run after the server is registered.
+
+lsp_unregister_server                                *lsp_unregister_server*
+
+This autocommand is run after the server is unregistered.
+
+lsp_server_init                                            *lsp_server_init*
+
+This autocommand is run after the server is initialized.
+
+lsp_server_exit                                            *lsp_server_exit*
+
+This autocommand is run after the server is exited.
+
+lsp_buffer_enabled                                      *lsp_buffer_enabled*
+
+This autocommand is run after vim-lsp is enabled for the buffer. This event is
+triggered imediately when the buffer is currently active. If the buffer is not
+current active, the event will be triggered when the buffer will be active.
 
 
 ==============================================================================

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -142,7 +142,7 @@ on pyls (https://github.com/palantir/python-language-server)
 3. Configure your settings for the buffer
    Use |lsp_buffer_enabled| autocommand to configure the buffer.
 >
-        function! s:lsp_install() abort
+        function! s:on_lsp_buffer_enabled() abort
             setlocal omnifunc=lsp#complete
             setlocal signcolumn=yes
             nmap <buffer> gd <plug>(lsp-definition)
@@ -151,7 +151,7 @@ on pyls (https://github.com/palantir/python-language-server)
 
        augroup lsp_install
             au!
-            autocmd User lsp_enabled call s:lsp_install()
+            autocmd User lsp_enabled call s:on_lsp_buffer_enabled()
        augroup END
 <
 


### PR DESCRIPTION
Current implementation of vim-lsp fire lsp_server_init event after received response of initialize method. So

1. `:e foo.rb`
2. `:new` immediately
3. waiting

lsp_server_init event is triggered on empty buffer. I want to do key-mappings only to buffers with LSP enabled.

```vim
function! s:lsp_install() abort
  setlocal omnifunc=lsp#complete
  setlocal signcolumn=yes
  nmap <buffer> gd <plug>(lsp-definition)
  nmap <buffer> <f2> <plug>(lsp-rename)
endfunction

augroup lsp_install
  au!
  autocmd User lsp_server_init call s:lsp_install()
augroup END
```

But lsp_server_init event is not useful for this.  So I added new event lsp_enabled. This event is triggered imediately when the buffer is currently active. If the buffer is not current active, the event will be triggered when the buffer will be active.

This will be merged, we can write settings like below.
```vim
function! s:lsp_install() abort
  setlocal omnifunc=lsp#complete
  setlocal signcolumn=yes
  nmap <buffer> gd <plug>(lsp-definition)
  nmap <buffer> <f2> <plug>(lsp-rename)
endfunction

augroup lsp_install
  au!
  autocmd User lsp_enabled call s:lsp_install()
augroup END
```
