### PR TITLE
Avoid autocmd-once for compatibility of VIM8.0

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -353,7 +353,9 @@ function! s:fire_lsp_buffer_enabled(server_name, buf, ...) abort
     if a:buf == bufnr('%')
         doautocmd User lsp_buffer_enabled
     else
-        exec printf('autocmd BufEnter <buffer=%d> ++once doautocmd User lsp_buffer_enabled', a:buf)
+        " Not using ++once in autocmd for compatibility of VIM8.0
+        let l:cmd = printf('autocmd BufEnter <buffer=%d> doautocmd User lsp_buffer_enabled', a:buf)
+        exec printf('augroup _lsp_fire_buffer_enabled | exec "%s | autocmd! _lsp_fire_buffer_enabled BufEnter <buffer>" | augroup END', l:cmd)
     endif
 endfunction
 


### PR DESCRIPTION
Fix #800

Steps to test the functionality (or to reproduce the issue in VIM8.0): 

1. Launch VIM8.0 
2. `:badd` a file which would trigger LSP
3. `:ba`
4. Enter the loaded buffer and check whether `lsp_buffer_enabled` has been called
