### PR TITLE
Fix cursor pos after text edit

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -11,7 +11,7 @@ function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
     endfor
     call s:_switch(l:current_bufname)
 
-    if l:current_bufname == l:target_bufname
+    if bufnr(l:current_bufname) == bufnr(l:target_bufname)
         let l:length = strlen(getline(l:cursor_pos[0]))
         let l:cursor_pos[2] = max([0, l:cursor_pos[1] + l:cursor_pos[2] - l:length])
         let l:cursor_pos[1] = min([l:length, l:cursor_pos[1] + l:cursor_pos[2]])
@@ -58,10 +58,9 @@ function! s:_apply(bufnr, text_edit, cursor_pos) abort
   call append(a:text_edit.range.start.line, l:new_lines)
 
   " remove old lines
-  let l:buffer_length = len(getbufline(a:bufnr, '^', '$'))
   execute printf('%s,%sdelete _',
   \   l:new_lines_len + a:text_edit.range.start.line + 1,
-  \   min([l:buffer_length, l:new_lines_len + a:text_edit.range.end.line + 1])
+  \   min([l:new_lines_len + a:text_edit.range.end.line + 1, line('$')])
   \ )
 
   return l:cursor_offset


### PR DESCRIPTION
Sometimes, target_bufname is not equaled to current_bufname.
