### PR TITLE
Fix CompleteDone

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -58,7 +58,7 @@ function! lsp#enable() abort
         if g:lsp_highlights_enabled | call lsp#ui#vim#highlights#enable() | endif
         if g:lsp_textprop_enabled | call lsp#ui#vim#diagnostics#textprop#enable() | endif
     endif
-    call lsp#ui#vim#completion#setup()
+    call lsp#ui#vim#completion#_setup()
     call s:register_events()
 endfunction
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -58,6 +58,7 @@ function! lsp#enable() abort
         if g:lsp_highlights_enabled | call lsp#ui#vim#highlights#enable() | endif
         if g:lsp_textprop_enabled | call lsp#ui#vim#diagnostics#textprop#enable() | endif
     endif
+    call lsp#ui#vim#completion#setup()
     call s:register_events()
 endfunction
 

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -247,7 +247,13 @@ function! s:lsp_send(id, opts, type) abort " opts = { id?, method?, result?, par
     if (a:type == s:send_type_request)
         let l:id = l:request['id']
         if get(a:opts, 'sync', 0) !=# 0
+            let l:start_time = reltime()
+
+            let l:timeout = get(a:opts, 'sync_timeout', -1)
             while has_key(l:ctx['requests'], l:request['id'])
+                if reltimefloat(reltime(l:start_time)) > l:timeout && l:timeout != -1
+                    throw 'lsp#client: timeout'
+                endif
                 sleep 1m
             endwhile
         endif

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -251,7 +251,7 @@ function! s:lsp_send(id, opts, type) abort " opts = { id?, method?, result?, par
 
             let l:timeout = get(a:opts, 'sync_timeout', -1)
             while has_key(l:ctx['requests'], l:request['id'])
-                if reltimefloat(reltime(l:start_time)) > l:timeout && l:timeout != -1
+                if (reltimefloat(reltime(l:start_time)) * 1000) > l:timeout && l:timeout != -1
                     throw 'lsp#client: timeout'
                 endif
                 sleep 1m

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -325,7 +325,7 @@ function! s:create_user_data(item, server_name) abort
     return l:user_data
 endfunction
 
-function! lsp#omni#extract_user_data_from_completed_item(completed_item) abort
+function! lsp#omni#get_user_data_from_completed_item(completed_item) abort
     " the item has no user_data.
     if !has_key(a:completed_item, 'user_data')
         return {}
@@ -333,7 +333,7 @@ function! lsp#omni#extract_user_data_from_completed_item(completed_item) abort
 
     " try to decode user_data.
     try
-        let l:user_data = json_decode(a:completed_item.user_data)
+        let l:user_data = json_decode(a:completed_item['user_data'])
     catch /.*/
         let l:user_data = {}
     endtry
@@ -347,10 +347,7 @@ function! lsp#omni#extract_user_data_from_completed_item(completed_item) abort
         return {}
     endif
 
-    return {
-                \   'server_name': l:user_data[s:user_data_server_name_key],
-                \   'completion_item': l:user_data[s:user_data_completion_item_key]
-                \ }
+    return l:user_data
 endfunction
 
 function! lsp#omni#get_completion_item_kinds() abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -300,7 +300,7 @@ endfunction
 "
 " This function should call at `CompleteDone` only if not empty `v:completed_item`.
 "
-function! lsp#omni#clear_managed_user_data_map() abort
+function! lsp#omni#_clear_managed_user_data_map() abort
     let s:managed_user_data_key_base = 0
     let s:managed_user_data_map = {}
 endfunction
@@ -309,10 +309,11 @@ endfunction
 " create item's user_data.
 "
 function! s:create_user_data(completion_item, server_name) abort
-    let l:user_data_key = 'vim-lsp/' . string(s:managed_user_data_key_base)
-    let s:managed_user_data_map[l:user_data_key] = {}
-    let s:managed_user_data_map[l:user_data_key]['server_name'] = a:server_name
-    let s:managed_user_data_map[l:user_data_key]['completion_item'] = a:completion_item
+    let l:user_data_key = 'vim-lsp/key/' . string(s:managed_user_data_key_base)
+    let s:managed_user_data_map[l:user_data_key] = {
+                \   'server_name': a:server_name,
+                \   'completion_item': a:completion_item
+                \ }
     let s:managed_user_data_key_base += 1
     return l:user_data_key
 endfunction

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -300,7 +300,7 @@ endfunction
 "
 " create item's user_data.
 "
-function! s:create_user_data(item, server_name)
+function! s:create_user_data(item, server_name) abort
     let l:user_data = {}
 
     " InsertStartKey.
@@ -323,7 +323,7 @@ function! s:create_user_data(item, server_name)
     return l:user_data
 endfunction
 
-function! lsp#omni#extract_user_data_from_completed_item(completed_item)
+function! lsp#omni#extract_user_data_from_completed_item(completed_item) abort
     " the item has no user_data.
     if !has_key(a:completed_item, 'user_data')
         return {}

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -39,6 +39,7 @@ let s:completion_status_pending = 'pending'
 let s:is_user_data_support = has('patch-8.0.1493')
 let s:user_data_insert_start_key = 'vim-lsp/insertStart'
 let s:user_data_filtertext_key = 'vim-lsp/filterText'
