### PR TITLE
Show only first line while popup visible

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -245,6 +245,9 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     elseif !empty(get(a:item, 'insertText', ''))
         " if plain-text insertText, use it.
         let l:word = a:item['insertText']
+        if !empty(l:word)
+            let l:word = split(l:word, '\n')[0]
+        endif
     elseif has_key(a:item, 'textEdit')
         let l:word = lsp#utils#make_valid_word(a:item['label'])
     endif


### PR DESCRIPTION
pyls-ms return completion candidates with multi-lines.

![image](https://user-images.githubusercontent.com/10111/74440438-604c1c00-4eb1-11ea-8ec0-362a0f3abad0.png)

This change show only first-line while popup visible.

![screenshot](https://user-images.githubusercontent.com/10111/74440575-94bfd800-4eb1-11ea-8f40-b4029a2f9e49.gif)
