### PR TITLE
Fix completion when enable `g:lsp_async_completion`

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -1,3 +1,5 @@
+" vint: -ProhibitUnusedVariable
+
 " constants {{{
 
 let s:default_completion_item_kinds = {
@@ -421,10 +423,10 @@ function! s:apply_text_edits() abort
         " should not be duplicated since the textEdit include the character.
         " this remove the following character.
         if l:snippet_marker_pos != -1
-            let oldpos = line('.')
-            let oldline = getline('.')
+            let l:oldpos = line('.')
+            let l:oldline = getline('.')
             call timer_start(1, {_-> [
-        \    setline(oldpos, oldline),
+        \    setline(l:oldpos, l:oldline),
         \    execute('redraw', 1),
         \    execute('doautocmd User lsp_complete_done', 1),
         \] })


### PR DESCRIPTION
This PR aims to solve #614.

#614 is caused by `g:lsp_async_completion = 1`.
The reason is that different implementation for the cases that `g:lsp_async_completion` 1 or 0.

I refactored to use same implementation for the both cases.