+let s:user_data_text_edit_key = 'vim-lsp/textEdit' " This key can be removed. But vim-lsp-snippets uses this key. So this key leave for now.
 let s:user_data_server_name_key = 'vim-lsp/serverName'
 let s:user_data_completion_item_key = 'vim-lsp/completionItem'
 
@@ -306,6 +307,7 @@ function! s:create_user_data(item, server_name) abort
     " InsertStartKey.
     let l:user_data[s:user_data_insert_start_key] = -1
     if has_key(a:item, 'textEdit') && type(a:item.textEdit) == type({})
+        let l:user_data[s:user_data_text_edit_key] = a:item.textEdit
         let l:user_data[s:user_data_insert_start_key] = a:item.textEdit.range.start.character
     endif
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -147,7 +147,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
 endfunction
 
 "
-" Remove inserted text duratin completion.
+" Remove inserted text during completion.
 "
 function! s:clear_inserted_text(line, position, completed_item, completion_item) abort
   " Remove commit characters.

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -79,7 +79,7 @@ endfunction
 "
 " Try `completionItem/resolve` if it possible.
 "
-function! s:resolve_completion_item(completion_item, server_name)
+function! s:resolve_completion_item(completion_item, server_name) abort
   " server_name is not provided.
   if empty(a:server_name)
     return a:completion_item

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -1,0 +1,179 @@
+let s:context = {}
+
+function! lsp#ui#vim#completion#setup() abort
+  augroup lsp_ui_vim_completion
+    autocmd!
+    autocmd CompleteDone * call s:on_complete_done()
+  augroup END
+endfunction
+
+"
+" After CompleteDone, v:complete_item's word has been inserted into the line.
+" Yet not inserted commit characters.
+"
+" below example uses # as cursor position.
+"
+" 1. `call getbuf#`<C-x><C-o>
+" 2. select `getbufline` item.
+" 3. Insert commit characters. e.g. `(`
+" 4. fire CompleteDone, then the line is `call getbufline#`
+" 5. call feedkeys to call `s:on_complete_done_after`
+" 6. then the line is `call getbufline(#` in `s:on_complete_done_after`
+"
+function! s:on_complete_done() abort
+  let l:user_data = lsp#omni#extract_user_data_from_completed_item(v:completed_item)
+  if empty(l:user_data)
+    doautocmd User lsp_complete_done
+    return
+  endif
+
+  let s:context.line = getline('.')
+  let s:context.position = getpos('.')
+  let s:context.completed_item = copy(v:completed_item)
+  let s:context.server_name = l:user_data.server_name
+  let s:context.completion_item = l:user_data.completion_item
+  call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
+endfunction
+
+"
+" Apply textEdit or insertText(snippet) and additionalTextEdits.
+"
+function! s:on_complete_done_after() abort
+  let l:line = s:context.line
+  let l:position = s:context.position
+  let l:completed_item = s:context.completed_item
+  let l:server_name = s:context.server_name
+  let l:completion_item = s:context.completion_item
+
+  " check the commit characters are <BS> or <C-w>.
+  if strlen(getline('.')) < strlen(l:line)
+    doautocmd User lsp_complete_done
+    return ''
+  endif
+
+  let l:completion_item = s:resolve_completion_item(l:completion_item, l:server_name)
+
+  " apply textEdit or insertText(snippet).
+  let l:expanding_text = s:get_expanding_text(l:completed_item, l:completion_item)
+  if strlen(l:expanding_text) > 0
+    call s:clear_inserted_text(
+          \   l:line,
+          \   l:position,
+          \   l:completed_item,
+          \   l:completion_item
+          \ )
+  endif
+
+  " apply additionalTextEdits.
+  if has_key(l:completion_item, 'additionalTextEdits')
+    call lsp#utils#text_edit#apply_text_edits(
+          \ lsp#utils#get_buffer_uri(bufnr('%')),
+          \ l:completion_item.additionalTextEdits
+          \ )
+  endif
+
+  doautocmd User lsp_complete_done
+  return ''
+endfunction
+
+"
+" Try `completionItem/resolve` if it possible.
+"
+function! s:resolve_completion_item(completion_item, server_name)
+  " server_name is not provided.
+  if empty(a:server_name)
+    return a:completion_item
+  endif
+
+  " check server capabilities.
+  let l:capabilities = lsp#get_server_capabilities(a:server_name)
+  if !has_key(l:capabilities, 'completionProvider')
+        \ || !has_key(l:capabilities.completionProvider, 'resolveProvider')
+    return a:completion_item
+  endif
+
+  let l:ctx = {}
+  let l:ctx.response = {}
+  function! l:ctx.callback(data) abort
+    let self.response = a:data.response
+  endfunction
+
+  call lsp#send_request(a:server_name, {
+        \   'method': 'completionItem/resolve',
+        \   'params': a:completion_item,
+        \   'sync': 1,
+        \   'on_notification': function(l:ctx.callback, [], l:ctx)
+        \ })
+
+  if empty(l:ctx.response)
+    return a:completion_item
+  endif
+
+  if lsp#client#is_error(l:ctx.response)
+    return a:completion_item
+  endif
+
+  return l:ctx.response.result
+endfunction
+
+"
+" Remove inserted text duratin completion.
+"
+function! s:clear_inserted_text(line, position, completed_item, completion_item) abort
+  " Remove commit characters.
+  call setline('.', a:line)
+
+  " Create range to remove v:completed_item.
+  let l:range = {
+        \   'start': {
+        \     'line': a:position[1] - 1,
+        \     'character': (a:position[2] + a:position[3]) - strlen(a:completed_item.word) - 1
+        \   },
+        \   'end': {
+        \     'line': a:position[1] - 1,
+        \     'character': (a:position[2] + a:position[3]) - 1
+        \   }
+        \ }
+
+  " Expand remove range to textEdit.
+  if has_key(a:completion_item, 'textEdit')
+    let l:range.start.character = min([
+          \   l:range.start.character,
+          \   a:completion_item.textEdit.range.start.character
+          \ ])
+    let l:range.end.character = max([
+          \   l:range.end.character,
+          \   a:completion_item.textEdit.range.end.character
+          \ ])
+  endif
+
+  " Remove.
+  call lsp#utils#text_edit#apply_text_edits(lsp#utils#get_buffer_uri(bufnr('%')), [{
+        \   'range': l:range,
+        \   'newText': ''
+        \ }])
+
+  " Move to complete start position.
+  call cursor([l:range.start.line + 1, l:range.start.character + 1])
+endfunction
+
+"
+" Get textEdit.newText or insertText when the text is not same to v:completed_item.word.
+"
+function! s:get_expanding_text(completed_item, completion_item) abort
+  let l:text = a:completed_item.word
+  if has_key(a:completion_item, 'textEdit')
+    let l:text = a:completion_item.textEdit.newText
+  elseif has_key(a:completion_item, 'insertText')
+    let l:text = a:completion_item.insertText
+  endif
+  return l:text != a:completed_item.word ? l:text : ''
+endfunction
+
+"
+" Get script id that uses to call `s:` function in feedkeys.
+"
+function! s:SID() abort
+  return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
+endfun
+

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -72,7 +72,7 @@ function! s:on_complete_done_after() abort
           \ )
     if exists('g:lsp_snippets_expand_snippet') && len(g:lsp_snippets_expand_snippet) > 0
       " vim-lsp-snippets expects commit characters removed.
