### PR TITLE
Small API change with lsp#ui#vim#code_action#do() for more flexible filtering

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -535,6 +535,6 @@ function! lsp#ui#vim#code_action() abort
     call lsp#ui#vim#code_action#do({
         \   'sync': v:false,
         \   'selection': v:false,
-        \   'query': '',
+        \   'query_filter': v:false,
         \ })
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -58,12 +58,12 @@ endif
 command! -range -nargs=* -complete=customlist,lsp#ui#vim#code_action#complete LspCodeAction call lsp#ui#vim#code_action#do({
       \   'sync': v:false,
       \   'selection': <range> != 0,
-      \   'query': '<args>'
+      \   'query_filter': empty('<args>') ? v:false : {action -> get(action, 'kind', '') =~# '^<args>'}
       \ })
 command! -range -nargs=* -complete=customlist,lsp#ui#vim#code_action#complete LspCodeActionSync call lsp#ui#vim#code_action#do({
       \   'sync': v:true,
       \   'selection': <range> != 0,
-      \   'query': '<args>'
+      \   'query_filter': empty('<args>') ? v:false : {action -> get(action, 'kind', '') =~# '^<args>'}
       \ })
 command! LspDeclaration call lsp#ui#vim#declaration(0, <q-mods>)
 command! LspPeekDeclaration call lsp#ui#vim#declaration(1)


### PR DESCRIPTION

Problem:
  - Now, the way to filter the code_action is only to filter kind property.
  - Some Code Actions doesn't include kind property.

Solution:
  - Change the internal API to be provided filter function.


Example:

After change, we can easily make the command like below.

```vim
command! -range -nargs=0 TypeScriptImport call lsp#ui#vim#code_action#do({
      \   'sync': v:false,
      \   'selection': <range> != 0,
      \   'query_filter': { action -> get(action, 'title', '') =~#
      \     '^Import ''\k\+'' from module "\f\+"\|' ..
      \     '^Add ''\k\+'' to existing import declaration from "\f\+"'
      \   }
      \ })
```

This command is for `filetype=typescript` and `typescript-language-server`.


<details>
<summary>More information</summary>

Consider the following situation.

```typescript
// index.ts
import { add } from "./foo";

console.log(add(2, 3))
console.log(sub(2, 3))
console.log(mul(2, 3))

// foo.ts
export function add (a:number, b:number){ return a + b }
export function sub (a:number, b:number){ return a - b }

// bar.ts
export function sub (a:number, b:number){ return a - b }
export function mul (a:number, b:number){ return a * b }
```

We can use `:TypeScriptImport` above on the `mul` in `index.ts`.

On the `sub`, we will get below code action list.

```json
[
  {
    "code_action": {
      "arguments": [
        {
          "documentChanges": [
            {
              "edits": [
                {
                  "range": {
                    "end": {
                      "character": 12,
                      "line": 0
                    },
                    "start": {
                      "character": 12,
                      "line": 0
                    }
                  },
                  "newText": ", sub"
                }
              ],
              "textDocument": {
                "uri": "file:///home/luma/work/typescript-playground/src/index.ts",
                "version": 1
              }
            }
          ]
        }
      ],
      "title": "Add \"sub\" to existing import declaration from \"./foo\"",
      "command": "_typescript.applyWorkspaceEdit"
    },
    "server_name": "typescript-language-server"
  },
  {
    "code_action": {
      "arguments": [
        {
          "documentChanges": [
            {
              "edits": [
                {
                  "range": {
                    "end": {
                      "character": 0,
                      "line": 1
                    },
                    "start": {
                      "character": 0,
                      "line": 1
                    }
                  },
                  "newText": "import { sub } from \"./bar\";^@"
                }
              ],
              "textDocument": {
                "uri": "file:///home/luma/work/typescript-playground/src/index.ts",
                "version": 1
              }
            }
          ]
        }
      ],
      "title": "Import \"sub\" from module \"./bar\"",
      "command": "_typescript.applyWorkspaceEdit"
    },
    "server_name": "typescript-language-server"
  },
  {
    "code_action": {
      "kind": "source.organizeImports",
      "title": "Organize Imports",
      "command": {
        "arguments": [
          "/home/luma/work/typescript-playground/src/index.ts"
        ],
        "title": "",
        "command": "_typescript.organizeImports"
      }
    },
    "server_name": "typescript-language-server"
  }
]
```

![screenshot](https://user-images.githubusercontent.com/29811106/77724089-6d723400-7035-11ea-9307-19044a222bb9.gif)

</details>


