### PR TITLE
ESC to cancel workspace/symbol

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -343,7 +343,10 @@ function! lsp#ui#vim#workspace_symbol() abort
         return
     endif
 
-    let l:query = input('query>')
+    let l:query = inputdialog('query>', '', "\<ESC>")
+    if l:query ==# "\<ESC>"
+        return
+    endif
 
     for l:server in l:servers
         call lsp#send_request(l:server, {


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_symbol

> A query string to filter symbols by. Clients may send an empty
>	 * string here to request all symbols.

input() can be used to handle canceling. (ex ESC or CTRL-C)