### PR TITLE
Fix insert text

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -40,7 +40,7 @@ let s:is_user_data_support = has('patch-8.0.1493')
 let s:managed_user_data_key_base = 0
 let s:managed_user_data_map = {}
 
-let s:valid_word_pattern = '^[^ (<{\[\r\n]\+'
+let s:valid_word_pattern = '^[^ :(<{\[\r\n]\+'
 
 " }}}
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -40,8 +40,6 @@ let s:is_user_data_support = has('patch-8.0.1493')
 let s:managed_user_data_key_base = 0
 let s:managed_user_data_map = {}
 
-let s:valid_word_pattern = '^[^ :(<{\[\r\n]\+'
-
 " }}}
 
 " completion state
@@ -243,12 +241,12 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     if get(a:item, 'insertTextFormat', -1) == 2 && !empty(get(a:item, 'insertText', ''))
         " if candidate is snippet, use insertText. But it may include
         " placeholder.
-        let l:word = matchstr(a:item['insertText'], s:valid_word_pattern)
+        let l:word = lsp#utils#make_valid_word(a:item['insertText'])
     elseif !empty(get(a:item, 'insertText', ''))
         " if plain-text insertText, use it.
         let l:word = a:item['insertText']
     elseif has_key(a:item, 'textEdit')
-        let l:word = matchstr(a:item['label'], s:valid_word_pattern)
+        let l:word = lsp#utils#make_valid_word(a:item['label'])
     endif
     if empty(l:word)
         let l:word = a:item['label']

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -237,17 +237,21 @@ endfunction
 function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     let l:server_name = get(a:, 1, '')
 
-    if g:lsp_insert_text_enabled && has_key(a:item, 'insertText') && !empty(a:item['insertText'])
-        if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] != 1
-            let l:word = a:item['label']
-        else
-            let l:word = a:item['insertText']
-        endif
-        let l:abbr = a:item['label']
-    else
-        let l:word = a:item['label']
-        let l:abbr = a:item['label']
+    let l:word = ''
+    if get(a:item, 'insertTextFormat', -1) == 2 && !empty(get(a:item, 'insertText', ''))
+        " if candidate is snippet, use insertText. But it may include
+        " placeholder.
+        let l:word = matchstr(a:item['insertText'], '\w\+')
+    elseif !empty(get(a:item, 'insertText', ''))
+        " if plain-text insertText, use it.
+        let l:word = a:item['insertText']
+    elseif has_key(a:item, 'textEdit')
+        let l:word = matchstr(a:item['label'], '\w\+')
     endif
+    if empty(l:word)
+        let l:word = a:item['label']
+    endif
+    let l:abbr = a:item['label']
 
     if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
         let l:word = substitute(l:word, '\<\$[0-9]\+\|\${[^}]\+}\>', '', 'g')

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -40,6 +40,8 @@ let s:is_user_data_support = has('patch-8.0.1493')
 let s:managed_user_data_key_base = 0
 let s:managed_user_data_map = {}
 
+let s:valid_word_pattern = '^[^ (<{\[\r\n]\+'
+
 " }}}
 
 " completion state
@@ -241,12 +243,12 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     if get(a:item, 'insertTextFormat', -1) == 2 && !empty(get(a:item, 'insertText', ''))
         " if candidate is snippet, use insertText. But it may include
         " placeholder.
-        let l:word = matchstr(a:item['insertText'], '\w\+')
+        let l:word = matchstr(a:item['insertText'], s:valid_word_pattern)
     elseif !empty(get(a:item, 'insertText', ''))
         " if plain-text insertText, use it.
         let l:word = a:item['insertText']
     elseif has_key(a:item, 'textEdit')
-        let l:word = matchstr(a:item['label'], '\w\+')
+        let l:word = matchstr(a:item['label'], s:valid_word_pattern)
     endif
     if empty(l:word)
         let l:word = a:item['label']

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -313,9 +313,9 @@ function! lsp#utils#base64_decode(data) abort
 endfunction
 
 function! lsp#utils#make_valid_word(str) abort
-   let str = matchstr(a:str, '^[^ (<{\[\r\n]\+')
-   if str =~# ':$'
-     return str[:-2]
+   let l:str = matchstr(a:str, '^[^ (<{\[\r\n]\+')
+   if l:str =~# ':$'
+     return l:str[:-2]
    endif
-   return str
+   return l:str
 endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -311,3 +311,11 @@ function! lsp#utils#base64_decode(data) abort
 
     return l:ret
 endfunction
