### PR TITLE
Add ability to set unique highlight group for virtual text

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ let g:lsp_signs_warning = {'text': '‼', 'icon': '/path/to/some/icon'} " icons 
 let g:lsp_signs_hint = {'icon': '/path/to/some/other/icon'} " icons require GUI
 ```
 
-Also two highlight groups for every sign group are defined (for example for LspError these are LspErrorText and LspErrorHighlight). By default, LspError text is highlighted using Error group, LspWarning is highlighted as Todo, others use Normal group. Line highlighting is not set by default. If your colorscheme of choise does not provide any of these, it is possible to clear them or link to some other group, like so:
+Also three highlight groups for every sign group are defined (for example for LspError these are LspErrorText, LspErrorVirtual, and LspErrorHighlight). By default, LspError text is highlighted using Error group, LspWarning is highlighted as Todo, others use Normal group. Virtual text will by default use the Text highlight group, for example for LspErrorVirtual will default to LspErrorText. Line highlighting is not set by default. If your colorscheme of choice does not provide any of these, it is possible to clear them or link to some other group, like so:
 
 ```viml
 highlight link LspErrorText GruvboxRedSign " requires gruvbox

--- a/autoload/lsp/ui/vim/virtual.vim
+++ b/autoload/lsp/ui/vim/virtual.vim
@@ -7,20 +7,36 @@ let s:severity_sign_names_mapping = {
     \ 4: 'LspHint',
     \ }
 
-if !hlexists('LspErrorText')
-    highlight link LspErrorText Error
+if !hlexists('LspErrorVirtual')
+  if !hlexists('LspErrorText')
+    highlight link LspErrorVirtual Error
+  else
+    highlight link LspErrorVirtual LspErrorText
+  endif
 endif
 
-if !hlexists('LspWarningText')
-    highlight link LspWarningText Todo
+if !hlexists('LspWarningVirtual')
+  if !hlexists('LspWarningText')
+    highlight link LspWarningVirtual Todo
+  else
+    highlight link LspWarningVirtual LspWarningText
+  endif
 endif
 
-if !hlexists('LspInformationText')
-    highlight link LspInformationText Normal
+if !hlexists('LspInformationVirtual')
+  if !hlexists('LspInformationText')
+    highlight link LspInformationVirtual Normal
+  else
+    highlight link LspInformationVirtual LspInformationText
+  endif
 endif
 
-if !hlexists('LspHintText')
-    highlight link LspHintText Normal
+if !hlexists('LspHintVirtual')
+  if !hlexists('LspHintText')
+    highlight link LspHintVirtual Normal
+  else
+    highlight link LspHintVirtual LspHintText
+  endif
 endif
 
 function! lsp#ui#vim#virtual#enable() abort
@@ -80,7 +96,7 @@ function! s:place_virtual(server_name, path, diagnostics) abort
             let l:line = l:item['range']['start']['line']
 
             let l:name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
-            let l:hl_name = l:name . 'Text'
+            let l:hl_name = l:name . 'Virtual'
             call nvim_buf_set_virtual_text(l:bufnr, l:ns, l:line,
                         \ [[g:lsp_virtual_text_prefix . l:item['message'], l:hl_name]], {})
         endfor

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -428,7 +428,12 @@ g:lsp_virtual_text_enabled                      *g:lsp_virtual_text_enabled*
     Default: `1` for neovim 0.3+
 
     Enables virtual text to be shown next to diagnostic errors. Requires
-    NeoVim with version 0.3 or newer.
+    NeoVim with version 0.3 or newer.  Virtual text uses the same highlight
+    groups used for signs (eg LspErrorText), but can be uniquely defined if
+    you want to have different highlight groups for signs and virtual text.
+    To set unique virtual text highlighting, you can set or link
+    `LspErrorVirtual`, `LspWarningVirtual`, `LspInformationVirtual` and
+    `LspHintVirtual` highlight groups.
 
     Example: >
 	let g:lsp_virtual_text_enabled = 1
@@ -1258,7 +1263,7 @@ current active, the event will be triggered when the buffer will be active.
 
 lsp_diagnostics_updated                            *lsp_diagnostics_updated*
 
-This autocommand us run after every time after new diagnostics received and 
+This autocommand us run after every time after new diagnostics received and
 processed by vim-lsp.
 >
   function! DoSomething


### PR DESCRIPTION
Adds the following user definable highlight groups:

- LspErrorVirtual
- LspWarningVirtual
- LspInformationVirtual
- LspHintVirtual

Each will fall back to it's 'Text' equivalent if set or vim-lsp default.  For example if a user does not set LspErrorVirtual but does set LspErrorText, error virtual text will use the LspErrorText highlight group.  If neither of the two from the previous example are set, error virtual text will use the vim-lsp default of Error highlight group.

Updated documentation to reflect changes.  Fixed typo in README.md.