### PR TITLE
Zipfile uri support(includes dirty-hack).

### DIFF
--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -1,5 +1,5 @@
 function! lsp#utils#is_file_uri(uri) abort
-    return stridx(a:uri, 'file:///') == 0
+    return stridx(a:uri, 'file:///') >= 0
 endfunction
 
 function! lsp#utils#is_remote_uri(uri) abort
@@ -68,10 +68,16 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#uri_to_path(uri) abort
+        if stridx(a:uri, 'zipfile:///') == 0
+            return substitute(s:decode_uri(a:uri), '/', '\\', 'g')
+        endif
         return substitute(s:decode_uri(a:uri[len('file:///'):]), '/', '\\', 'g')
     endfunction
 else
     function! lsp#utils#uri_to_path(uri) abort
+        if stridx(a:uri, 'zipfile:///') == 0
+            return s:decode_uri(a:uri)
+        endif
         return s:decode_uri(a:uri[len('file://'):])
     endfunction
 endif

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -74,7 +74,13 @@ function! s:lsp_location_item_to_vim(loc, cache) abort
         if !empty(l:contents)
             let l:text = l:contents[l:index]
         else
-            let l:contents = readfile(l:path)
+            if stridx(l:path, 'zipfile:///') == 0
+                " FIXME: dirty-hack...readfile() to zipfile not found.
+                call lsp#utils#tagstack#_update()
+                execute ":edit " . l:path
+            else
+                let l:contents = readfile(l:path)
+            endif
             let a:cache[l:path] = l:contents
             let l:text = l:contents[l:index]
         endif

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -77,7 +77,7 @@ function! s:lsp_location_item_to_vim(loc, cache) abort
             if stridx(l:path, 'zipfile:///') == 0
                 " FIXME: dirty-hack...readfile() to zipfile not found.
                 call lsp#utils#tagstack#_update()
-                execute ":edit " . l:path
+                execute ':edit ' . l:path
             else
                 let l:contents = readfile(l:path)
             endif


### PR DESCRIPTION
Currently `:LspDefinition` can't jump to zipfile-located uri. (e.g. zip, jar...)
This PR makes possible that.
Notice: Of course you know, I'm vimscript newbie so that includes dirty-hack.
Please give me suggests if you have better solution.