### PR TITLE
Fix completion for clangd

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -254,7 +254,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     endif
 
     let l:completion = {
-                \ 'word': trim(l:word),
+                \ 'word': lsp#utils#_trim(l:word),
                 \ 'abbr': l:abbr,
                 \ 'menu': '',
                 \ 'info': '',

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -249,8 +249,12 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         let l:abbr = a:item['label']
     endif
 
+    if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
+        let l:word = substitute(l:word, '\<\$[0-9]\+\|\${[^}]\+}\>', '', 'g')
+    endif
+
     let l:completion = {
-                \ 'word': l:word,
+                \ 'word': trim(l:word),
                 \ 'abbr': l:abbr,
                 \ 'menu': '',
                 \ 'info': '',

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -232,6 +232,16 @@ function! s:get_base64_alphabet() abort
     return l:alphabet
 endfunction
 
+if exists('*trim')
+  function! lsp#utils#_trim(string) abort
+    return trim(a:string)
+  endfunction
+else
+  function! lsp#utils#_trim(string) abort
+    return substitute(a:string, '^\s*\|\s*$', '', 'g')
+  endfunction
+endif
+
 function! lsp#utils#_get_before_line() abort
   let l:text = getline('.')
   let l:idx = min([strlen(l:text), col('.') - 2])


### PR DESCRIPTION
This PR aims to fix completion when using clangd.

The clangd returns CompletionItem that's label includes white-space in first of character.
So start col does not handle correctly in vim.

Related: https://github.com/thomasfaingnaert/vim-lsp-ultisnips/pull/9#issuecomment-572442547

And fix my failure.
Old implementation removes snippet marker but I was losing this functionality.