### PR TITLE
Fix splitting behaviour of open_location()

### DIFF
--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -1,7 +1,7 @@
 function! s:open_location(path, line, col, ...) abort
     normal! m'
     let l:mods = a:0 ? a:1 : ''
-    if l:mods is# '' && (!&modified || &hidden)
+    if l:mods is# '' && &modified && !&hidden
         let l:mods = &splitbelow ? 'rightbelow' : 'leftabove'
     endif
     let l:buffer = bufnr(a:path)


### PR DESCRIPTION
Commit 9a4f8de changed the default behaviour (probably unintentionally)
to always open in a split if 'hidden' is set.  The window should only
split if
- `<mods>` were used on the command or
- the buffer is modified and hidden is *not* set