### PR TITLE
Implement register command

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -166,6 +166,16 @@ function! lsp#register_server(server_info) abort
     doautocmd User lsp_register_server
 endfunction
 
+"
+" lsp#register_command
+"
+" @param {command_name} = string
+" @param {callback} = funcref
+"
+function! lsp#register_command(command_name, callback) abort
+    call lsp#ui#vim#execute_command#_register(a:command_name, a:callback)
+endfunction
+
 function! lsp#register_notifications(name, callback) abort
     call add(s:notification_callbacks, { 'name': a:name, 'callback': a:callback })
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -469,8 +469,8 @@ function! s:handle_rename_prepare(server, last_command_id, type, data) abort
 
     let l:range = a:data['response']['result']
     let l:lines = getline(1, '$')
-    let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim('%', l:range['start'])
-    let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim('%', l:range['end'])
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim('%', l:range['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim('%', l:range['end'])
     if l:start_line ==# l:end_line
         let l:name = l:lines[l:start_line - 1][l:start_col - 1 : l:end_col - 2]
     else

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -199,7 +199,7 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
         \ }])
 
   " Move to complete start position.
-  call cursor(lsp#utils#position#_lsp_to_vim('%', l:range['start']))
+  call cursor(lsp#utils#position#lsp_to_vim('%', l:range['start']))
 endfunction
 
 "
@@ -240,7 +240,7 @@ function! s:simple_expand_text(text) abort
         \   'newText': l:text
         \ }])
 
-  let l:pos = lsp#utils#position#_lsp_to_vim('%', {
+  let l:pos = lsp#utils#position#lsp_to_vim('%', {
         \   'line': l:pos['line'],
         \   'character': l:pos['character'] + l:offset
         \ })

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -86,7 +86,7 @@ function! lsp#ui#vim#diagnostics#get_diagnostics_under_cursor(...) abort
     let l:closest_distance = -1
 
     for l:diagnostic in l:diagnostics
-        let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim('%', l:diagnostic['range']['start'])
+        let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim('%', l:diagnostic['range']['start'])
 
         if l:line == l:start_line
             let l:distance = abs(l:start_col - l:col)
@@ -126,7 +126,7 @@ function! s:next_diagnostic(diagnostics) abort
     let l:next_line = 0
     let l:next_col = 0
     for l:diagnostic in a:diagnostics
-        let [l:line, l:col] = lsp#utils#position#_lsp_to_vim('%', l:diagnostic['range']['start'])
+        let [l:line, l:col] = lsp#utils#position#lsp_to_vim('%', l:diagnostic['range']['start'])
         if l:line > l:view['lnum']
             \ || (l:line == l:view['lnum'] && l:col > l:view['col'] + 1)
             let l:next_line = l:line
@@ -137,7 +137,7 @@ function! s:next_diagnostic(diagnostics) abort
 
     if l:next_line == 0
         " Wrap to start
-        let [l:next_line, l:next_col] = lsp#utils#position#_lsp_to_vim('%', a:diagnostics[0]['range']['start'])
+        let [l:next_line, l:next_col] = lsp#utils#position#lsp_to_vim('%', a:diagnostics[0]['range']['start'])
         let l:next_col -= 1
     endif
 
@@ -184,7 +184,7 @@ function! s:previous_diagnostic(diagnostics) abort
     let l:next_col = 0
     let l:index = len(a:diagnostics) - 1
     while l:index >= 0
-        let [l:line, l:col] = lsp#utils#position#_lsp_to_vim('%', a:diagnostics[l:index]['range']['start'])
+        let [l:line, l:col] = lsp#utils#position#lsp_to_vim('%', a:diagnostics[l:index]['range']['start'])
         if l:line < l:view['lnum']
             \ || (l:line == l:view['lnum'] && l:col < l:view['col'])
             let l:next_line = l:line
@@ -196,7 +196,7 @@ function! s:previous_diagnostic(diagnostics) abort
 
     if l:next_line == 0
         " Wrap to end
-        let [l:next_line, l:next_col] = lsp#utils#position#_lsp_to_vim('%', a:diagnostics[-1]['range']['start'])
+        let [l:next_line, l:next_col] = lsp#utils#position#lsp_to_vim('%', a:diagnostics[-1]['range']['start'])
         let l:next_col -= 1
     endif
 

