### PR TITLE
Improve signature help with lexima.vim

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -58,6 +58,9 @@ function! lsp#enable() abort
         if g:lsp_highlights_enabled | call lsp#ui#vim#highlights#enable() | endif
         if g:lsp_textprop_enabled | call lsp#ui#vim#diagnostics#textprop#enable() | endif
     endif
+    if g:lsp_signature_help_enabled
+        call lsp#ui#vim#signature_help#setup()
+    endif
     call lsp#ui#vim#completion#_setup()
     call s:register_events()
 endfunction
@@ -742,9 +745,6 @@ function! s:handle_initialize(server_name, data) abort
     for l:Init_callback in l:init_callbacks
         call l:Init_callback(a:data)
     endfor
-    if g:lsp_signature_help_enabled
-        call lsp#ui#vim#signature_help#setup()
-    endif
 
     doautocmd User lsp_server_init
 endfunction

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -292,7 +292,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
        \ && type(g:lsp_preview_doubletap) == 3
        \ && len(g:lsp_preview_doubletap) >= 1
        \ && type(g:lsp_preview_doubletap[0]) == 2
-       \ && mode()[0] !=# 'i'
+       \ && index(['i', 's'], mode()[0]) == -1
         echo ''
         return call(g:lsp_preview_doubletap[0], [])
     endif

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -111,14 +111,20 @@ function! s:get_parameter_doc(parameter) abort
     return printf('***%s*** - %s', a:parameter['label'], l:doc)
 endfunction
 
-function! s:on_text_changed() abort
+function! s:on_cursor_moved() abort
     let l:bufnr = bufnr('%')
     call timer_stop(s:debounce_timer_id)
-    let s:debounce_timer_id = timer_start(500, { -> s:on_text_changed_after(l:bufnr) })
+    let s:debounce_timer_id = timer_start(200, { -> s:on_text_changed_after(l:bufnr) }, { 'repeat': 1 })
 endfunction
 
 function! s:on_text_changed_after(bufnr) abort
     if bufnr('%') != a:bufnr
