### PR TITLE
using lsp#ui#vim#output#closepreview() to close preview before open new one

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -301,9 +301,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
         return call(g:lsp_preview_doubletap[0], [])
     endif
     " Close any previously opened preview window
-    if !g:lsp_preview_float
-        pclose
-    endif
+    call lsp#ui#vim#output#closepreview()
 
     let l:current_window_id = win_getid()
 


### PR DESCRIPTION
With `let g:lsp_diagnostics_float_cursor = 1` I can't open hover on line with errors.

Using `lsp#ui#vim#output#closepreview()` to close previous preview window seems to fix it. From reading the code, it seems to be correct to use this function, but I not sure if there are any other reasons for the original code

![lsp](https://user-images.githubusercontent.com/1186411/74135292-6763f780-4c2f-11ea-8c5a-1ecb933df03d.gif)
