### PR TITLE
Support any completion-engine

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -338,7 +338,7 @@ endfunction
 " create item's user_data.
 "
 function! s:create_user_data(completion_item, server_name, complete_position) abort
-    let l:user_data_key = '{"vim-lsp/key' . '":"' . string(s:managed_user_data_key_base) . '"}'
+    let l:user_data_key = s:create_user_data_key(s:managed_user_data_key_base)
     let s:managed_user_data_map[l:user_data_key] = {
     \   'complete_position': a:complete_position,
     \   'server_name': a:server_name,
@@ -354,17 +354,35 @@ function! lsp#omni#get_managed_user_data_from_completed_item(completed_item) abo
         return {}
     endif
 
+    let l:user_data_string = get(a:completed_item, 'user_data', '')
+
     " Check managed user_data.
-    let l:user_data_key = get(a:completed_item, 'user_data', '')
-    if !has_key(s:managed_user_data_map, l:user_data_key)
-        return {}
+    if has_key(s:managed_user_data_map, l:user_data_string)
+        return s:managed_user_data_map[l:user_data_string]
     endif
 
-    return s:managed_user_data_map[l:user_data_key]
+    " Check json.
+    if stridx(l:user_data_string, '"vim-lsp/key"') != -1
+        try
+            let l:user_data = json_decode(l:user_data_string)
+            if has_key(l:user_data, 'vim-lsp/key')
+                let l:user_data_key = s:create_user_data_key(l:user_data['vim-lsp/key'])
+                if has_key(s:managed_user_data_map, l:user_data_key)
+                    return s:managed_user_data_map[l:user_data_key]
+                endif
+            endif
+        catch /.*/
+        endtry
+    endif
+    return {}
 endfunction
 
 function! lsp#omni#get_completion_item_kinds() abort
     return map(keys(s:default_completion_item_kinds), {idx, key -> str2nr(key)})
+endfunction
+
+function! s:create_user_data_key(base) abort
+    return '{"vim-lsp/key":"' . a:base . '"}'
 endfunction
 
 " }}}


### PR DESCRIPTION
Currently, vim-lsp uses user_data as string not json.

But sometimes, any completion-engine modify user_data.
For example, ncm2 adding some props to user_data and then vim-lsp's `CompleteDone` behavior was disabled.

This PR aims to support modified user_data as a fallback.