-      call s:expand_text_simply(v:completed_item.word)
+      call s:expand_text_simply(v:completed_item['word'])
     elseif exists('g:lsp_snippet_expand') && len(g:lsp_snippet_expand) > 0
       " other snippet integartion point.
       call g:lsp_snippet_expand[0]({

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -1,3 +1,5 @@
+" vint: -ProhibitUnusedVariable
+"
 let s:context = {}
 
 function! lsp#ui#vim#completion#setup() abort

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -146,6 +146,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
           \   'on_notification': function(l:ctx['callback'], [], l:ctx)
           \ })
   catch /.*/
+    call lsp#log('s:resolve_completion_item', 'request timeout.')
   endtry
 
   if empty(l:ctx['response'])

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -134,13 +134,14 @@ function! s:resolve_completion_item(completion_item, server_name) abort
   let l:ctx = {}
   let l:ctx['response'] = {}
   function! l:ctx['callback'](data) abort
-    let l:self['response'] = a:data.response
+    let l:self['response'] = a:data['response']
   endfunction
 
   call lsp#send_request(a:server_name, {
         \   'method': 'completionItem/resolve',
         \   'params': a:completion_item,
         \   'sync': 1,
+        \   'sync_timeout': g:lsp_completion_resolve_timeout,
         \   'on_notification': function(l:ctx['callback'], [], l:ctx)
         \ })
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -177,7 +177,7 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
           \ ])
   endif
 
-  " Remove.
+  " Remove v:completed_item.word (and textEdit range if need).
   call lsp#utils#text_edit#apply_text_edits(lsp#utils#get_buffer_uri(bufnr('%')), [{
         \   'range': l:range,
         \   'newText': ''

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -136,6 +136,10 @@ function! s:resolve_completion_item(completion_item, server_name) abort
     return a:completion_item
   endif
 
+  if empty(l:ctx.response.result)
+    return a:completion_item
+  endif
+
   return l:ctx.response.result
 endfunction
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -68,10 +68,16 @@ function! s:on_complete_done_after() abort
 
   " apply additionalTextEdits.
   if has_key(l:completion_item, 'additionalTextEdits')
+    let l:saved_mark = getpos("'a")
+    let l:pos = getpos('.')
+    call setpos("'a", l:pos)
     call lsp#utils#text_edit#apply_text_edits(
           \ lsp#utils#get_buffer_uri(bufnr('%')),
           \ l:completion_item.additionalTextEdits
           \ )
+    let l:pos = getpos("'a")
+    call setpos("'a", l:saved_mark)
+    call setpos('.', l:pos)
   endif
 
   doautocmd User lsp_complete_done

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -13,27 +13,27 @@ endfunction
 " After CompleteDone, v:complete_item's word has been inserted into the line.
 " Yet not inserted commit characters.
 "
