### PR TITLE
Update diagnostics when document open

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -209,6 +209,12 @@ function! s:on_text_document_did_open() abort
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
     if getcmdwintype() !=# '' | return | endif
     call lsp#log('s:on_text_document_did_open()', l:buf, &filetype, getcwd(), lsp#utils#get_buffer_uri(l:buf))
+
+    " Some language server notify diagnostics to the buffer that has not been loaded yet.
+    " This diagnostics was stored `autoload/lsp/ui/vim/diagnostics.vim` but not highlighted.
+    " So we should refresh highlights when buffer opened.
+    call lsp#ui#vim#diagnostics#force_refresh(l:buf)
+
     for l:server_name in lsp#get_whitelisted_servers(l:buf)
         call s:ensure_flush(l:buf, l:server_name, function('s:fire_lsp_buffer_enabled', [l:server_name, l:buf]))
     endfor

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -20,6 +20,22 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     call lsp#ui#vim#signs#set(a:server_name, a:data)
 endfunction
 
+function! lsp#ui#vim#diagnostics#force_refresh(bufnr) abort
+    let l:data = lsp#ui#vim#diagnostics#get_document_diagnostics(a:bufnr)
+    if !empty(l:data)
+        for [l:server_name, l:response] in items(l:data)
+            call lsp#ui#vim#virtual#set(l:server_name, l:response)
+            call lsp#ui#vim#highlights#set(l:server_name, l:response)
+            call lsp#ui#vim#diagnostics#textprop#set(l:server_name, l:response)
+            call lsp#ui#vim#signs#set(l:server_name, l:response)
+        endfor
+    endif
+endfunction
+
+function! lsp#ui#vim#diagnostics#get_document_diagnostics(bufnr) abort
+    return get(s:diagnostics, lsp#utils#get_buffer_uri(a:bufnr), {})
+endfunction
+
 function! lsp#ui#vim#diagnostics#document_diagnostics() abort
     if !g:lsp_diagnostics_enabled
         call lsp#utils#error('Diagnostics manually disabled -- g:lsp_diagnostics_enabled = 0')


### PR DESCRIPTION
The gopls returns diagnostics to the buffer that has not been loaded yet.

- Open `test1.go`
- The server returns diagnostics to `test1.go, test2.go, test3.go`.
- vim-lsp stores all diagnostics but not highlight it.

So we should highlight diagnostics when buffer opened if needed.