--- a/autoload/lsp/ui/vim/diagnostics/textprop.vim
+++ b/autoload/lsp/ui/vim/diagnostics/textprop.vim
@@ -125,8 +125,8 @@ function! s:place_highlights(server_name, path, diagnostics) abort
     let l:bufnr = bufnr(a:path)
     if !empty(a:diagnostics) && l:bufnr >= 0
         for l:item in a:diagnostics
-            let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, l:item['range']['start'])
-            let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, l:item['range']['end'])
+            let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, l:item['range']['start'])
+            let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, l:item['range']['end'])
 
             let l:prop_type = s:get_prop_type(a:server_name, get(l:item, 'severity', 1))
             try

--- a/autoload/lsp/ui/vim/execute_command.vim
+++ b/autoload/lsp/ui/vim/execute_command.vim
@@ -1,0 +1,63 @@
+let s:commands = {}
+
+"
+" @param {name} = string
+" @param {callback} = funcref
+"
+function! lsp#ui#vim#execute_command#_register(command_name, callback) abort
+  if has_key(s:commands, a:command_name)
+    throw printf('lsp#ui#vim#execute_command#_register_command: %s already registered.', a:command_name)
+  endif
+
+  let s:commands[a:command_name] = a:callback
+endfunction
+
+"
+" TODO: This method does not handle any return value.
+"
+function! lsp#ui#vim#execute_command#_execute(params) abort
+  let l:command_name = a:params['command_name']
+  let l:command_args = get(a:params, 'command_args', v:null)
+  let l:server_name = get(a:params, 'server_name', '')
+  let l:bufnr = get(a:params, 'bufnr', -1)
+  let l:sync = get(a:params, 'sync', v:false)
+
+  " create command.
+  let l:command = { 'command': l:command_name }
+  if l:command_args isnot v:null
+    let l:command['arguments'] = l:command_args
+  endif
+
+  " execute command on local.
+  if has_key(s:commands, l:command_name)
+    try
+      call s:commands[l:command_name]({
+      \   'bufnr': l:bufnr,
+      \   'command': l:command,
+      \ })
+    catch /.*/
+      call lsp#utils#error(printf('Execute command failed: %s', string(a:params)))
+    endtry
+    return
+  endif
+
+  " execute command on server.
+  if !empty(l:server_name)
+    call lsp#send_request(l:server_name, {
+    \   'method': 'workspace/executeCommand',
+    \   'params': l:command,
+    \   'sync': l:sync,
+    \   'on_notification': function('s:handle_execute_command', [l:server_name, l:command]),
+    \ })
+  endif
+endfunction
+
+"
+" handle workspace/executeCommand response
+"
+function! s:handle_execute_command(server_name, command, data) abort
+  if lsp#client#is_error(a:data['response'])
+    call lsp#utils#error('Execute command failed on ' . a:server_name . ': ' . string(a:command) . ' -> ' . string(a:data))
+  endif
+endfunction
+

--- a/autoload/lsp/ui/vim/execute_command.vim
+++ b/autoload/lsp/ui/vim/execute_command.vim
@@ -33,6 +33,7 @@ function! lsp#ui#vim#execute_command#_execute(params) abort
     try
       call s:commands[l:command_name]({
       \   'bufnr': l:bufnr,
+      \   'server_name': l:server_name,
       \   'command': l:command,
       \ })
     catch /.*/

--- a/autoload/lsp/ui/vim/highlights.vim
+++ b/autoload/lsp/ui/vim/highlights.vim
@@ -95,8 +95,8 @@ function! s:place_highlights(server_name, path, diagnostics) abort
 
     if !empty(a:diagnostics) && l:bufnr >= 0
         for l:item in a:diagnostics
-            let [l:line, l:start_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, l:item['range']['start'])
-            let [l:_, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, l:item['range']['end'])
+            let [l:line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, l:item['range']['start'])
+            let [l:_, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, l:item['range']['end'])
 
             let l:name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
             let l:hl_name = l:name . 'Highlight'

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -14,8 +14,8 @@ endif
 function! s:range_to_position(bufnr, range) abort
     let l:position = []
 
