### PR TITLE
Cache signature_help_trigger_chars

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -688,9 +688,6 @@ function! s:on_exit(server_name, id, data, event) abort
         let l:server['exited'] = 1
         if has_key(l:server, 'init_result')
             unlet l:server['init_result']
-            if has_key(b:, 'lsp_signature_help_trigger_character')
-                unlet b:lsp_signature_help_trigger_character
-            endif
         endif
         doautocmd User lsp_server_exit
     endif
@@ -749,6 +746,10 @@ function! s:handle_initialize(server_name, data) abort
 
     if !lsp#client#is_error(l:response)
         let l:server['init_result'] = l:response
+        " Delete cache of trigger chars
+        if has_key(b:, 'lsp_signature_help_trigger_character')
+            unlet b:lsp_signature_help_trigger_character
+        endif
     else
         let l:server['failed'] = l:response['error']
         call lsp#utils#error('Failed to initialize ' . a:server_name . ' with error ' . l:response['error']['code'] . ': ' . l:response['error']['message'])

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -688,6 +688,9 @@ function! s:on_exit(server_name, id, data, event) abort
         let l:server['exited'] = 1
         if has_key(l:server, 'init_result')
             unlet l:server['init_result']
+            if has_key(b:, 'lsp_signature_help_trigger_character')
+                unlet b:lsp_signature_help_trigger_character
+            endif
         endif
         doautocmd User lsp_server_exit
     endif

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -1,3 +1,4 @@
+" vint: -ProhibitUnusedVariable
 let s:debounce_timer_id = 0
 
 function! s:not_supported(what) abort

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -128,6 +128,7 @@ function! s:on_text_changed_after(bufnr) abort
         return
     endif
 
+    " Cache trigger chars since this loop is heavy
     let l:chars = get(b:, 'lsp_signature_help_trigger_character', [])
     if empty(l:chars)
         for l:server_name in lsp#get_whitelisted_servers(a:bufnr)

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -128,10 +128,13 @@ function! s:on_text_changed_after(bufnr) abort
         return
     endif
 
-    let l:chars = []
-    for l:server_name in lsp#get_whitelisted_servers(a:bufnr)
-        let l:chars += lsp#capabilities#get_signature_help_trigger_characters(l:server_name)
-    endfor
+    let l:chars = get(b:, 'lsp_signature_help_trigger_character', [])
+    if empty(l:chars)
+        for l:server_name in lsp#get_whitelisted_servers(a:bufnr)
+            let l:chars += lsp#capabilities#get_signature_help_trigger_characters(l:server_name)
+        endfor
+        let b:lsp_signature_help_trigger_character = l:chars
+    endif
 
     if index(l:chars, lsp#utils#_get_before_char_skip_white()) >= 0
         call lsp#ui#vim#signature_help#get_signature_help_under_cursor()

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -114,10 +114,10 @@ endfunction
 function! s:on_cursor_moved() abort
     let l:bufnr = bufnr('%')
     call timer_stop(s:debounce_timer_id)
-    let s:debounce_timer_id = timer_start(200, { -> s:on_text_changed_after(l:bufnr) }, { 'repeat': 1 })
+    let s:debounce_timer_id = timer_start(500, function('s:on_text_changed_after', [l:bufnr]), { 'repeat': 1 })
 endfunction
 
-function! s:on_text_changed_after(bufnr) abort
+function! s:on_text_changed_after(bufnr, timer) abort
     if bufnr('%') != a:bufnr
         return
     endif


### PR DESCRIPTION
s:on_text_changed_after in autoload/lsp/ui/vim/signature_help.vim is too heavy eventhough it is called by every key typing.