### PR TITLE
Remove prefix

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -249,7 +249,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     elseif has_key(a:item, 'textEdit')
         let l:maybe = lsp#utils#make_valid_word(a:item['label'])
     endif
-    if !empty(l:maybe)
+    if !empty(l:maybe) && !empty(l:server_name)
         " maybe probably be a text should be inserted which server expected.
         " But it contains prefix text already typed.
         let l:server_info = lsp#get_server_info(l:server_name)

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -250,6 +250,8 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         let l:maybe = lsp#utils#make_valid_word(a:item['label'])
     endif
     if !empty(l:maybe)
+        " maybe probably be a text should be inserted which server expected.
+        " But it contains prefix text already typed.
         let l:server_info = lsp#get_server_info(l:server_name)
         let l:typed_pattern = has_key(l:server_info, 'config') && has_key(l:server_info['config'], 'typed_pattern') ? l:server_info['config']['typed_pattern'] : '\k*$'
         if !empty(l:typed_pattern)

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -28,12 +28,12 @@ function! s:encode_uri(path, start_pos_encode, default_prefix) abort
 
     let l:result = strpart(a:path, 0, a:start_pos_encode)
 
-    for i in range(a:start_pos_encode, len(l:path) - 1)
+    for l:i in range(a:start_pos_encode, len(l:path) - 1)
         " Don't encode '/' here, `path` is expected to be a valid path.
-        if l:path[i] =~# '^[a-zA-Z0-9_.~/-]$'
-            let l:result .= l:path[i]
+        if l:path[l:i] =~# '^[a-zA-Z0-9_.~/-]$'
+            let l:result .= l:path[l:i]
         else
-            let l:result .= s:urlencode_char(l:path[i])
+            let l:result .= s:urlencode_char(l:path[l:i])
         endif
     endfor
 


### PR DESCRIPTION
In selecting candidates in popup, if the item does not plain-text insertText  (i.e. label or insertText with snippet), it incude prefix text which already inserted. And it shoud be removed.

before
![terminal7](https://user-images.githubusercontent.com/10111/73830840-a7e6fe00-4848-11ea-9514-0a8f144e7ba3.gif)

after
![terminal7](https://user-images.githubusercontent.com/10111/73830893-c2b97280-4848-11ea-8536-c9384b6197fb.gif)

I confirmed html-language-server and metals. @hrsh7th Could you please check another Language Servers? Please note that this must use latest vim-lsp-settings, asyncomplete, asyncomplete-lsp since this feature need to set correct `typed_pattern` and `refresh_pattern`.