### PR TITLE
Compute overflow information in completion

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -250,6 +250,7 @@ endfunction
 
 function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     let l:server_name = get(a:, 1, '')
+    let l:complete_position = get(a:, 2, lsp#get_position())
 
     let l:word = ''
     if get(a:item, 'insertTextFormat', -1) == 2 && !empty(get(a:item, 'insertText', ''))
@@ -296,7 +297,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
 
     " Add user_data.
     if s:is_user_data_support
-        let l:completion['user_data'] = s:create_user_data(a:item, l:server_name)
+        let l:completion['user_data'] = s:create_user_data(a:item, l:server_name, l:complete_position)
     endif
 
     if has_key(a:item, 'detail') && !empty(a:item['detail'])
@@ -333,12 +334,13 @@ endfunction
 "
 " create item's user_data.
 "
-function! s:create_user_data(completion_item, server_name) abort
+function! s:create_user_data(completion_item, server_name, complete_position) abort
     let l:user_data_key = '{"vim-lsp/key' . '":"' . string(s:managed_user_data_key_base) . '"}'
     let s:managed_user_data_map[l:user_data_key] = {
-                \   'server_name': a:server_name,
-                \   'completion_item': a:completion_item
-                \ }
+    \   'complete_position': a:complete_position,
+    \   'server_name': a:server_name,
+    \   'completion_item': a:completion_item
+    \ }
     let s:managed_user_data_key_base += 1
     return l:user_data_key
 endfunction

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -43,8 +43,9 @@ function! s:on_complete_done() abort
   endif
 
   let s:context['line'] = getline('.')
-  let s:context['position'] = getpos('.')
   let s:context['completed_item'] = copy(v:completed_item)
+  let s:context['done_position'] = getpos('.')
+  let s:context['complete_position'] = l:managed_user_data['complete_position']
   let s:context['server_name'] = l:managed_user_data['server_name']
   let s:context['completion_item'] = l:managed_user_data['completion_item']
   call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
@@ -58,8 +59,9 @@ function! s:on_complete_done_after() abort
   echo ''
 
   let l:line = s:context['line']
-  let l:position = s:context['position']
   let l:completed_item = s:context['completed_item']
+  let l:done_position = s:context['done_position']
+  let l:complete_position = s:context['complete_position']
   let l:server_name = s:context['server_name']
   let l:completion_item = s:context['completion_item']
 
@@ -82,9 +84,10 @@ function! s:on_complete_done_after() abort
   if strlen(l:expand_text) > 0
     call s:clear_inserted_text(
           \   l:line,
-          \   l:position,
+          \   l:done_position,
+          \   l:complete_position,
           \   l:completed_item,
-          \   l:completion_item
+          \   l:completion_item,
           \ )
   endif
 
@@ -167,34 +170,34 @@ endfunction
 "
 " Remove inserted text during completion.
 "
-function! s:clear_inserted_text(line, position, completed_item, completion_item) abort
+function! s:clear_inserted_text(line, done_position, complete_position, completed_item, completion_item) abort
   " Remove commit characters.
   call setline('.', a:line)
 
   " Create range to remove v:completed_item.
   let l:range = {
         \   'start': {
-        \     'line': a:position[1] - 1,
-        \     'character': lsp#utils#to_char('%', a:position[1], a:position[2] + a:position[3]) - strchars(a:completed_item['word'])
+        \     'line': a:done_position[1] - 1,
+        \     'character': lsp#utils#to_char('%', a:done_position[1], a:done_position[2] + a:done_position[3]) - strchars(a:completed_item['word'])
         \   },
         \   'end': {
-        \     'line': a:position[1] - 1,
-        \     'character': lsp#utils#to_char('%', a:position[1], a:position[2] + a:position[3])
+        \     'line': a:done_position[1] - 1,
+        \     'character': lsp#utils#to_char('%', a:done_position[1], a:done_position[2] + a:done_position[3])
         \   }
         \ }
 
   " Expand remove range to textEdit.
   if has_key(a:completion_item, 'textEdit')
-    let l:offset = max([0, l:range['start']['character'] - a:completion_item['textEdit']['range']['start']['character']])
-    let l:range['start']['character'] = a:completion_item['textEdit']['range']['start']['character']
-    let l:range['end']['character'] = max([
-          \   l:range['end']['character'],
-          \   a:completion_item['textEdit']['range']['end']['character']
-          \ ])
-
-    if l:range['end']['character'] + l:offset <= strchars(getline(l:range['end']['line'] + 1))
-      let l:range['end']['character'] += l:offset
-    endif
+    let l:range = {
+    \   'start': {
+    \     'line': a:completion_item['textEdit']['range']['start']['line'],
+    \     'character': a:completion_item['textEdit']['range']['start']['character'],
+    \   },
+    \   'end': {
+    \     'line': a:completion_item['textEdit']['range']['end']['line'],
+    \     'character': a:completion_item['textEdit']['range']['end']['character'] + strchars(a:completed_item['word']) - (a:complete_position['character'] - l:range['start']['character'])
+    \   }
+    \ }
   endif
 
   " Remove v:completed_item.word (and textEdit range if need).

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -185,11 +185,16 @@ function! s:clear_inserted_text(line, position, completed_item, completion_item)
 
   " Expand remove range to textEdit.
   if has_key(a:completion_item, 'textEdit')
+    let l:offset = max([0, l:range['start']['character'] - a:completion_item['textEdit']['range']['start']['character']])
     let l:range['start']['character'] = a:completion_item['textEdit']['range']['start']['character']
     let l:range['end']['character'] = max([
           \   l:range['end']['character'],
           \   a:completion_item['textEdit']['range']['end']['character']
           \ ])
+
+    if l:range['end']['character'] + l:offset <= strchars(getline(l:range['end']['line'] + 1))
+      let l:range['end']['character'] += l:offset
+    endif
   endif
 
   " Remove v:completed_item.word (and textEdit range if need).

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -59,11 +59,12 @@ Describe lsp#omni
             \ 'user_data': '{"vim-lsp/key":"0"}'
             \}
 
-            let got = lsp#omni#get_vim_completion_item(item)
+            let got = lsp#omni#get_vim_completion_item(item, '', { 'line': 1, 'character': 1 })
             Assert Equals(got, want)
             Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got), {
                         \   'server_name': '',
-                        \   'completion_item': item
+                        \   'completion_item': item,
+                        \   'complete_position': { 'line': 1, 'character': 1 }
                         \ })
         End
 


### PR DESCRIPTION
This PR is an experimental feature, please verify it has no edge case.

I had been investigating VSCode's completion behavior.
In this investigation, I found strange behavior.

### json-languageserver's completion behavior

I test this situation of completion in `package.json`. (`"` is automatically closed by lexima.vim)

```json
{
  "na|"
}
```

I confirm `name` candidates and then `VSCode` gets below results.

```json
{
  "name": "|"
}
```

This is an ideal behavior, I think. (`"` was not duplicates)
But vim-lsp or other client does not get this result.

My investigation founds the point of this behavior in VSCode's implementation.

https://github.com/microsoft/vscode/blob/master/src/vs/editor/contrib/suggest/suggestController.ts#L339

This PR implements VSCode's `getOverwriteInfo` maybe.