-    let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim(a:bufnr, a:range['start'])
-    let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(a:bufnr, a:range['end'])
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['end'])
     if l:end_line == l:start_line
         let l:position = [[
         \ l:start_line,

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -38,7 +38,7 @@ let s:diagnostic_severity = {
 
 function! s:symbols_to_loc_list_children(server, path, list, symbols, depth) abort
     for l:symbol in a:symbols
-        let [l:line, l:col] = lsp#utils#position#_lsp_to_vim(a:path, l:symbol['range']['start'])
+        let [l:line, l:col] = lsp#utils#position#lsp_to_vim(a:path, l:symbol['range']['start'])
 
         call add(a:list, {
             \ 'filename': a:path,
@@ -67,7 +67,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                 let l:location = l:symbol['location']
                 if lsp#utils#is_file_uri(l:location['uri'])
                     let l:path = lsp#utils#uri_to_path(l:location['uri'])
-                    let [l:line, l:col] = lsp#utils#position#_lsp_to_vim(l:path, l:location['range']['start'])
+                    let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:location['range']['start'])
                     call add(l:list, {
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
@@ -79,7 +79,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                 let l:location = a:result['request']['params']['textDocument']['uri']
                 if lsp#utils#is_file_uri(l:location)
                     let l:path = lsp#utils#uri_to_path(l:location)
-                    let [l:line, l:col] = lsp#utils#position#_lsp_to_vim(l:path, l:symbol['range']['start'])
+                    let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:symbol['range']['start'])
                     call add(l:list, {
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
@@ -121,7 +121,7 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
                 let l:text .= l:item['code'] . ':'
             endif
             let l:text .= l:item['message']
-            let [l:line, l:col] = lsp#utils#position#_lsp_to_vim(l:path, l:item['range']['start'])
+            let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:item['range']['start'])
             call add(l:list, {
                 \ 'filename': l:path,
                 \ 'lnum': l:line,

--- a/autoload/lsp/utils/buffer.vim
+++ b/autoload/lsp/utils/buffer.vim
@@ -49,8 +49,8 @@ function! lsp#utils#buffer#_open_lsp_location(location) abort
     let l:path = lsp#utils#uri_to_path(a:location['uri'])
     let l:bufnr = bufnr(l:path)
 
-    let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['start'])
-    let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['end'])
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['end'])
 
     normal! m'
     if &modified && !&hidden

--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -29,8 +29,8 @@ function! lsp#utils#location#_open_lsp_location(location) abort
     let l:path = lsp#utils#uri_to_path(a:location['uri'])
     let l:bufnr = bufnr(l:path)
 
-    let [l:start_line, l:start_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['start'])
-    let [l:end_line, l:end_col] = lsp#utils#position#_lsp_to_vim(l:bufnr, a:location['range']['end'])
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(l:bufnr, a:location['range']['end'])
 
     call s:open_location(l:path, l:start_line, l:start_col)
 
@@ -64,7 +64,7 @@ function! s:lsp_location_item_to_vim(loc, cache) abort
     endif
 
     let l:path = lsp#utils#uri_to_path(l:uri)
-    let [l:line, l:col] = lsp#utils#position#_lsp_to_vim(l:path, l:range['start'])
+    let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:range['start'])
 
     let l:index = l:line - 1
     if has_key(a:cache, l:path)
@@ -87,8 +87,8 @@ function! s:lsp_location_item_to_vim(loc, cache) abort
             \ 'lnum': l:line,
             \ 'col': l:col,
             \ 'text': l:text,
-            \ 'viewstart': lsp#utils#position#_lsp_to_vim(l:path, a:loc['targetRange']['start'])[0] - 1,
-            \ 'viewend': lsp#utils#position#_lsp_to_vim(l:path, a:loc['targetRange']['end'])[0] - 1,
+            \ 'viewstart': lsp#utils#position#lsp_to_vim(l:path, a:loc['targetRange']['start'])[0] - 1,
+            \ 'viewend': lsp#utils#position#lsp_to_vim(l:path, a:loc['targetRange']['end'])[0] - 1,
             \ }
     else
         return {

--- a/autoload/lsp/utils/position.vim
+++ b/autoload/lsp/utils/position.vim
@@ -1,5 +1,5 @@
 " This function can be error prone if the caller forgets to use +1 to vim line
-" so use lsp#utils#position#_lsp_to_vim instead
+" so use lsp#utils#position#lsp_to_vim instead
 " Convert a character-index (0-based) to byte-index (1-based)
 " This function requires a buffer specifier (expr, see :help bufname()),
 " a line number (lnum, 1-based), and a character-index (char, 0-based).
@@ -42,7 +42,7 @@ endfunction
 "   line,
 "   col
 " ]
-function! lsp#utils#position#_lsp_to_vim(expr, position) abort
+function! lsp#utils#position#lsp_to_vim(expr, position) abort
     let l:line = a:position['line'] + 1
     let l:char = a:position['character']
     let l:col = s:to_col(a:expr, l:line, l:char)
@@ -55,7 +55,7 @@ endfunction
 "   'line': line,
 "   'character': character
 " }
-function! lsp#utils#position#_vim_to_lsp(expr, pos) abort
+function! lsp#utils#position#vim_to_lsp(expr, pos) abort
     return {
          \   'line': a:pos[0] - 1,
          \   'character': s:to_char(a:expr, a:pos[0], a:pos[1])

--- a/autoload/lsp/utils/range.vim
+++ b/autoload/lsp/utils/range.vim
@@ -13,8 +13,8 @@ function! lsp#utils#range#_get_recent_visual_range() abort
     endif
 
     let l:range = {}
-    let l:range['start'] = lsp#utils#position#_vim_to_lsp('%', l:start_pos)
-    let l:range['end'] = lsp#utils#position#_vim_to_lsp('%', l:end_pos)
+    let l:range['start'] = lsp#utils#position#vim_to_lsp('%', l:start_pos)
+    let l:range['end'] = lsp#utils#position#vim_to_lsp('%', l:end_pos)
     return l:range
 endfunction
 
@@ -24,8 +24,8 @@ endfunction
 function! lsp#utils#range#_get_current_line_range() abort
   let l:pos = getpos('.')[1 : 2]
   let l:range = {}
-  let l:range['start'] = lsp#utils#position#_vim_to_lsp('%', l:pos)
-  let l:range['end'] = lsp#utils#position#_vim_to_lsp('%', [l:pos[0], l:pos[1] + strlen(getline(l:pos[0])) + 1])
+  let l:range['start'] = lsp#utils#position#vim_to_lsp('%', l:pos)
+  let l:range['end'] = lsp#utils#position#vim_to_lsp('%', [l:pos[0], l:pos[1] + strlen(getline(l:pos[0])) + 1])
   return l:range
 endfunction
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -49,6 +49,7 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|
       lsp#register_server                   |lsp#register_server()|
+      lsp#register_command                  |lsp#register_command()|
       lsp#stop_server                       |lsp#stop_server()|
       lsp#utils#find_nearest_parent_file_directory()
                               |lsp#utils#find_nearest_parent_file_directory()|
@@ -881,6 +882,41 @@ Note: After triggering completion with |i_CTRL-X_CTRL-O|, further filtering is
 only possible by adding to the already typed prefix (even if you're using the
 `contains` filter). If you'd like to retrigger the filtering, you will have to
 press CTRL-X CTRL-O again.
+
+
+lsp#register_command({command-name}, {callback})     *lsp#register_command()*
+
+Some language server expects handling custom command in the client.
+You can use this function to add custom command handler.
+
+{command-name} is unique id to specify command.
+{callback} is funcref that accepts below argument.
+>
+  callback({
+      'command': {
+          'command': string,
+          'arguments':  [...]
+      }
+  })
+<
+
+For example, the rust-analyzer expects the client handles some custom command as below example.
+>
+  function! s:rust_analyzer_apply_source_change(context)
+      let l:command = get(a:context, 'command', {})
+
+      let l:workspace_edit = get(l:command['arguments'][0], 'workspaceEdit', {})
+      if !empty(l:workspace_edit)
+          call lsp#utils#workspace_edit#apply_workspace_edit(l:workspace_edit)
+      endif
+
+      let l:cursor_position = get(l:command['arguments'][0], 'cursorPosition', {})
+      if !empty(l:cursor_position)
+          call cursor(lsp#utils#position#_lsp_to_vim('%', l:cursor_position))
+      endif
+  endfunction
+  call lsp#register_command('rust-analyzer.applySourceChange', function('s:rust_analyzer_apply_source_change'))
+<
 
 lsp#stop_server({name-of-server})                        *lsp#stop_server()*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -912,7 +912,7 @@ For example, the rust-analyzer expects the client handles some custom command as
 
       let l:cursor_position = get(l:command['arguments'][0], 'cursorPosition', {})
       if !empty(l:cursor_position)
-          call cursor(lsp#utils#position#_lsp_to_vim('%', l:cursor_position))
+          call cursor(lsp#utils#position#lsp_to_vim('%', l:cursor_position))
       endif
   endfunction
   call lsp#register_command('rust-analyzer.applySourceChange', function('s:rust_analyzer_apply_source_change'))
@@ -939,6 +939,22 @@ Get the status of a server.
 <
     Returns one of "unknown server", " "exited", "starting", "failed",
     "running", "not running".
+
+
+lsp#utils#position#lsp_to_vim({expr}, {position})  *lsp#utils#position#lsp_to_vim()*
+
+Convert LSP's positon to vim's pos ([lnum, col]).
+
+{expr} is same of bufname argument.
+{position} is LSP's position params.
+
+
+lsp#utils#position#vim_to_lsp({expr}, {pos})      *lsp#utils#position#lsp_to_vim()*
+
+Convert vim's pos to LSP's position ({ 'line': ..., 'character': ... }).
+
+{expr} is same of bufname argument.
+{pos} is vim's position params.
 
                             *lsp#utils#find_nearest_parent_file_directory()*
 lsp#utils#find_nearest_parent_file_directory({path}, {filename})

--- a/test/lsp/utils/position.vimspec
+++ b/test/lsp/utils/position.vimspec
@@ -8,56 +8,56 @@ Describe lsp#utils#position
         % delete _
     End
 
-    Describe lsp#utils#position#_lsp_to_vim
+    Describe lsp#utils#position#lsp_to_vim
 
         It should return the byte-index from the given character-index on a buffer
             call setline(1, ['a β c', 'δ', ''])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 0, 'character': 0 }), [1, 1])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 0, 'character': 1 }), [1, 2])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 0, 'character': 2 }), [1, 3])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 0, 'character': 3 }), [1, 5])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 0, 'character': 4 }), [1, 6])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 1, 'character': 0 }), [2, 1])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 1, 'character': 1 }), [2, 3])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('%', { 'line': 2, 'character': 0 }), [3, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 0, 'character': 0 }), [1, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 0, 'character': 1 }), [1, 2])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 0, 'character': 2 }), [1, 3])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 0, 'character': 3 }), [1, 5])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 0, 'character': 4 }), [1, 6])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 1, 'character': 0 }), [2, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 1, 'character': 1 }), [2, 3])