-" below example uses # as cursor position.
+" below example uses | as cursor position.
 "
-" 1. `call getbuf#`<C-x><C-o>
+" 1. `call getbuf|`<C-x><C-o>
 " 2. select `getbufline` item.
 " 3. Insert commit characters. e.g. `(`
-" 4. fire CompleteDone, then the line is `call getbufline#`
+" 4. fire CompleteDone, then the line is `call getbufline|`
 " 5. call feedkeys to call `s:on_complete_done_after`
-" 6. then the line is `call getbufline(#` in `s:on_complete_done_after`
+" 6. then the line is `call getbufline(|` in `s:on_complete_done_after`
 "
 function! s:on_complete_done() abort
-  let l:user_data = lsp#omni#extract_user_data_from_completed_item(v:completed_item)
+  let l:user_data = lsp#omni#get_user_data_from_completed_item(v:completed_item)
   if empty(l:user_data)
     doautocmd User lsp_complete_done
     return
   endif
 
-  let s:context.line = getline('.')
-  let s:context.position = getpos('.')
-  let s:context.completed_item = copy(v:completed_item)
-  let s:context.server_name = l:user_data.server_name
-  let s:context.completion_item = l:user_data.completion_item
+  let s:context['line'] = getline('.')
+  let s:context['position'] = getpos('.')
+  let s:context['completed_item'] = copy(v:completed_item)
+  let s:context['server_name'] = l:user_data['vim-lsp/serverName']
+  let s:context['completion_item'] = l:user_data['vim-lsp/completionItem']
   call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
 endfunction
 
@@ -41,11 +41,11 @@ endfunction
 " Apply textEdit or insertText(snippet) and additionalTextEdits.
 "
 function! s:on_complete_done_after() abort
-  let l:line = s:context.line
-  let l:position = s:context.position
-  let l:completed_item = s:context.completed_item
-  let l:server_name = s:context.server_name
-  let l:completion_item = s:context.completion_item
+  let l:line = s:context['line']
+  let l:position = s:context['position']
+  let l:completed_item = s:context['completed_item']
+  let l:server_name = s:context['server_name']
+  let l:completion_item = s:context['completion_item']
 
   " check the commit characters are <BS> or <C-w>.
   if strlen(getline('.')) < strlen(l:line)
@@ -91,7 +91,7 @@ function! s:on_complete_done_after() abort
     call setpos("'a", l:pos)
     call lsp#utils#text_edit#apply_text_edits(
           \ lsp#utils#get_buffer_uri(bufnr('%')),
-          \ l:completion_item.additionalTextEdits
+          \ l:completion_item['additionalTextEdits']
           \ )
     let l:pos = getpos("'a")
     call setpos("'a", l:saved_mark)
@@ -114,36 +114,36 @@ function! s:resolve_completion_item(completion_item, server_name) abort
   " check server capabilities.
   let l:capabilities = lsp#get_server_capabilities(a:server_name)
   if !has_key(l:capabilities, 'completionProvider')
-        \ || !has_key(l:capabilities.completionProvider, 'resolveProvider')
+        \ || !has_key(l:capabilities['completionProvider'], 'resolveProvider')
     return a:completion_item
   endif
 
   let l:ctx = {}
-  let l:ctx.response = {}
-  function! l:ctx.callback(data) abort
-    let l:self.response = a:data.response
+  let l:ctx['response'] = {}
+  function! l:ctx['callback'](data) abort
+    let l:self['response'] = a:data.response
   endfunction
 
   call lsp#send_request(a:server_name, {
         \   'method': 'completionItem/resolve',
         \   'params': a:completion_item,
         \   'sync': 1,
-        \   'on_notification': function(l:ctx.callback, [], l:ctx)
+        \   'on_notification': function(l:ctx['callback'], [], l:ctx)
         \ })
 
-  if empty(l:ctx.response)
+  if empty(l:ctx['response'])
     return a:completion_item
   endif
 
-  if lsp#client#is_error(l:ctx.response)
+  if lsp#client#is_error(l:ctx['response'])
     return a:completion_item
   endif
 
-  if empty(l:ctx.response.result)
+  if empty(l:ctx['response']['result'])
     return a:completion_item
   endif
 
-  return l:ctx.response.result
+  return l:ctx['response']['result']
 endfunction
 
 "