+
+function! lsp#utils#make_valid_word(str) abort
+   let str = matchstr(a:str, '^[^ (<{\[\r\n]\+')
+   if str =~# ':$'
+     return str[:-2]
+   endif
+   return str
+endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -313,7 +313,7 @@ function! lsp#utils#base64_decode(data) abort
 endfunction
 
 function! lsp#utils#make_valid_word(str) abort
-   let l:str = matchstr(a:str, '^[^ (<{\[\r\n]\+')
+   let l:str = matchstr(a:str, '^[^ (<{\[\t\r\n]\+')
    if l:str =~# ':$'
      return l:str[:-2]
    endif

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -184,7 +184,12 @@ Describe lsp#utils
             Assert Equals(lsp#utils#make_valid_word('my-func()'), 'my-func')
             Assert Equals(lsp#utils#make_valid_word('my-name::space'), 'my-name::space')
             Assert Equals(lsp#utils#make_valid_word('my-name#space'), 'my-name#space')
-            Assert Equals(lsp#utils#make_valid_word('my-name#space'), 'my-name#space')
+            Assert Equals(lsp#utils#make_valid_word('my-name.space'), 'my-name.space')
+            Assert Equals(lsp#utils#make_valid_word('my-name.space: foo'), 'my-name.space')
+            Assert Equals(lsp#utils#make_valid_word('my-name%space: foo'), 'my-name%space')
+            Assert Equals(lsp#utils#make_valid_word('my-name&space: foo'), 'my-name&space')
+            Assert Equals(lsp#utils#make_valid_word('my-array[0]'), 'my-array')
+            Assert Equals(lsp#utils#make_valid_word('my-array<string>'), 'my-array')
         End
     End
 End

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -172,4 +172,15 @@ Describe lsp#utils
             Assert Equals(lsp#utils#base64_decode('AAAAEgAJABYAAAAIAAQAFw=='), [0, 0, 0, 18, 0, 9, 0, 22, 0, 0, 0, 8, 0, 4, 0, 23])
         End
     End
+
+    Describe lsp#utils#make_valid_word
+        It should make valid word
+            Assert Equals(lsp#utils#make_valid_word('my-word'), 'my-word')
+            Assert Equals(lsp#utils#make_valid_word('my-word: description'), 'my-word')
+            Assert Equals(lsp#utils#make_valid_word('my-word : description'), 'my-word')
+            Assert Equals(lsp#utils#make_valid_word('my-word is word'), 'my-word')
+            Assert Equals(lsp#utils#make_valid_word('my-func()'), 'my-func')
+            Assert Equals(lsp#utils#make_valid_word('my-name::space'), 'my-name::space')
+        End
+    End
 End

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -176,11 +176,15 @@ Describe lsp#utils
     Describe lsp#utils#make_valid_word
         It should make valid word
             Assert Equals(lsp#utils#make_valid_word('my-word'), 'my-word')
+            Assert Equals(lsp#utils#make_valid_word(' my-word'), '')
+            Assert Equals(lsp#utils#make_valid_word("my\nword"), 'my')
             Assert Equals(lsp#utils#make_valid_word('my-word: description'), 'my-word')
             Assert Equals(lsp#utils#make_valid_word('my-word : description'), 'my-word')
             Assert Equals(lsp#utils#make_valid_word('my-word is word'), 'my-word')
             Assert Equals(lsp#utils#make_valid_word('my-func()'), 'my-func')
             Assert Equals(lsp#utils#make_valid_word('my-name::space'), 'my-name::space')
+            Assert Equals(lsp#utils#make_valid_word('my-name#space'), 'my-name#space')
+            Assert Equals(lsp#utils#make_valid_word('my-name#space'), 'my-name#space')
         End
     End
 End

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -190,6 +190,7 @@ Describe lsp#utils
             Assert Equals(lsp#utils#make_valid_word('my-name&space: foo'), 'my-name&space')
             Assert Equals(lsp#utils#make_valid_word('my-array[0]'), 'my-array')
             Assert Equals(lsp#utils#make_valid_word('my-array<string>'), 'my-array')
+            Assert Equals(lsp#utils#make_valid_word("my-name\tdescription"), 'my-name')
         End
     End
 End


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/10111/73123210-db1bc880-3fd0-11ea-9b2c-1e3d201e75c3.png)

Vim always insert active candidate while selecting items in popup. So the inserted text might be wrong. Please see discussion about Metals and Vim's behavior.

https://twitter.com/olafurpg/status/1208442913266577409

I discussed how to fix this behavior with @hrsh7th . And we decided some rules for how to make insertion text.

* When insertTextFormat==2, it should prefer insertText. But it may include placeholder.
* When insertTextFormat!=2, use insertText since it is plain-text.
* When it have textEdit, the inserted text will be modified in later, so insert only word.
* Otherwize, insert label since it should be what the server want to insert.