### PR TITLE
Add lsp#activate()

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -214,6 +214,10 @@ function! s:on_text_document_did_open() abort
     endfor
 endfunction
 
+function! lsp#activate() abort
+  call s:on_text_document_did_open()
+endfunction
+
 function! s:on_text_document_did_save() abort
     let l:buf = bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif


### PR DESCRIPTION
Currently, vim-lsp-settings is using FileType base event handling. The FileType event is triggered when the filetype is modified from syntax plugins. For example, `*.jl` is registered as filetype=lisp at $VIMRUNTIME/filetype.vim in default. But some users want to use julia with `*.jl`. So user install [plugin](https://github.com/ajpaulson/julia-syntax.vim). If a Language Server for common-lisp (ex: cl-lsp) is already installed, vim-lsp-settings start cl-lsp and julia-language-server both. To avoid this, vim-lsp-settings have to make little delay to check the last modified. However, vim-lsp does not have a way to activate Language Server. So this change add `lsp#activate` to activate Language Server in lazy.
ex:

```vim
function! s:vim_lsp_load_or_suggest_delay(ft) abort
  call timer_start(0, {timer -> [s:vim_lsp_load_or_suggest(a:ft), lsp#activate()]})
endfunction
```