@@ -157,7 +157,7 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
   let l:range = {
         \   'start': {
         \     'line': a:position[1] - 1,
-        \     'character': lsp#utils#to_char('%', a:position[1], a:position[2] + a:position[3]) - strchars(a:completed_item.word)
+        \     'character': lsp#utils#to_char('%', a:position[1], a:position[2] + a:position[3]) - strchars(a:completed_item['word'])
         \   },
         \   'end': {
         \     'line': a:position[1] - 1,
@@ -167,13 +167,13 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
 
   " Expand remove range to textEdit.
   if has_key(a:completion_item, 'textEdit')
-    let l:range.start.character = min([
-          \   l:range.start.character,
-          \   a:completion_item.textEdit.range.start.character
+    let l:range['start']['character'] = min([
+          \   l:range['start']['character'],
+          \   a:completion_item['textEdit']['range']['start']['character']
           \ ])
-    let l:range.end.character = max([
-          \   l:range.end.character,
-          \   a:completion_item.textEdit.range.end.character
+    let l:range['end']['character'] = max([
+          \   l:range['end']['character'],
+          \   a:completion_item['textEdit']['range']['end']['character']
           \ ])
   endif
 
@@ -185,8 +185,8 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
 
   " Move to complete start position.
   call cursor(
-        \   l:range.start.line + 1,
-        \   lsp#utils#to_col('%', l:range.start.line + 1, l:range.start.character)
+        \   l:range['start']['line'] + 1,
+        \   lsp#utils#to_col('%', l:range['start']['line'] + 1, l:range['start']['character'])
         \ )
 endfunction
 
@@ -194,13 +194,13 @@ endfunction
 " Get textEdit.newText or insertText when the text is not same to v:completed_item.word.
 "
 function! s:get_expand_text(completed_item, completion_item) abort
-  let l:text = a:completed_item.word
+  let l:text = a:completed_item['word']
   if has_key(a:completion_item, 'textEdit')
-    let l:text = a:completion_item.textEdit.newText
+    let l:text = a:completion_item['textEdit']['newText']
   elseif has_key(a:completion_item, 'insertText')
-    let l:text = a:completion_item.insertText
+    let l:text = a:completion_item['insertText']
   endif
-  return l:text != a:completed_item.word ? l:text : ''
+  return l:text != a:completed_item['word'] ? l:text : ''
 endfunction
 
 "
@@ -213,7 +213,7 @@ function! s:expand_text_simply(text) abort
         \ }
 
   " Remove placeholders and get first placeholder position that use to cursor position.
-  " e.g. `#getbufline(${1:expr}, ${2:lnum})${0}` to getbufline(#,)
+  " e.g. `|getbufline(${1:expr}, ${2:lnum})${0}` to getbufline(|,)
   let l:text = substitute(a:text, '\$\%({[0-9]*[^}]*}\|[0-9]*\)', '', 'g')
   let l:offset = match(a:text, '\$\%({[0-9]*[^}]*}\|[0-9]*\)')
   if l:offset == -1
@@ -228,8 +228,8 @@ function! s:expand_text_simply(text) abort
         \   'newText': l:text
         \ }])
   call cursor(
-        \   l:pos.line + 1,
-        \   lsp#utils#to_col('%', l:pos.line + 1, l:pos.character) + l:offset
+        \   l:pos['line'] + 1,
+        \   lsp#utils#to_col('%', l:pos['line'] + 1, l:pos['character']) + l:offset
         \ )
 endfunction
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -115,6 +115,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
   let l:capabilities = lsp#get_server_capabilities(a:server_name)
   if !has_key(l:capabilities, 'completionProvider')
         \ || !has_key(l:capabilities['completionProvider'], 'resolveProvider')
+        \ || !l:capabilities['completionProvider']['resolveProvider']
     return a:completion_item
   endif
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -2,7 +2,7 @@
 "
 let s:context = {}
 
-function! lsp#ui#vim#completion#setup() abort
+function! lsp#ui#vim#completion#_setup() abort
   augroup lsp_ui_vim_completion
     autocmd!
     autocmd CompleteDone * call s:on_complete_done()
@@ -32,7 +32,7 @@ function! s:on_complete_done() abort
   let l:managed_user_data = lsp#omni#get_managed_user_data_from_completed_item(v:completed_item)
 
   " Clear managed user_data.
-  call lsp#omni#clear_managed_user_data_map()
+  call lsp#omni#_clear_managed_user_data_map()
 
   " If managed user_data does not exists, skip it.
   if empty(l:managed_user_data)
@@ -81,9 +81,10 @@ function! s:on_complete_done_after() abort
           \   l:completed_item,
           \   l:completion_item
           \ )
+
     if exists('g:lsp_snippets_expand_snippet') && len(g:lsp_snippets_expand_snippet) > 0
       " vim-lsp-snippets expects commit characters removed.
-      call s:expand_text_simply(v:completed_item['word'])
+      call s:simple_expand_text(v:completed_item['word'])
     elseif exists('g:lsp_snippet_expand') && len(g:lsp_snippet_expand) > 0
       " other snippet integartion point.
       call g:lsp_snippet_expand[0]({
@@ -91,7 +92,7 @@ function! s:on_complete_done_after() abort
             \ })
     else
       " expand text simply.
-      call s:expand_text_simply(l:expand_text)
+      call s:simple_expand_text(l:expand_text)
     endif
   endif
 
@@ -196,10 +197,7 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
         \ }])
 
   " Move to complete start position.
-  call cursor(
-        \   l:range['start']['line'] + 1,
-        \   lsp#utils#to_col('%', l:range['start']['line'] + 1, l:range['start']['character'])
-        \ )
+  call cursor(lsp#utils#position#_lsp_to_vim('%', l:range['start']))
 endfunction
 
 "
@@ -218,7 +216,7 @@ endfunction
 "
 " Expand text
 "
-function! s:expand_text_simply(text) abort
+function! s:simple_expand_text(text) abort
   let l:pos = {
         \   'line': line('.') - 1,
         \   'character': lsp#utils#to_char('%', line('.'), col('.'))
@@ -239,10 +237,12 @@ function! s:expand_text_simply(text) abort
         \   },
         \   'newText': l:text
         \ }])
