### PR TITLE
Show only first line while popup visible

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -259,11 +259,11 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     elseif !empty(get(a:item, 'insertText', ''))
         " if plain-text insertText, use it.
         let l:word = a:item['insertText']
-        if !empty(l:word)
-            let l:word = split(l:word, '\n')[0]
-        endif
     elseif has_key(a:item, 'textEdit')
         let l:word = lsp#utils#make_valid_word(a:item['label'])
+    endif
+    if !empty(l:word)
+        let l:word = split(l:word, '\n')[0]
     endif
     if empty(l:word)
         let l:word = a:item['label']


### PR DESCRIPTION
One another fix is required. This is fixed in 9962ef9

But vls (vue-language-serer) send snippets even if snippet is disabled. So this change fixes to show only first line while popup is displayed.