### PR TITLE
Don't allow hover window to close preview window

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -297,7 +297,9 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
         return call(g:lsp_preview_doubletap[0], [])
     endif
     " Close any previously opened preview window
-    pclose
+    if !g:lsp_preview_float
+        pclose
+    endif
 
     let l:current_window_id = win_getid()
 

--- a/ftplugin/lsp-hover.vim
+++ b/ftplugin/lsp-hover.vim
@@ -2,7 +2,7 @@
 
 if has('patch-8.1.1517') && g:lsp_preview_float && !has('nvim')
   " Can not set buftype or popup_close will fail with 'not a popup window'
-  setlocal previewwindow bufhidden=wipe noswapfile nobuflisted
+  setlocal bufhidden=wipe noswapfile nobuflisted
 else
   setlocal previewwindow buftype=nofile bufhidden=wipe noswapfile nobuflisted
 endif


### PR DESCRIPTION
If g:lsp_preview_float is enabled there is no reason to close the
preview window on LspHover and LspSignatureHelp. Moreover the preview
window may be in use by other plugins or by the user.