-  call cursor(
-        \   l:pos['line'] + 1,
-        \   lsp#utils#to_col('%', l:pos['line'] + 1, l:pos['character']) + l:offset
-        \ )
+
+  let l:pos = lsp#utils#position#_lsp_to_vim('%', {
+        \   'line': l:pos['line'],
+        \   'character': l:pos['character'] + l:offset
+        \ })
+  call cursor(l:pos)
 endfunction
 
 "

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -23,8 +23,19 @@ endfunction
 " 6. then the line is `call getbufline(|` in `s:on_complete_done_after`
 "
 function! s:on_complete_done() abort
-  let l:user_data = lsp#omni#get_user_data_from_completed_item(v:completed_item)
-  if empty(l:user_data)
+  if empty(v:completed_item)
+    doautocmd User lsp_complete_done
+    return
+  endif
+
+  " Try to get managed user_data.
+  let l:managed_user_data = lsp#omni#get_managed_user_data_from_completed_item(v:completed_item)
+
+  " Clear managed user_data.
+  call lsp#omni#clear_managed_user_data_map()
+
+  " If managed user_data does not exists, skip it.
+  if empty(l:managed_user_data)
     doautocmd User lsp_complete_done
     return
   endif
@@ -32,8 +43,8 @@ function! s:on_complete_done() abort
   let s:context['line'] = getline('.')
   let s:context['position'] = getpos('.')
   let s:context['completed_item'] = copy(v:completed_item)
-  let s:context['server_name'] = l:user_data['vim-lsp/serverName']
-  let s:context['completion_item'] = l:user_data['vim-lsp/completionItem']
+  let s:context['server_name'] = l:managed_user_data['server_name']
+  let s:context['completion_item'] = l:managed_user_data['completion_item']
   call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
 endfunction
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -137,13 +137,16 @@ function! s:resolve_completion_item(completion_item, server_name) abort
     let l:self['response'] = a:data['response']
   endfunction
 
-  call lsp#send_request(a:server_name, {
-        \   'method': 'completionItem/resolve',
-        \   'params': a:completion_item,
-        \   'sync': 1,
-        \   'sync_timeout': g:lsp_completion_resolve_timeout,
-        \   'on_notification': function(l:ctx['callback'], [], l:ctx)
-        \ })
+  try
+    call lsp#send_request(a:server_name, {
+          \   'method': 'completionItem/resolve',
+          \   'params': a:completion_item,
+          \   'sync': 1,
+          \   'sync_timeout': g:lsp_completion_resolve_timeout,
+          \   'on_notification': function(l:ctx['callback'], [], l:ctx)
+          \ })
+  catch /.*/
+  endtry
 
   if empty(l:ctx['response'])
     return a:completion_item

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -53,6 +53,11 @@ function! s:on_complete_done_after() abort
     return ''
   endif
 
+  " Do nothing if text_edit is disabled.
+  if !g:lsp_text_edit_enabled
+    return ''
+  endif
+
   let l:completion_item = s:resolve_completion_item(l:completion_item, l:server_name)
 
   " apply textEdit or insertText(snippet).

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -75,7 +75,9 @@ function! s:on_complete_done_after() abort
       call s:expand_text_simply(v:completed_item.word)
     elseif exists('g:lsp_snippet_expand') && len(g:lsp_snippet_expand) > 0
       " other snippet integartion point.
-      call g:lsp_snippet_expand[0](l:expand_text)
+      call g:lsp_snippet_expand[0]({
+            \   'snippet': l:expand_text
+            \ })
     else
       " expand text simply.
       call s:expand_text_simply(l:expand_text)

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -95,7 +95,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
   let l:ctx = {}
   let l:ctx.response = {}
   function! l:ctx.callback(data) abort
-    let self.response = a:data.response
+    let l:self.response = a:data.response
   endfunction
 
   call lsp#send_request(a:server_name, {

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -594,6 +594,12 @@ g:lsp_snippet_expand                                 *g:lsp_snippet_expand*
     The integration point to other snippet plugin.
     vim-lsp may invoke the first item of this value when it needs snippet expansion.
 
+g:lsp_completion_resolve_timeout         *g:lsp_completion_resolve_timeout*
+    Type: |Number|
+    Default: `200`
+
+    The `completionItem/resolve` request's timeout value.
+    If your vim freeze at `CompleteDone`, you can set this value to 0.
 
 ==============================================================================
 FUNCTIONS                                               *vim-lsp-functions*

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -40,6 +40,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_log_file                        |g:lsp_log_file|
       g:lsp_semantic_enabled                |g:lsp_semantic_enabled|
       g:lsp_text_document_did_save_delay    |g:lsp_text_document_did_save_delay|
+      g:lsp_snippet_expand                  |g:lsp_snippet_expand|
     Functions                             |vim-lsp-functions|
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|
@@ -586,6 +587,12 @@ g:lsp_text_document_did_save_delay   *g:lsp_text_document_did_save_delay*
     The waiting time in milliseconds before sending textDocument/didSave to
     LSP servers, -1 by default means no delay. If >= 0, will delay using
     |timer_start()| with {time} is the number.
