### PR TITLE
Improve user_data format

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -309,7 +309,7 @@ endfunction
 " create item's user_data.
 "
 function! s:create_user_data(completion_item, server_name) abort
-    let l:user_data_key = 'vim-lsp/key/' . string(s:managed_user_data_key_base)
+    let l:user_data_key = '{"vim-lsp/key/' . string(s:managed_user_data_key_base) . '":""}'
     let s:managed_user_data_map[l:user_data_key] = {
                 \   'server_name': a:server_name,
                 \   'completion_item': a:completion_item

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -309,7 +309,7 @@ endfunction
 " create item's user_data.
 "
 function! s:create_user_data(completion_item, server_name) abort
-    let l:user_data_key = '{"vim-lsp/key/' . string(s:managed_user_data_key_base) . '":""}'
+    let l:user_data_key = '{"vim-lsp/key' . '":"' . string(s:managed_user_data_key_base) . '"}'
     let s:managed_user_data_map[l:user_data_key] = {
                 \   'server_name': a:server_name,
                 \   'completion_item': a:completion_item

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -22,7 +22,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': 'vim-lsp/key/0'
+            \ 'user_data': '{"vim-lsp/key/0":""}'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)
@@ -56,7 +56,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': 'vim-lsp/key/0'
+            \ 'user_data': '{"vim-lsp/key/0":""}'
             \}
 
             let got = lsp#omni#get_vim_completion_item(item)
@@ -84,7 +84,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail more-detail',
-            \ 'user_data': 'vim-lsp/key/0'
+            \ 'user_data': '{"vim-lsp/key/0":""}'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -22,7 +22,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': '{"vim-lsp/key/0":""}'
+            \ 'user_data': '{"vim-lsp/key":"0"}'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)
@@ -56,7 +56,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail',
-            \ 'user_data': '{"vim-lsp/key/0":""}'
+            \ 'user_data': '{"vim-lsp/key":"0"}'
             \}
 
             let got = lsp#omni#get_vim_completion_item(item)
@@ -84,7 +84,7 @@ Describe lsp#omni
             \ 'empty': 1,
             \ 'kind': 'function',
             \ 'menu': 'my-detail more-detail',
-            \ 'user_data': '{"vim-lsp/key/0":""}'
+            \ 'user_data': '{"vim-lsp/key":"0"}'
             \}
 
             Assert Equals(lsp#omni#get_vim_completion_item(item), want)


### PR DESCRIPTION
Currently, user_data is not JSON string so another plugin might occur exception.
So we should be better to store JSON-like text to user_data.