### PR TITLE
Fix peek {definition,declaration} in files with whitespaces in pathnames

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -385,7 +385,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 echo 'Retrieved ' . a:type
                 botright copen
             else
-                let l:lines = readfile(fnameescape(l:loc['filename']))
+                let l:lines = readfile(l:loc['filename'])
                 if has_key(l:loc,'viewstart') " showing a locationLink
                     let l:view = l:lines[l:loc['viewstart'] : l:loc['viewend']]
                     call lsp#ui#vim#output#preview(a:server, l:view, {


### PR DESCRIPTION
Peeking the definition or declaration of a symbol found in a file with one or more whitespaces in its name and/or pathname silently causes **E484** as per vim-lsp's log file at ``g:lsp_log_verbose = 1``:

```
10 May 2020 16:08:50:["<---",1,"clangd",{"response":{"id":2,"jsonrpc":"2.0","result":[{"uri":"file:///cygdrive/e/Documents%20-%20Repositories/mtree-port/verify.c","range":{"end":{"character":16,"line":60},"start":{"character":0,"line":60}}}]},"request":{"id":2,"jsonrpc":"2.0","method":"textDocument/definition","params":{"textDocument":{"uri":"file:///cygdrive/e/Documents%20-%20Repositories/mtree-port/mtree.c"},"position":{"character":25,"line":185}}}}]
10 May 2020 16:08:50:["s:on_stdout client request on_notification() error","Vim(let):E484: Cannot open file /cygdrive/e/Documents\\ -\\ Repositories/mtree-port/verify.c","function <SNR>75_out_cb[2]..<SNR>74_on_stdout[79]..<lambda>11[1]..<SNR>86_handle_location, line 30"]
```

This occurs as ``s:handle_location()`` erroneously calls ``fnameescape()`` on the (full) filename prior to passing it to ``readfile()``, causing whitespaces to be escaped w/ a single backslash. Calling ``fnameescape()`` is, by my understanding, neither required nor of benefit here since the result is not subsequently used as a file name command argument to e.g. ``exec()`` or ``system()``.

The commit enclosed fixes this by simply calling ``readfile()`` on the filename directly w/o an intermediate ``fnameescape()`` call.