### PR TITLE
Fix preview feature for vim without patch-8.1.1517

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -290,7 +290,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
         return call(g:lsp_preview_doubletap[0], [])
     endif
     " Close any previously opened preview window
-    if !g:lsp_preview_float
+    if s:use_preview
         pclose
     endif
 


### PR DESCRIPTION
Even if `g:lsp_preview_float` is true, vim-lsp should call `:pclose` if `s:use_vim_popup` is false.