### PR TITLE
Replace builtin trim() by lsp#utils#_trim()

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -95,9 +95,9 @@ endfunction
 function! s:get_filter_label(item) abort
     let l:user_data = lsp#omni#get_managed_user_data_from_completed_item(a:item)
     if has_key(l:user_data, 'completion_item') && has_key(l:user_data['completion_item'], 'filterText') && !empty(l:user_data['completion_item']['filterText'])
-        return trim(l:user_data['completion_item']['filterText'])
+        return lsp#utils#_trim(l:user_data['completion_item']['filterText'])
     endif
-    return trim(a:item['word'])
+    return lsp#utils#_trim(a:item['word'])
 endfunction
 
 function! s:prefix_filter(item, last_typed_word) abort


### PR DESCRIPTION
Builtin trim() does not exist in e.g. vim 8.0, which is the default version of Ubuntu 18.04 LTS.