+            Assert Equals(lsp#utils#position#lsp_to_vim('%', { 'line': 2, 'character': 0 }), [3, 1])
         End
 
         It should return the byte-index from the given character-index in an unloaded file
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 0 }), [1, 1])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 1 }), [1, 2])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 2 }), [1, 3])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 3 }), [1, 5])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 4 }), [1, 6])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 1, 'character': 0 }), [2, 1])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 1, 'character': 1 }), [2, 3])
-            Assert Equals(lsp#utils#position#_lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 2, 'character': 0 }), [3, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 0 }), [1, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 1 }), [1, 2])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 2 }), [1, 3])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 3 }), [1, 5])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 0, 'character': 4 }), [1, 6])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 1, 'character': 0 }), [2, 1])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 1, 'character': 1 }), [2, 3])
+            Assert Equals(lsp#utils#position#lsp_to_vim('./test/testfiles/multibyte.txt', { 'line': 2, 'character': 0 }), [3, 1])
         End
 
     End
 
-    Describe lsp#utils#position#_vim_to_lsp
+    Describe lsp#utils#position#vim_to_lsp
 
         It should return the character-index from the given byte-index on a buffer
             call setline(1, ['a β c', 'δ', ''])
-            Assert Equals({ 'line': 0, 'character': 0 }, lsp#utils#position#_vim_to_lsp('%', [1, 1]))
-            Assert Equals({ 'line': 0, 'character': 1 }, lsp#utils#position#_vim_to_lsp('%', [1, 2]))
-            Assert Equals({ 'line': 0, 'character': 2 }, lsp#utils#position#_vim_to_lsp('%', [1, 3]))
-            Assert Equals({ 'line': 0, 'character': 3 }, lsp#utils#position#_vim_to_lsp('%', [1, 5]))
-            Assert Equals({ 'line': 0, 'character': 4 }, lsp#utils#position#_vim_to_lsp('%', [1, 6]))
-            Assert Equals({ 'line': 1, 'character': 0 }, lsp#utils#position#_vim_to_lsp('%', [2, 1]))
-            Assert Equals({ 'line': 1, 'character': 1 }, lsp#utils#position#_vim_to_lsp('%', [2, 3]))
-            Assert Equals({ 'line': 2, 'character': 0 }, lsp#utils#position#_vim_to_lsp('%', [3, 1]))
+            Assert Equals({ 'line': 0, 'character': 0 }, lsp#utils#position#vim_to_lsp('%', [1, 1]))
+            Assert Equals({ 'line': 0, 'character': 1 }, lsp#utils#position#vim_to_lsp('%', [1, 2]))
+            Assert Equals({ 'line': 0, 'character': 2 }, lsp#utils#position#vim_to_lsp('%', [1, 3]))
+            Assert Equals({ 'line': 0, 'character': 3 }, lsp#utils#position#vim_to_lsp('%', [1, 5]))
+            Assert Equals({ 'line': 0, 'character': 4 }, lsp#utils#position#vim_to_lsp('%', [1, 6]))
+            Assert Equals({ 'line': 1, 'character': 0 }, lsp#utils#position#vim_to_lsp('%', [2, 1]))
+            Assert Equals({ 'line': 1, 'character': 1 }, lsp#utils#position#vim_to_lsp('%', [2, 3]))
+            Assert Equals({ 'line': 2, 'character': 0 }, lsp#utils#position#vim_to_lsp('%', [3, 1]))
         End
 
         It should return the character-index from the given byte-index in an unloaded file
-            Assert Equals({ 'line': 0, 'character': 0 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [1, 1]))
-            Assert Equals({ 'line': 0, 'character': 1 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [1, 2]))
-            Assert Equals({ 'line': 0, 'character': 2 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [1, 3]))
-            Assert Equals({ 'line': 0, 'character': 3 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [1, 5]))
-            Assert Equals({ 'line': 0, 'character': 4 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [1, 6]))
-            Assert Equals({ 'line': 1, 'character': 0 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [2, 1]))
-            Assert Equals({ 'line': 1, 'character': 1 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [2, 3]))
-            Assert Equals({ 'line': 2, 'character': 0 }, lsp#utils#position#_vim_to_lsp('./test/testfiles/multibyte.txt', [3, 1]))
+            Assert Equals({ 'line': 0, 'character': 0 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [1, 1]))
+            Assert Equals({ 'line': 0, 'character': 1 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [1, 2]))
+            Assert Equals({ 'line': 0, 'character': 2 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [1, 3]))
+            Assert Equals({ 'line': 0, 'character': 3 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [1, 5]))
+            Assert Equals({ 'line': 0, 'character': 4 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [1, 6]))
+            Assert Equals({ 'line': 1, 'character': 0 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [2, 1]))
+            Assert Equals({ 'line': 1, 'character': 1 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [2, 3]))
+            Assert Equals({ 'line': 2, 'character': 0 }, lsp#utils#position#vim_to_lsp('./test/testfiles/multibyte.txt', [3, 1]))
         End
 
     End


### PR DESCRIPTION
I've implemented custom command register interface.

It will be useful when use rust-analyzer, eclipse.jdt.ls or some server that returns custom command.

For example, rust-analyzer returns `rust-analyzer.applySourceChange` command as CodeAction response and expects to handle it in client-side.

I think, it will be good to support custom command in vim-lsp-settings maybe.

#### TODO
- [ ] ~~Check capability~~
- [x] Check servers (typescript, gopls... etc)


EDIT: (mattn)

This closes #693, and related on #505,