### PR TITLE
refactor LspTypeHierarchy

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -671,20 +671,8 @@ endfunction
 
 function! s:hierarchy_treeitem_command(hierarchyitem) abort
     bwipeout
-
-    let l:path = lsp#utils#uri_to_path(a:hierarchyitem['uri'])
-    let l:line = a:hierarchyitem['range']['start']['line'] + 1
-    let l:char = a:hierarchyitem['range']['start']['character']
-    let l:col = lsp#utils#to_col(l:path, l:line, l:char)
-
-    let l:buffer = bufnr(l:path)
-    if &modified && !&hidden
-        let l:cmd = l:buffer !=# -1 ? 'sb ' . l:buffer : 'split ' . fnameescape(l:path)
-    else
-        echom 'edit'
-        let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . fnameescape(l:path)
-    endif
-    execute l:cmd . ' | call cursor('.l:line.','.l:col.')'
+    call lsp#utils#tagstack#_update()
+    call lsp#utils#buffer#_open_lsp_location(a:hierarchyitem)
 endfunction
 
 function! s:get_children_for_tree_hierarchy(Callback, ...) dict abort

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -672,7 +672,7 @@ endfunction
 function! s:hierarchy_treeitem_command(hierarchyitem) abort
     bwipeout
     call lsp#utils#tagstack#_update()
-    call lsp#utils#buffer#_open_lsp_location(a:hierarchyitem)
+    call lsp#utils#location#_open_lsp_location(a:hierarchyitem)
 endfunction
 
 function! s:get_children_for_tree_hierarchy(Callback, ...) dict abort

--- a/autoload/lsp/utils/buffer.vim
+++ b/autoload/lsp/utils/buffer.vim
@@ -33,3 +33,30 @@ function! lsp#utils#buffer#_get_lines(buf) abort
     endif
     return l:lines
 endfunction
+
+" @params {location} = {
+"   'uri': 'file://....',
+"   'range': {
+"       'start': { 'line': 1, 'character': 1 },
+"       'end': { 'line': 1, 'character': 1 },
+"   }
+" }
+function! lsp#utils#buffer#_open_lsp_location(location) abort
+    let l:path = lsp#utils#uri_to_path(a:location['uri'])
+    let l:bufnr = bufnr(l:path)
+
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['end'])
+
+    normal! m'
+    if &modified && !&hidden
+        let l:cmd = l:bufnr !=# -1 ? 'sb ' . l:bufnr : 'split ' . fnameescape(l:path)
+    else
+        let l:cmd = l:bufnr !=# -1 ? 'b ' . l:bufnr : 'edit ' . fnameescape(l:path)
+    endif
+    execute l:cmd . ' | call cursor('.l:start_line.','.l:start_col.')'
+
+    normal V
+    call setpos("'<", [l:bufnr, l:start_line, l:start_col])
+    call setpos("'>", [l:bufnr, l:end_line, l:end_col])
+endfunction

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -9,8 +9,8 @@ function! lsp#utils#location#_open_lsp_location(location) abort
     let l:path = lsp#utils#uri_to_path(a:location['uri'])
     let l:bufnr = bufnr(l:path)
 
-    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['start'])
-    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['end'])
+    let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['end'])
 
     normal! m'
     if &modified && !&hidden

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -20,6 +20,7 @@ function! lsp#utils#location#_open_lsp_location(location) abort
     endif
     execute l:cmd . ' | call cursor('.l:start_line.','.l:start_col.')'
 
+    let l:bufnr = bufnr('%')
     normal! V
     call setpos("'<", [l:bufnr, l:start_line, l:start_col])
     call setpos("'>", [l:bufnr, l:end_line, l:end_col])

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -20,7 +20,7 @@ function! lsp#utils#location#_open_lsp_location(location) abort
     endif
     execute l:cmd . ' | call cursor('.l:start_line.','.l:start_col.')'
 
-    normal V
+    normal! V
     call setpos("'<", [l:bufnr, l:start_line, l:start_col])
     call setpos("'>", [l:bufnr, l:end_line, l:end_col])
 endfunction

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -1,0 +1,26 @@
+" @params {location} = {
+"   'uri': 'file://....',
+"   'range': {
+"       'start': { 'line': 1, 'character': 1 },
+"       'end': { 'line': 1, 'character': 1 },
+"   }
+" }
+function! lsp#utils#location#_open_lsp_location(location) abort
+    let l:path = lsp#utils#uri_to_path(a:location['uri'])
+    let l:bufnr = bufnr(l:path)
+
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['end'])
+
+    normal! m'
+    if &modified && !&hidden
+        let l:cmd = l:bufnr !=# -1 ? 'sb ' . l:bufnr : 'split ' . fnameescape(l:path)
+    else
+        let l:cmd = l:bufnr !=# -1 ? 'b ' . l:bufnr : 'edit ' . fnameescape(l:path)
+    endif
+    execute l:cmd . ' | call cursor('.l:start_line.','.l:start_col.')'
+
+    normal V
+    call setpos("'<", [l:bufnr, l:start_line, l:start_col])
+    call setpos("'>", [l:bufnr, l:end_line, l:end_col])
+endfunction

--- a/autoload/lsp/utils/position.vim
+++ b/autoload/lsp/utils/position.vim
@@ -7,7 +7,7 @@
 "   line,
 "   col
 " ]
-function! lsp#utils#position#lsp_to_vim(expr, position) abort
+function! lsp#utils#position#_lsp_to_vim(expr, position) abort
     let l:line = a:position['line'] + 1
     let l:char = a:position['character']
     let l:col = lsp#utils#to_col(a:expr, l:line, l:char)

--- a/autoload/lsp/utils/position.vim
+++ b/autoload/lsp/utils/position.vim
@@ -1,0 +1,15 @@
+" @param bufnr = bufnr
+" @param position = {
+"   'line': 1,
+"   'character': 1
+" }
+" @returns [
+"   line,
+"   col
+" ]
+function! lsp#utils#position#lsp_to_vim(expr, position) abort
+    let l:line = a:position['line'] + 1
+    let l:char = a:position['character']
+    let l:col = lsp#utils#to_col(a:expr, l:line, l:char)
+    return [l:line, l:col]
+endfunction


### PR DESCRIPTION
* add `lsp#utils#location#_open_lsp_location(location)`
* add `lsp#utils#position#_lsp_to_vim(expr, position)`
* add visual selection when using `_open_lsp_location`
* update `tagstack` when opening hierarchy item

This is also introducing some new coding patterns. I have added `location.vim` to refer to LSPs `Location` interface and `position.vim` to refer to LSP's `Position`. Even thought it is public it starts with `_` meaning only `vim-lsp` should be using this. Having public will allows us to write unit tests easily which is a TODO. My goal is to also have something like `vim_to_lsp` and `lsp_to_vim` utils so it does conversion with proper multibyte, 0 vs 1 starting index and so on.