### PR TITLE
Register CursorMoved event only when required

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -189,9 +189,10 @@ function! s:register_events() abort
         if exists('##TextChangedP')
             autocmd TextChangedP * call s:on_text_document_did_change()
         endif
-        autocmd CursorMoved * call s:on_cursor_moved()
+        if g:lsp_diagnostics_echo_cursor || g:lsp_highlight_references_enabled
+            autocmd CursorMoved * call s:on_cursor_moved()
+        endif
         autocmd BufWinEnter,BufWinLeave,InsertEnter * call lsp#ui#vim#references#clean_references()
-        autocmd CursorMoved * if g:lsp_highlight_references_enabled | call lsp#ui#vim#references#highlight(v:false) | endif
     augroup END
     call s:on_text_document_did_open()
 endfunction
@@ -239,7 +240,14 @@ endfunction
 function! s:on_cursor_moved() abort
     let l:buf = bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
-    call lsp#ui#vim#diagnostics#echo#cursor_moved()
+
+    if g:lsp_diagnostics_echo_cursor
+        call lsp#ui#vim#diagnostics#echo#cursor_moved()
+    endif
+
+    if g:lsp_highlight_references_enabled
+        call lsp#ui#vim#references#highlight(v:false)
+    endif
 endfunction
 
 function! s:call_did_save(buf, server_name, result, cb) abort

--- a/autoload/lsp/ui/vim/diagnostics/echo.vim
+++ b/autoload/lsp/ui/vim/diagnostics/echo.vim
@@ -1,8 +1,4 @@
 function! lsp#ui#vim#diagnostics#echo#cursor_moved() abort
-    if !g:lsp_diagnostics_echo_cursor
-        return
-    endif
-
     if mode() isnot# 'n'
         " dont' show echo only in normal mode
         return


### PR DESCRIPTION
I'm wondering we can improve the performance when the user disable some features. Specifically using CursorMoved is heavy so we can use this only when either `diagnostics_echo_cursor` or `highlight_references_enabled` is enabled.