+        return
+    endif
+    if index(['i', 's'], mode()[0]) == -1
+        return
+    endif
+    if win_id2win(lsp#ui#vim#output#getpreviewwinid()) >= 1
         return
     endif
 
@@ -135,6 +141,7 @@ endfunction
 function! lsp#ui#vim#signature_help#setup() abort
     augroup _lsp_signature_help_
         autocmd!
-        autocmd TextChangedI,TextChangedP <buffer> call s:on_text_changed()
+        autocmd CursorMoved,CursorMovedI <buffer> call s:on_cursor_moved()
     augroup END
 endfunction
+

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -133,7 +133,7 @@ function! s:on_text_changed_after(bufnr) abort
         let l:chars += lsp#capabilities#get_signature_help_trigger_characters(l:server_name)
     endfor
 
-    if index(l:chars, lsp#utils#get_before_char_skip_white()) >= 0
+    if index(l:chars, lsp#utils#_get_before_char_skip_white()) >= 0
         call lsp#ui#vim#signature_help#get_signature_help_under_cursor()
     endif
 endfunction

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -141,7 +141,7 @@ endfunction
 function! lsp#ui#vim#signature_help#setup() abort
     augroup _lsp_signature_help_
         autocmd!
-        autocmd CursorMoved,CursorMovedI <buffer> call s:on_cursor_moved()
+        autocmd CursorMoved,CursorMovedI * call s:on_cursor_moved()
     augroup END
 endfunction
 

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -118,8 +118,12 @@ function! s:on_text_changed() abort
 endfunction
 
 function! s:on_text_changed_after(bufnr) abort
+    if bufnr('%') != a:bufnr
+        return
+    endif
+
     let l:chars = []
-    for l:server_name in lsp#get_whitelisted_servers(bufnr('%'))
+    for l:server_name in lsp#get_whitelisted_servers(a:bufnr)
         let l:chars += lsp#capabilities#get_signature_help_trigger_characters(l:server_name)
     endfor
 

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -232,6 +232,31 @@ function! s:get_base64_alphabet() abort
     return l:alphabet
 endfunction
 
+function! lsp#utils#get_before_line() abort
+  let l:text = getline('.')
+  return l:text[0 : min([strlen(l:text), col('.') - 2])]
+endfunction
+
+function! lsp#utils#get_before_char_skip_white() abort
+  let l:current_lnum = line('.')
+
+  let l:lnum = l:current_lnum
+  while l:lnum > 0
+    if l:lnum == l:current_lnum
+      let l:text = lsp#utils#get_before_line()
+    else
+      let l:text = getline(l:lnum)
+    endif
+    let l:match = matchlist(l:text, '\([^[:blank:]]\)\s*$')
+    if get(l:match, 1, v:null) isnot v:null
+      return l:match[1]
+    endif
+    let l:lnum -= 1
+  endwhile
+
+  return ''
+endfunction
+
 let s:alphabet = s:get_base64_alphabet()
 
 function! lsp#utils#base64_decode(data) abort

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -232,7 +232,7 @@ function! s:get_base64_alphabet() abort
     return l:alphabet
 endfunction
 
-function! lsp#utils#get_before_line() abort
+function! lsp#utils#_get_before_line() abort
   let l:text = getline('.')
   let l:idx = min([strlen(l:text), col('.') - 2])
   let l:idx = max([l:idx, -1])
@@ -242,13 +242,13 @@ function! lsp#utils#get_before_line() abort
   return l:text[0 : l:idx]
 endfunction
 
-function! lsp#utils#get_before_char_skip_white() abort
+function! lsp#utils#_get_before_char_skip_white() abort
   let l:current_lnum = line('.')
 
   let l:lnum = l:current_lnum
   while l:lnum > 0
     if l:lnum == l:current_lnum
-      let l:text = lsp#utils#get_before_line()
+      let l:text = lsp#utils#_get_before_line()
     else
       let l:text = getline(l:lnum)
     endif

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -234,7 +234,12 @@ endfunction
 
 function! lsp#utils#get_before_line() abort
   let l:text = getline('.')
-  return l:text[0 : min([strlen(l:text), col('.') - 2])]
+  let l:idx = min([strlen(l:text), col('.') - 2])
+  let l:idx = max([l:idx, -1])
+  if l:idx == -1
+    return ''
+  endif
+  return l:text[0 : l:idx]
 endfunction
 
 function! lsp#utils#get_before_char_skip_white() abort

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -110,6 +110,47 @@ Describe lsp#utils
         End
     End
 
+    Describe lsp#utils#get_before_line
+        It should return line before cursor on col=1
+            enew!
+            call setline(1, ['123456789'])
+            call cursor(1, 1)
+            Assert Equals(lsp#utils#get_before_line(), '')
+        End
+
+        It should return line before cursor on col=$
+            let l:saved_virtualedit = &virtualedit
+            let &virtualedit = 'all'
+            enew!
+            call setline(1, ['123456789'])
+            call cursor(1, 10)
+            Assert Equals(lsp#utils#get_before_line(), '123456789')
+            let &virtualedit = l:saved_virtualedit
+        End
+
+        It should return line before cursor with multibyte
+            enew!
+            call setline(1, ['あいうえおabc'])
+            call cursor(1, 18)
+            Assert Equals(lsp#utils#get_before_line(), 'あいうえおab')
+        End
+    End
+
+    Describe lsp#utils#get_before_char_skip_white
+        It should return before char in above of line
+            enew!
+            call setline(1, ['(', ''])
+            call cursor(2, 1)
+            Assert Equals(lsp#utils#get_before_char_skip_white(), '(')
+        End
+        It should return before char with multibyte
+            enew!
+            call setline(1, ['あいうえお(    '])
+            call cursor(1, 21)
+            Assert Equals(lsp#utils#get_before_char_skip_white(), '(')
+        End
+    End
+
     Describe lsp#utils#base64_decode
         It should decode basic string correctly
             Assert Equals(lsp#utils#base64_decode('TWFu'), [77, 97, 110])

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -110,12 +110,12 @@ Describe lsp#utils
         End
     End
 
-    Describe lsp#utils#get_before_line
+    Describe lsp#utils#_get_before_line
         It should return line before cursor on col=1
             enew!
             call setline(1, ['123456789'])
             call cursor(1, 1)
-            Assert Equals(lsp#utils#get_before_line(), '')
+            Assert Equals(lsp#utils#_get_before_line(), '')
         End
 
         It should return line before cursor on col=$
@@ -124,7 +124,7 @@ Describe lsp#utils
             enew!
             call setline(1, ['123456789'])
             call cursor(1, 10)
-            Assert Equals(lsp#utils#get_before_line(), '123456789')
+            Assert Equals(lsp#utils#_get_before_line(), '123456789')
             let &virtualedit = l:saved_virtualedit
         End
 
@@ -132,22 +132,22 @@ Describe lsp#utils
             enew!
             call setline(1, ['あいうえおabc'])
             call cursor(1, 18)
-            Assert Equals(lsp#utils#get_before_line(), 'あいうえおab')
+            Assert Equals(lsp#utils#_get_before_line(), 'あいうえおab')
         End
     End
 
-    Describe lsp#utils#get_before_char_skip_white
+    Describe lsp#utils#_get_before_char_skip_white
         It should return before char in above of line
             enew!
             call setline(1, ['(', ''])
             call cursor(2, 1)
-            Assert Equals(lsp#utils#get_before_char_skip_white(), '(')
+            Assert Equals(lsp#utils#_get_before_char_skip_white(), '(')
         End
         It should return before char with multibyte
             enew!
             call setline(1, ['あいうえお(    '])
             call cursor(1, 21)
-            Assert Equals(lsp#utils#get_before_char_skip_white(), '(')
+            Assert Equals(lsp#utils#_get_before_char_skip_white(), '(')
         End
     End
 


### PR DESCRIPTION
This PR aims to improve signature help when with lexima.vim.

I'm introduced debounce timer.
It is easy to remove, So if it should be deleted, Please instruction for me.