### PR TITLE
Handle empty buffer-name

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -601,6 +601,12 @@ function! s:ensure_changed(buf, server_name, cb) abort
     let l:path = lsp#utils#get_buffer_uri(a:buf)
 
     let l:buffers = l:server['buffers']
+    if !has_key(l:buffers, l:path)
+        let l:msg = s:new_rpc_success('file is not managed', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log(l:msg)
+        call a:cb(l:msg)
+        return
+    endif
     let l:buffer_info = l:buffers[l:path]
 
     let l:changed_tick = getbufvar(a:buf, 'changedtick')
@@ -634,7 +640,7 @@ function! s:ensure_open(buf, server_name, cb) abort
     let l:path = lsp#utils#get_buffer_uri(a:buf)
 
     if empty(l:path)
-        let l:msg = s:new_rpc_error('ignore open since not a valid uri', { 'server_name': a:server_name, 'path': l:path })
+        let l:msg = s:new_rpc_success('ignore open since not a valid uri', { 'server_name': a:server_name, 'path': l:path })
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return


### PR DESCRIPTION
Current imlementation abandon requests when the buffer is blacklisted or emty buffer-name. Also ensure_flush send ensure_open always, so that the workspace commands fail ex: LspCodeAction.