### PR TITLE
clear_all_highlights: check if buffer is loaded

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics/textprop.vim
+++ b/autoload/lsp/ui/vim/diagnostics/textprop.vim
@@ -78,7 +78,7 @@ function! s:clear_all_highlights() abort
         endif
 
         for l:bufnr in range(1, bufnr('$'))
-            if bufexists(l:bufnr)
+            if bufexists(l:bufnr) && bufloaded(l:bufnr)
                 call prop_remove({
                     \ 'type': l:prop_type,
                     \ 'bufnr': l:bufnr,


### PR DESCRIPTION
when buffer is not loaded, `len(getbufline(...))` returns 0, calling
`prop_remove(..., lnum=1, lnum-end=0)` which fails with invalid range
error

this occurs when calling `lsp#disable()`