+
+g:lsp_snippet_expand                                 *g:lsp_snippet_expand*
+    Type: |List|
+
+    The integration point to other snippet plugin.
+    vim-lsp may invoke the first item of this value when it needs snippet expansion.
 
 
 ==============================================================================

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -41,6 +41,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_semantic_enabled                |g:lsp_semantic_enabled|
       g:lsp_text_document_did_save_delay    |g:lsp_text_document_did_save_delay|
       g:lsp_snippet_expand                  |g:lsp_snippet_expand|
+      g:lsp_completion_resolve_timeout      |g:lsp_completion_resolve_timeout|
     Functions                             |vim-lsp-functions|
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -41,6 +41,7 @@ let g:lsp_hover_conceal = get(g:, 'lsp_hover_conceal', 1)
 let g:lsp_ignorecase = get(g:, 'lsp_ignorecase', &ignorecase)
 let g:lsp_semantic_enabled = get(g:, 'lsp_semantic_enabled', 1)
 let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_delay', -1)
+let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -1,7 +1,7 @@
 Describe lsp#omni
 
     Before each
-        call lsp#omni#clear_managed_user_data_map()
+        call lsp#omni#_clear_managed_user_data_map()
     End
 
     Describe lsp#omni#get_vim_completion_item
@@ -22,7 +22,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': 'vim-lsp/0'
+            \ 'user_data': 'vim-lsp/key/0'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)
@@ -56,7 +56,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': 'vim-lsp/0'
+            \ 'user_data': 'vim-lsp/key/0'
             \}
 
             let got = lsp#omni#get_vim_completion_item(item)
@@ -84,7 +84,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail more-detail',
-            \ 'user_data': 'vim-lsp/0'
+            \ 'user_data': 'vim-lsp/key/0'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -1,21 +1,9 @@
-" Remove keys we're not interested in
-function! PreprocessItem(item) abort
-    let l:item = a:item
-
-    if has_key(l:item, 'user_data')
-        let l:user_data = json_decode(l:item['user_data'])
-        unlet l:user_data['vim-lsp/insertStart']
-        let l:item['user_data'] = json_encode(l:user_data)
-    endif
-
-    if l:item['user_data'] == '{}'
-        unlet l:item['user_data']
-    endif
-
-    return l:item
-endfunction
-
 Describe lsp#omni
+
+    Before each
+        call lsp#omni#clear_managed_user_data_map()
+    End
+
     Describe lsp#omni#get_vim_completion_item
         It should return item with proper kind
             let item = {
@@ -34,43 +22,30 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': json_encode({
-            \   'vim-lsp/serverName': '',
-            \   'vim-lsp/completionItem': item
-            \ })
+            \ 'user_data': 'vim-lsp/0'
             \}
-            let got = lsp#omni#get_vim_completion_item(item)
 
-            Assert Equals(PreprocessItem(got), want)
+            Assert Equals(lsp#omni#get_vim_completion_item(item), want)
         End
 
-        It should return result contained user_data['vim-lsp/completionItem']
+        It should get user_data by the item
             if !has('patch-8.0.1493')
                 Skip This test requires 'patch-8.0.1493'
             endif
-
-            let l:text_edit = {
-            \    'range': {
-            \      'start': {'line': 5, 'character': 0},
-            \      'end': {'line': 5, 'character': 5}
-            \    },
-            \    'newText': 'yyy'
-            \  }
 
             let item = {
             \ 'label': 'my-label',
             \ 'documentation': 'my documentation.',
             \ 'detail': 'my-detail',
             \ 'kind': '3',
-            \ 'textEdit': l:text_edit
+            \ 'textEdit': {
+            \    'range': {
+            \      'start': {'line': 5, 'character': 0},
+            \      'end': {'line': 5, 'character': 5}
+            \    },
+            \    'newText': 'yyy'
+            \  }
             \}
-
-            let l:want_user_data = {
-            \  'vim-lsp/serverName': '',
-            \  'vim-lsp/completionItem': item,
-            \}
-
-            let l:want_user_data_string = json_encode(l:want_user_data)
 
             let want = {
             \ 'word': 'my-label',
@@ -81,11 +56,15 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': l:want_user_data_string
+            \ 'user_data': 'vim-lsp/0'
             \}
-            let got = lsp#omni#get_vim_completion_item(item)
 
-            Assert Equals(PreprocessItem(got), want)
+            let got = lsp#omni#get_vim_completion_item(item)
+            Assert Equals(got, want)
+            Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got), {
+                        \   'server_name': '',
+                        \   'completion_item': item
+                        \ })
         End
 
         It should return item with newlines in 'menu' replaced
@@ -105,14 +84,10 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail more-detail',
-            \ 'user_data': json_encode({
-            \   'vim-lsp/serverName': '',
-            \   'vim-lsp/completionItem': item
-            \ })
+            \ 'user_data': 'vim-lsp/0'
             \}
-            let got = lsp#omni#get_vim_completion_item(item)
 
