### PR TITLE
Add an option to use customized function to open location.

### DIFF
--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -1,7 +1,12 @@
 function! s:open_location(path, line, col) abort
     normal! m'
     let l:buffer = bufnr(a:path)
-    if &modified && !&hidden
+    if exists('g:lsp_custom_open_location')
+        call g:lsp_custom_open_location[0]({
+                    \'path':fnameescape(a:path),
+                    \'line':a:line,
+                    \'col':a:col})
+    elseif &modified && !&hidden
         let l:cmd = l:buffer !=# -1 ? 'sb ' . l:buffer : 'split ' . fnameescape(a:path)
     else
         let l:cmd = l:buffer !=# -1 ? 'b ' . l:buffer : 'edit ' . fnameescape(a:path)

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -603,6 +603,25 @@ g:lsp_completion_resolve_timeout         *g:lsp_completion_resolve_timeout*
     The `completionItem/resolve` request's timeout value.
     If your vim freeze at `CompleteDone`, you can set this value to 0.
 
+g:lsp_custom_open_location				*g:lsp_custom_open_location*
+    Type: |String|
+    Default: `""`
+
+    Name of the customizable function to jump to a location (e.g. in use of
+    |LspDefinition|, |LspImplementation|, etc.). The function takes a
+    dictionary as input whose keys include "path", "line", "col" that are the
+    target path, line # and column #. Note, however, vim-lsp handles line #
+    and column # automatically. Users only need to open the file with their
+    favorite command as shown in the following exaple.
+
+    Example:
+	function! s:LspGoTo(args)
+	    let l:cmd = 'tabedit '.a:args["path"]
+	    execute l:cmd
+	endfunction
+>
+	let g:lsp_custom_open_location = [function('s:LspGoTo')]
+
 ==============================================================================
 FUNCTIONS                                               *vim-lsp-functions*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -42,6 +42,7 @@ let g:lsp_ignorecase = get(g:, 'lsp_ignorecase', &ignorecase)
 let g:lsp_semantic_enabled = get(g:, 'lsp_semantic_enabled', 0)
 let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_delay', -1)
 let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
+let g:lsp_custom_open_location = get(g:, 'lsp_custom_open_location', [])
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])


### PR DESCRIPTION
This is an update of #517. I don't quite understand @prabirshrestha's comment. Particularly, do I still need to pass a dictionary to the customized location_open function? If so, what should the dictionary contain?