### PR TITLE
Support regexp for language matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ _Note: [async.vim](https://github.com/prabirshrestha/async.vim) is required and 
 ```viml
 if executable('pyls')
     " pip install python-language-server
+    " use whitelistre for regular expressions
     au User lsp_setup call lsp#register_server({
         \ 'name': 'pyls',
         \ 'cmd': {server_info->['pyls']},

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -802,6 +802,16 @@ function! lsp#get_whitelisted_servers(...) abort
                 endif
             endfor
         endif
+
+        if has_key(l:server_info, 'whitelistre')
+            for l:filetype in l:server_info['whitelistre']
+                " If this is a regex expression, we allow it
+                if l:buffer_filetype =~ l:filetype
+                    let l:active_servers += [l:server_name]
+                    break
+                endif
+            endfor
+        endif
     endfor
 
     return l:active_servers


### PR DESCRIPTION
Currently, depending on the framework I'm toggling the buffer types. That's because I'm using it in conjunction with UltiSnips so I want some macros to only be active if doing some specific thing in a framework.

What I'd want is to have for python language support, regardless of the exact buffer type, since it depends on the order of the activation. I.e. Having two frameworks: `X_Adhesive`, and `X_Test` that I can potentially activate, yields the following combinations that I'd have to whitelist currently:  `python`, `X_Test.python`, `X_Adhesive.python`, `X_Test.X_Adhesive.python`, `X_Adhesive.X_Test.python`.

Of course, this is getting out of hand. Using whitelisting with regexp, matching all of these becomes:

```
    au User lsp_setup call lsp#register_server({
        \ 'name': 'pyls',
        \ 'cmd': {server_info->['pyls']},
        \ 'whitelistre': ['^.*\.\=python$']
        \ })
```