### PR TITLE
Fix capability parsing when textDocumentSync.save is a boolean

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -108,12 +108,11 @@ function! lsp#capabilities#get_text_document_save_registration_options(server_na
     let l:capabilities = lsp#get_server_capabilities(a:server_name)
     if !empty(l:capabilities) && has_key(l:capabilities, 'textDocumentSync')
         if type(l:capabilities['textDocumentSync']) == type({})
-            if  has_key(l:capabilities['textDocumentSync'], 'save')
-                return [1, {
-                    \ 'includeText': has_key(l:capabilities['textDocumentSync']['save'], 'includeText') ? l:capabilities['textDocumentSync']['save']['includeText'] : 0,
-                    \ }]
+            let l:save_options = get(l:capabilities['textDocumentSync'], 'save', 0)
+            if type(l:save_options) == type({})
+              return [1, {'includeText': get(save_options, 'includeText', 0)}]
             else
-                return [0, { 'includeText': 0 }]
+              return [l:save_options ? 1 : 0, {'includeText': 0 }]
             endif
         else
             return [1, { 'includeText': 0 }]


### PR DESCRIPTION
clangd recently started sending `true`; vim-lsp emits E715: Dictionary required
when preparing to save. A boolean is valid here:

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave

> Server Capability:
>
> property name (optional): textDocumentSync.save
> property type: boolean | SaveOptions