### PR TITLE
lsp_diagnostics_updated autocommand

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -29,6 +29,7 @@ augroup _lsp_silent_
     autocmd User lsp_float_opened silent
     autocmd User lsp_float_closed silent
     autocmd User lsp_buffer_enabled silent
+    autocmd User lsp_diagnostics_updated silent
 augroup END
 
 function! lsp#log_verbose(...) abort

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -18,6 +18,8 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     call lsp#ui#vim#highlights#set(a:server_name, a:data)
     call lsp#ui#vim#diagnostics#textprop#set(a:server_name, a:data)
     call lsp#ui#vim#signs#set(a:server_name, a:data)
+
+    doautocmd User lsp_diagnostics_updated
 endfunction
 
 function! lsp#ui#vim#diagnostics#force_refresh(bufnr) abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1239,7 +1239,7 @@ current active, the event will be triggered when the buffer will be active.
 lsp_diagnostics_updated                            *lsp_diagnostics_updated*
 
 This autocommand us run after every time after new diagnostics received and 
-processed by vim-lsp. Example way of using it is to update statusline counts.
+processed by vim-lsp.
 >
   function! DoSomething
     echo lsp#get_buffer_diagnostics_counts()

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1241,9 +1241,13 @@ lsp_diagnostics_updated                            *lsp_diagnostics_updated*
 This autocommand us run after every time after new diagnostics received and 
 processed by vim-lsp. Example way of using it is to update statusline counts.
 >
-  augroup LightlineLSP
+  function! DoSomething
+    echo lsp#get_buffer_diagnostics_counts()
+  endfunction
+
+  augroup OnLSP
     autocmd!
-    autocmd User lsp_diagnostics_updated call lightline#update()
+    autocmd User lsp_diagnostics_updated call DoSomething()
   augroup END
 <
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -99,6 +99,7 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp_server_init                       |lsp_server_init|
       lsp_server_exit                       |lsp_server_exit|
       lsp_buffer_enabled                    |lsp_buffer_enabled|
+      lsp_diagnostics_updated               |lsp_diagnostics_updated|
     Mappings                              |vim-lsp-mappings|
        <plug>(lsp-preview-close)            |<plug>(lsp-preview-close)|
        <plug>(lsp-preview-focus)            |<plug>(lsp-preview-focus)|
@@ -1235,6 +1236,16 @@ This autocommand is run after vim-lsp is enabled for the buffer. This event is
 triggered imediately when the buffer is currently active. If the buffer is not
 current active, the event will be triggered when the buffer will be active.
 
+lsp_diagnostics_updated                            *lsp_diagnostics_updated*
+
+This autocommand us run after every time after new diagnostics received and 
+processed by vim-lsp. Example way of using it is to update statusline counts.
+>
+  augroup LightlineLSP
+    autocmd!
+    autocmd User lsp_diagnostics_updated call lightline#update()
+  augroup END
+<
 
 ==============================================================================
 Mappings                                                  *vim-lsp-mappings*


### PR DESCRIPTION
The idea is to add `lsp_diagnostics_updated` autocommand to make it possible to execute functions ONLY when new diagnostics information is received.

I have recently faced a problem with combining [vim-lsp](https://github.com/prabirshrestha/vim-lsp) with [lightline.vim](https://github.com/itchyny/lightline.vim). I came up with config:

```vim
Plug 'prabirshrestha/async.vim'
Plug 'prabirshrestha/vim-lsp'
  let g:lsp_diagnostics_enabled = v:true

Plug 'itchyny/lightline.vim'
  let g:lightline = {
    \   'active': {
    \      'right': [['lsp_errors', 'lsp_warnings', 'lsp_ok']],
    \   },
    \   'component_expand': {
    \     'lsp_warnings': 'LightlineLSPWarnings',
    \     'lsp_errors':   'LightlineLSPErrors',
    \     'lsp_ok':       'LightlineLSPOk',
    \   },
    \   'component_type': {
    \     'lsp_warnings': 'warning',
    \     'lsp_errors':   'error',
    \     'lsp_ok':       'middle',
    \   },
    \ }
  function! LightlineLSPWarnings() abort
    let l:counts = lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts()
    return l:counts.warning == 0 ? '' : printf('W:%d', l:counts.warning)
  endfunction

  function! LightlineLSPErrors() abort
    let l:counts = lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts()
    return l:counts.error == 0 ? '' : printf('E:%d', l:counts.error)
  endfunction

  function! LightlineLSPOk() abort
    let l:counts =  lsp#ui#vim#diagnostics#get_buffer_diagnostics_counts()
    let l:total = l:counts.error + l:counts.warning
    return l:total == 0 ? 'OK' : ''
  endfunction
```

The main struggle was to setup vim-lsp to call `lightline#update()` function every time new diagnostics info is received so that `LightlineLSPWarnings`, `LightlineLSPErrors` and `LightlineLSPOk` are called and `statusline` is updated. The only way that I found was following:

```vim
function! LSPUpdateLightLine(name, data)
  call lightline#update()
endfunction

call lsp#register_notifications('', function('LSPUpdateLightLine'))
```
And it worked. The main disadvantage in such approach is that callbacks registered with [`lsp#refigister_notifications`](https://github.com/prabirshrestha/vim-lsp/blob/46308234a2691824f2f3ad1fa8bc0086d4a3d4cf/autoload/lsp.vim#L179) is [called](https://github.com/prabirshrestha/vim-lsp/blob/46308234a2691824f2f3ad1fa8bc0086d4a3d4cf/autoload/lsp.vim#L754) EVERY time ANY update is received. You can check it by adding simple counter echoing to `LSPUpdateLightLine`:
 
```vim
let g:lightline_update_calls = 0
function! LSPUpdateLightLine(name, data)
  let g:lightline_update_calls += 1
  echo g:lightline_update_calls
  call lightline#update()
endfunction

call lsp#register_notifications('', function('LSPUpdateLightLine'))
```

Instead, approach with autocommands is less expensive in terms of frequency of function calls. This especially comes into play when you have a few expensive functions in your `statusline`.

With functionality provided in this PR, users can simply define such actions with `autocmd`:

```vim
augroup LightLineOnLSP
  autocmd!
  autocmd User lsp_diagnostics_updated call lightline#update()
augroup END
```