### PR TITLE
Ignore error of prop_add/prop_remove

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics/textprop.vim
+++ b/autoload/lsp/ui/vim/diagnostics/textprop.vim
@@ -79,11 +79,15 @@ function! s:clear_all_highlights() abort
 
         for l:bufnr in range(1, bufnr('$'))
             if bufexists(l:bufnr) && bufloaded(l:bufnr)
-                call prop_remove({
-                    \ 'type': l:prop_type,
-                    \ 'bufnr': l:bufnr,
-                    \ 'all': v:true,
-                    \ }, 1, len(getbufline(l:bufnr, 1, '$')))
+                try
+                    call prop_remove({
+                        \ 'type': l:prop_type,
+                        \ 'bufnr': l:bufnr,
+                        \ 'all': v:true,
+                        \ }, 1, len(getbufline(l:bufnr, 1, '$')))
+                catch
+                    call lsp#log('clear_all_highlights', v:exception)
+                endtry
             endif
         endfor
 
@@ -103,11 +107,15 @@ function! s:clear_highlights(server_name, path) abort
 
     for l:severity in keys(s:severity_sign_names_mapping)
         let l:prop_type = s:get_prop_type(a:server_name, l:severity)
-        call prop_remove({
-            \ 'type': l:prop_type,
-            \ 'bufnr': l:bufnr,
-            \ 'all': v:true,
-            \ }, 1, len(getbufline(l:bufnr, 1, '$')))
+        try
+            call prop_remove({
+                \ 'type': l:prop_type,
+                \ 'bufnr': l:bufnr,
+                \ 'all': v:true,
+                \ }, 1, len(getbufline(l:bufnr, 1, '$')))
+        catch
+            call lsp#log('clear_highlights', v:exception)
+        endtry
     endfor
 endfunction
 
@@ -121,12 +129,16 @@ function! s:place_highlights(server_name, path, diagnostics) abort
             let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, l:item['range']['end'])
 
             let l:prop_type = s:get_prop_type(a:server_name, get(l:item, 'severity', 1))
-            call prop_add(l:start_line, l:start_col, {
-                \ 'end_lnum': l:end_line,
-                \ 'end_col': l:end_col,
-                \ 'bufnr': l:bufnr,
-                \ 'type': l:prop_type,
-                \ })
+            try
+                call prop_add(l:start_line, l:start_col, {
+                    \ 'end_lnum': l:end_line,
+                    \ 'end_col': l:end_col,
+                    \ 'bufnr': l:bufnr,
+                    \ 'type': l:prop_type,
+                    \ })
+            catch
+                call lsp#log('place_highlights', v:exception)
+            endtry
         endfor
     endif
 endfunction


### PR DESCRIPTION
Some language server send diagnostics which send wrong locations. For example, solargraph send `line = line('$') + 1`