### PR TITLE
Follow vscode textEdit behavior

### DIFF
--- a/autoload/lsp/utils/workspace_edit.vim
+++ b/autoload/lsp/utils/workspace_edit.vim
@@ -1,24 +1,12 @@
 " Applies WorkspaceEdit changes.
 function! lsp#utils#workspace_edit#apply_workspace_edit(workspace_edit) abort
     if has_key(a:workspace_edit, 'documentChanges')
-        let l:cur_buffer = bufnr('%')
-        let l:view = winsaveview()
         for l:text_document_edit in a:workspace_edit['documentChanges']
             call lsp#utils#text_edit#apply_text_edits(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
         endfor
-        if l:cur_buffer !=# bufnr('%')
-            execute 'keepjumps keepalt b ' . l:cur_buffer
-        endif
-        call winrestview(l:view)
     elseif has_key(a:workspace_edit, 'changes')
-        let l:cur_buffer = bufnr('%')
-        let l:view = winsaveview()
         for [l:uri, l:text_edits] in items(a:workspace_edit['changes'])
             call lsp#utils#text_edit#apply_text_edits(l:uri, l:text_edits)
         endfor
-        if l:cur_buffer !=# bufnr('%')
-            execute 'keepjumps keepalt b ' . l:cur_buffer
-        endif
-        call winrestview(l:view)
     endif
 endfunction


### PR DESCRIPTION
This PR aims to fix text edit behavior.

I found the problem when using rust-analyzer.
rust-analyzer seems to expect to fix cursor col after applying text edit and VSCode seems to do it.

Before
![follow-vscode-behavior-before](https://user-images.githubusercontent.com/629908/77427258-6a9af780-6e19-11ea-8b22-1279900709b7.gif)

After
![follow-vscode-behavior-after](https://user-images.githubusercontent.com/629908/77427269-6ff84200-6e19-11ea-8796-3743453d855a.gif)

I thought vim-lsp should supports `virtual edit` position.
But VSCode and LSP does not tell how to support it.

My previous implementation trying to support it but I removed those codes from this PR.

--- Updated ---

New text edit implementation fix cursor position strictly so I removed winsaveview and winrestview.