### PR TITLE
Add only parameter for code action request

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -416,6 +416,7 @@ function! lsp#ui#vim#code_action() abort
             \   'range': l:range,
             \   'context': {
             \       'diagnostics' : l:diagnostics,
+            \       'only': ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source', 'source.organizeImports'],
             \   },
             \ },
             \ 'on_notification': function('s:handle_code_action', [l:server, s:last_req_id, 'codeAction']),


### PR DESCRIPTION
related #522.

Adding "only" parameter for code action request.
This will enables `organizeImports` action.

I checked `gopls`, `typescript-language-server` both.