-            Assert Equals(PreprocessItem(got), want)
+            Assert Equals(lsp#omni#get_vim_completion_item(item), want)
         End
     End
 End

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -33,14 +33,18 @@ Describe lsp#omni
             \ 'dup': 1,
             \ 'empty': 1,
             \ 'kind': 'function',
-            \ 'menu': 'my-detail'
+            \ 'menu': 'my-detail',
+            \ 'user_data': json_encode({
+            \   'vim-lsp/serverName': '',
+            \   'vim-lsp/completionItem': item
+            \ })
             \}
             let got = lsp#omni#get_vim_completion_item(item)
 
             Assert Equals(PreprocessItem(got), want)
         End
 
-        It should return result contained user_data['vim-lsp/textEdit'], if exist textEdit in item
+        It should return result contained user_data['vim-lsp/completionItem']
             if !has('patch-8.0.1493')
                 Skip This test requires 'patch-8.0.1493'
             endif
@@ -62,8 +66,8 @@ Describe lsp#omni
             \}
 
             let l:want_user_data = {
-            \  'vim-lsp/textEdit': l:text_edit,
-            \  'vim-lsp/insertFormat': 0
+            \  'vim-lsp/serverName': '',
+            \  'vim-lsp/completionItem': item,
             \}
 
             let l:want_user_data_string = json_encode(l:want_user_data)
@@ -78,34 +82,6 @@ Describe lsp#omni
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
             \ 'user_data': l:want_user_data_string
-            \}
-            let got = lsp#omni#get_vim_completion_item(item)
-
-            Assert Equals(PreprocessItem(got), want)
-        End
-
-        It should not add user_data, if provide textEdit property and textEdit value is null
-            if !has('patch-8.0.1493')
-                Skip This test requires 'patch-8.0.1493'
-            endif
-
-            let item = {
-            \ 'label': 'my-label',
-            \ 'documentation': 'my documentation.',
-            \ 'detail': 'my-detail',
-            \ 'kind': '3',
-            \ 'textEdit': v:null
-            \}
-
-            let want = {
-            \ 'word': 'my-label',
-            \ 'abbr': 'my-label',
-            \ 'info': 'my documentation.',
-            \ 'icase': 1,
-            \ 'dup': 1,
-            \ 'empty': 1,
-            \ 'kind': 'function',
-            \ 'menu': 'my-detail',
             \}
             let got = lsp#omni#get_vim_completion_item(item)
 
@@ -128,7 +104,11 @@ Describe lsp#omni
             \ 'dup': 1,
             \ 'empty': 1,
             \ 'kind': 'function',
-            \ 'menu': 'my-detail more-detail'
+            \ 'menu': 'my-detail more-detail',
+            \ 'user_data': json_encode({
+            \   'vim-lsp/serverName': '',
+            \   'vim-lsp/completionItem': item
+            \ })
             \}
             let got = lsp#omni#get_vim_completion_item(item)
 

--- a/test/lsp/ui/vim/completion.vimspec
+++ b/test/lsp/ui/vim/completion.vimspec
@@ -1,0 +1,37 @@
+Describe lsp#uivim#completion
+
+  Before each
+    %delete _
+    setlocal filetype=html
+    setlocal omnifunc=lsp#omni#complete
+  End
+
+  It should expand simple snippet with multibyte chars
+    Skip This test needs asynchronous process and snippetSupport=true
+
+    call setline(1, ['<div class="あいうえお">'])
+    execute "normal! 'gg$ha id\<C-x>\<C-o>\<C-n>\<Tab>'"
+
+    " wait for feedkeys.
+
+    Assert Equals(getline(1), '<div class="あいうえお" id="">')
+    Assert Equals(getpos('.')[1 : 2], [1, 30])
+  End
+
+  It should expand when textEdit.start.character is less than completion start col
+    Skip This test needs asynchronous process and snippetSupport=true
+
+    call setline(1, [
+          \ '<html>',
+          \ '  <div>',
+          \ '    </>',
+          \ '</html>'])
+    execute "normal! ':gg2j$ha\<C-x>\<C-o>\<C-n>\<Tab>'"
+
+    " wait for feedkeys.
+
+    Assert Equals(getline(3), '  </div>')
+    Assert Equals(getpos('.')[1 : 2], [1, 8])
+  End
+
+End


### PR DESCRIPTION
This PR aims to fix `textEdit` related problems.

TODO

### 1st step(no breaking change).
- [x] Separate `CompleteDone` handling from omni.vim
- [x] Check with `vim-lsp-snippets`
- [x] Support `g:lsp_text_edit_enabled = 0`
- ~[x] Support `g:lsp_insert_text_enabled = 0`~
    - This option already supported in omni.vim.
- [x] Try to create test.
  - Couldn't write test because the implementation uses feedkeys.
- [x] Add docs.
- [x] obj.key -> obj['key']
- [x] extract_user_data -> get_user_data
- [x] Create multi-byte test case example
- [x] Fix failed existing tests 
- [x] Implement timeout to  completionItem/resolve.

// The PR can be merged at this timing.

### 2nd step(has breaking change).

- [x] Use internal managed dict to store data.