### PR TITLE
Fix error on s:set_textprops()

### DIFF
--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -47,7 +47,7 @@ function! s:get_line_count_buf(buf) abort
     if !has('patch-8.1.1967')
         return line('$')
     endif
-    return line('$', bufwinid(a:buf))
+    return line('$', win_findbuf(a:buf)[0])
 endfunction
 
 function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort


### PR DESCRIPTION
`bufwinid()` works on current tab page only, so when user changes the
current tab page, bufwinid() returns -1.