### PR TITLE
Call command after edit

### DIFF
--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -95,9 +95,10 @@ function! s:handle_one_code_action(server_name, sync, command_or_code_action) ab
     " has WorkspaceEdit.
     if has_key(a:command_or_code_action, 'edit')
         call lsp#utils#workspace_edit#apply_workspace_edit(a:command_or_code_action['edit'])
+    endif
 
     " Command.
-    elseif has_key(a:command_or_code_action, 'command') && type(a:command_or_code_action['command']) == type('')
+    if has_key(a:command_or_code_action, 'command') && type(a:command_or_code_action['command']) == type('')
         call lsp#send_request(a:server_name, {
                     \   'method': 'workspace/executeCommand',
                     \   'params': a:command_or_code_action,


### PR DESCRIPTION
codeAction may contains edit and command both

https://microsoft.github.io/language-server-protocol/specifications/specification-current/

Language Server Specification says:

```
	/**
	 * The workspace edit this code action performs.
	 */
	edit?: WorkspaceEdit;

	/**
	 * A command this code action executes. If a code action
	 * provides an edit and a command, first the edit is
	 * executed and then the command.
	 */
	command?: Command;
```