### PR TITLE
Add support for the tagfunc option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ endif
 function! s:on_lsp_buffer_enabled() abort
     setlocal omnifunc=lsp#complete
     setlocal signcolumn=yes
+    if exists('+tagfunc')
+        setlocal tagfunc=lsp#tagfunc
+    endif
     nmap <buffer> gd <plug>(lsp-definition)
     nmap <buffer> <f2> <plug>(lsp-rename)
     " refer to doc to add more commands

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -901,6 +901,10 @@ function! lsp#complete(...) abort
     return call('lsp#omni#complete', a:000)
 endfunction
 
+function! lsp#tagfunc(...) abort
+    return call('lsp#tag#tagfunc', a:000)
+endfunction
+
 let s:didchange_queue = []
 let s:didchange_timer = -1
 

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -247,15 +247,10 @@ function! s:lsp_send(id, opts, type) abort " opts = { id?, method?, result?, par
     if (a:type == s:send_type_request)
         let l:id = l:request['id']
         if get(a:opts, 'sync', 0) !=# 0
-            let l:start_time = reltime()
-
             let l:timeout = get(a:opts, 'sync_timeout', -1)
-            while has_key(l:ctx['requests'], l:request['id'])
-                if (reltimefloat(reltime(l:start_time)) * 1000) > l:timeout && l:timeout != -1
-                    throw 'lsp#client: timeout'
-                endif
-                sleep 1m
-            endwhile
+            if lsp#utils#_wait(l:timeout, {-> has_key(l:ctx['requests'], l:request['id'])}, 1) == -1
+                throw 'lsp#client: timeout'
+            endif
         endif
         return l:id
     else

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -82,9 +82,7 @@ function! lsp#omni#complete(findstart, base) abort
             return exists('v:none') ? v:none : []
         else
             " wait for retrieve textDocument/completion response and then call `s:display_completions` explicitly.
-            while s:completion['status'] is# s:completion_status_pending && !complete_check()
-                sleep 10m
-            endwhile
+            call lsp#utils#_wait(-1, {-> s:completion['status'] isnot# s:completion_status_pending || complete_check()}, 10)
             call timer_start(0, { timer -> s:display_completions(timer, l:info) })
 
             return exists('v:none') ? v:none : []

--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -1,0 +1,184 @@
+let s:tag_kind_priority = ['definition', 'declaration', 'implementation', 'type definition']
+
+function! s:not_supported(what) abort
+    call lsp#log(a:what . ' not supported for ' . &filetype)
+endfunction
+
+" polyfill for the neovim wait function
+function! s:wait(timeout, condition, ...) abort
+    if exists('*wait')
+        return call('wait', extend([a:timeout, a:condition], a:000))
+    endif
+
+    try
+        let l:timeout = a:timeout / 1000.0
+        let l:interval = get(a:000, 0, 200)
+        let l:Condition = a:condition
+        if type(l:Condition) != v:t_func
+            let l:Condition = function('eval', l:Condition)
+        endif
+        let l:start = reltime()
+        while l:timeout < 0 || reltimefloat(reltime(l:start)) < l:timeout
+            if l:Condition()
+                return 0
+            endif
+
+            execute 'sleep ' . l:interval . 'm'
+        endwhile
+        return -1
+    catch /^Vim:Interrupt$/
+        return -2
+    endtry
+endfunction
+
+function! s:location_to_tag(loc) abort
+    if has_key(a:loc, 'targetUri')
+        let l:uri = a:loc['targetUri']
+        let l:range = a:loc['targetRange']
+    else
+        let l:uri = a:loc['uri']
+        let l:range = a:loc['range']
+    endif
+
+    if !lsp#utils#is_file_uri(l:uri)
+        return v:null
+    endif
+
+    return {
+        \ 'filename': lsp#utils#uri_to_path(l:uri),
+        \ 'cmd': string(l:range['start']['line'] + 1)
+        \ }
+endfunction
+
+function! s:handle_locations(ctx, server, type, data) abort
+    try
+        if lsp#client#is_error(a:data['response']) || !has_key(a:data['response'], 'result')
+            call lsp#utils#error('Failed to retrieve ' . a:type . ' for ' . a:server . ': ' . lsp#client#error_message(a:data['response']))
+            return
+        endif
+
+        let l:list = a:ctx['list']
+        let l:result = a:data['response']['result']
+        if type(l:result) != v:t_list
+            let l:result = [l:result]
+        endif
+        for l:loc in l:result
+            let l:tag = s:location_to_tag(l:loc)
+            if !empty(l:tag)
+                call add(l:list, extend(l:tag, { 'name': a:ctx['pattern'], 'kind': a:type }))
+            endif
+        endfor
+    finally
+        let a:ctx['counter'] -= 1
+    endtry
+endfunction
+
+function! s:handle_symbols(ctx, server, data) abort
+    try
+        if lsp#client#is_error(a:data['response']) || !has_key(a:data['response'], 'result')
+            call lsp#utils#error('Failed to retrieve workspace symbols for ' . a:server . ': ' . lsp#client#error_message(a:data['response']))
+            return
+        endif
+
+        let l:list = a:ctx['list']
+        for l:symbol in a:data['response']['result']
+            let l:tag = s:location_to_tag(l:symbol['location'])
+            if empty(l:tag)
+                continue
+            endif
+
+            let l:tag['name'] = l:symbol['name']
+            if has_key(l:symbol, 'kind')
+                let l:tag['kind'] = lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind'])
+            endif
+            call add(l:list, l:tag)
+        endfor
+    finally
+        let a:ctx['counter'] -= 1
+    endtry
+endfunction
+
+function! s:tag_view_sub(ctx, method, params) abort
+    let l:operation = substitute(a:method, '\u', ' \l\0', 'g')
+
+    let l:capabilities_func = printf('lsp#capabilities#has_%s_provider(v:val)', substitute(l:operation, ' ', '_', 'g'))
+    let l:servers = filter(lsp#get_whitelisted_servers(), l:capabilities_func)
+    if empty(l:servers)
+        call s:not_supported('retrieving ' . l:operation)
+        return v:false
+    endif
+
+    let a:ctx['counter'] += len(l:servers)
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'textDocument/'.a:method,
+            \ 'params': a:params,
+            \ 'on_notification': function('s:handle_locations', [a:ctx, l:server, l:operation])
+            \})
+    endfor
+    return v:true
+endfunction
+
+function! s:tag_view(ctx) abort
+    let l:params = {
+        \ 'textDocument': lsp#get_text_document_identifier(),
+        \ 'position': lsp#get_position(),
+        \ }
+    return !empty(filter(copy(g:lsp_tagfunc_source_methods),
+        \ {_, m -> s:tag_view_sub(a:ctx, m, l:params)}))
+endfunction
+
+function! s:tag_search(ctx) abort
+    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
+    if empty(l:servers)
+        call s:not_supported('retrieving workspace symbols')
+        return v:false
+    endif
+
+    let a:ctx['counter'] = len(l:servers)
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'workspace/symbol',
+            \ 'params': { 'query': a:ctx['pattern'] },
+            \ 'on_notification': function('s:handle_symbols', [a:ctx, l:server])
+            \ })
+    endfor
+    return v:true
+endfunction
+
+function! s:compare_tags(path, a, b) abort
+    " TODO: custom tag sorting, maybe?
+    if a:a['filename'] !=# a:b['filename']
+        if a:a['filename'] ==# a:path
+            return -1
+        elseif a:b['filename'] ==# a:path
+            return 1
+        endif
+    endif
+    let l:rank_a = index(s:tag_kind_priority, get(a:a, 'kind', ''))
+    let l:rank_b = index(s:tag_kind_priority, get(a:b, 'kind', ''))
+    if l:rank_a != l:rank_b
+        return l:rank_a < l:rank_b ? -1 : 1
+    endif
+    if a:a['filename'] !=# a:b['filename']
+        return a:a['filename'] <# a:b['filename'] ? -1 : 1
+    endif
+    return str2nr(a:a['cmd']) - str2nr(a:b['cmd'])
+endfunction
+
+function! lsp#tag#tagfunc(pattern, flags, info) abort
+    if stridx(a:flags, 'i') >= 0
+        return v:null
+    endif
+
+    let l:ctx = { 'pattern': a:pattern, 'counter': 0, 'list': [] }
+    if !(stridx(a:flags, 'c') >= 0 ? s:tag_view(l:ctx) : s:tag_search(l:ctx))
+        " No supported methods so use builtin tag source
+        return v:null
+    endif
+    while s:wait(-1, {-> l:ctx['counter'] == 0}) == -3
+        continue " ignore spurious internal error
+    endwhile
+    call sort(l:ctx['list'], function('s:compare_tags', [a:info['buf_ffname']]))
+    return l:ctx['list']
+endfunction

--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -17,9 +17,11 @@ function! s:location_to_tag(loc) abort
         return v:null
     endif
 
+    let l:path = lsp#utils#uri_to_path(l:uri)
+    let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:range['start'])
     return {
-        \ 'filename': lsp#utils#uri_to_path(l:uri),
-        \ 'cmd': string(l:range['start']['line'] + 1)
+        \ 'filename': l:path,
+        \ 'cmd': printf('/\%%%dl\%%%dc/', l:line, l:col)
         \ }
 endfunction
 
@@ -32,7 +34,7 @@ function! s:handle_locations(ctx, server, type, data) abort
 
         let l:list = a:ctx['list']
         let l:result = a:data['response']['result']
-        if type(l:result) != v:t_list
+        if type(l:result) != type([])
             let l:result = [l:result]
         endif
         for l:loc in l:result
@@ -62,7 +64,7 @@ function! s:handle_symbols(ctx, server, data) abort
 
             let l:tag['name'] = l:symbol['name']
             if has_key(l:symbol, 'kind')
-                let l:tag['kind'] = lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind'])
+                let l:tag['kind'] = lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind'])
             endif
             call add(l:list, l:tag)
         endfor

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -44,7 +44,7 @@ function! s:symbols_to_loc_list_children(server, path, list, symbols, depth) abo
             \ 'filename': a:path,
             \ 'lnum': l:line,
             \ 'col': l:col,
-            \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . printf('%' . a:depth. 's', '  ') . l:symbol['name'],
+            \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . printf('%' . a:depth. 's', '  ') . l:symbol['name'],
             \ })
         if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
             call s:symbols_to_loc_list_children(a:server, a:path, a:list, l:symbol['children'], a:depth + 1)
@@ -72,7 +72,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
                         \ })
                 endif
             else
@@ -84,7 +84,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
                         \ })
                     if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
                         call s:symbols_to_loc_list_children(a:server, l:path, l:list, l:symbol['children'], 1)
@@ -135,7 +135,7 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
     return l:list
 endfunction
 
-function! lsp#ui#vim#utils#get_symbol_text_from_kind(server, kind) abort
+function! lsp#ui#vim#utils#_get_symbol_text_from_kind(server, kind) abort
     if !has_key(s:symbol_kinds, a:server)
         let l:server_info = lsp#get_server_info(a:server)
         if has_key (l:server_info, 'config') && has_key(l:server_info['config'], 'symbol_kinds')

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -19,12 +19,12 @@ let s:default_symbol_kinds = {
     \ '18': 'array',
     \ '19': 'object',
     \ '20': 'key',
-    \ '21': 'null',    
-    \ '22': 'enum member',    
-    \ '23': 'struct',    
-    \ '24': 'event',    
-    \ '25': 'operator',    
-    \ '26': 'type parameter',    
+    \ '21': 'null',
+    \ '22': 'enum member',
+    \ '23': 'struct',
+    \ '24': 'event',
+    \ '25': 'operator',
+    \ '26': 'type parameter',
     \ }
 
 let s:symbol_kinds = {}
@@ -44,7 +44,7 @@ function! s:symbols_to_loc_list_children(server, path, list, symbols, depth) abo
             \ 'filename': a:path,
             \ 'lnum': l:line,
             \ 'col': l:col,
-            \ 'text': s:get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . printf('%' . a:depth. 's', '  ') . l:symbol['name'],
+            \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . printf('%' . a:depth. 's', '  ') . l:symbol['name'],
             \ })
         if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
             call s:symbols_to_loc_list_children(a:server, a:path, a:list, l:symbol['children'], a:depth + 1)
@@ -72,7 +72,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': s:get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
                         \ })
                 endif
             else
@@ -84,7 +84,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': s:get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
                         \ })
                     if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
                         call s:symbols_to_loc_list_children(a:server, l:path, l:list, l:symbol['children'], 1)
@@ -135,7 +135,7 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
     return l:list
 endfunction
 
-function! s:get_symbol_text_from_kind(server, kind) abort
+function! lsp#ui#vim#utils#get_symbol_text_from_kind(server, kind) abort
     if !has_key(s:symbol_kinds, a:server)
         let l:server_info = lsp#get_server_info(a:server)
         if has_key (l:server_info, 'config') && has_key(l:server_info['config'], 'symbol_kinds')
@@ -144,8 +144,7 @@ function! s:get_symbol_text_from_kind(server, kind) abort
             let s:symbol_kinds[a:server] = s:default_symbol_kinds
         endif
     endif
-    let l:symbol_kinds = s:symbol_kinds[a:server]
-    return has_key(l:symbol_kinds, a:kind) ? l:symbol_kinds[a:kind] : 'unknown symbol ' . a:kind
+    return get(s:symbol_kinds[a:server], a:kind, 'unknown symbol ' . a:kind)
 endfunction
 
 function! lsp#ui#vim#utils#get_symbol_kinds() abort

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -338,3 +338,43 @@ function! lsp#utils#parse_command_options(params) abort
     endfor
     return l:result
 endfunction
+
+" polyfill for the neovim wait function
+if exists('*wait')
+    function! lsp#utils#_wait(timeout, condition, ...) abort
+        if type(a:timeout) != v:t_number
+            return -3
+        endif
+        if type(get(a:000, 0, 0)) != v:t_number
+            return -3
+        endif
+        while 1
+            let l:result=call('wait', extend([a:timeout, a:condition], a:000))
+            if l:result != -3 " ignore spurious errors
+                return l:result
+            endif
+        endwhile
+    endfunction
+else
+    function! lsp#utils#_wait(timeout, condition, ...) abort
+        try
+            let l:timeout = a:timeout / 1000.0
+            let l:interval = get(a:000, 0, 200)
+            let l:Condition = a:condition
+            if type(l:Condition) != v:t_func
+                let l:Condition = function('eval', l:Condition)
+            endif
+            let l:start = reltime()
+            while l:timeout < 0 || reltimefloat(reltime(l:start)) < l:timeout
+                if l:Condition()
+                    return 0
+                endif
+
+                execute 'sleep ' . l:interval . 'm'
+            endwhile
+            return -1
+        catch /^Vim:Interrupt$/
+            return -2
+        endtry
+    endfunction
+endif

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -342,10 +342,10 @@ endfunction
 " polyfill for the neovim wait function
 if exists('*wait')
     function! lsp#utils#_wait(timeout, condition, ...) abort
-        if type(a:timeout) != v:t_number
+        if type(a:timeout) != type(0)
             return -3
         endif
-        if type(get(a:000, 0, 0)) != v:t_number
+        if type(get(a:000, 0, 0)) != type(0)
             return -3
         endif
         while 1
@@ -361,7 +361,7 @@ else
             let l:timeout = a:timeout / 1000.0
             let l:interval = get(a:000, 0, 200)
             let l:Condition = a:condition
-            if type(l:Condition) != v:t_func
+            if type(l:Condition) != type(function('eval'))
                 let l:Condition = function('eval', l:Condition)
             endif
             let l:start = reltime()

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -47,6 +47,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_text_document_did_save_delay    |g:lsp_text_document_did_save_delay|
       g:lsp_snippet_expand                  |g:lsp_snippet_expand|
       g:lsp_completion_resolve_timeout      |g:lsp_completion_resolve_timeout|
+      g:lsp_tagfunc_source_methods          |g:lsp_tagfunc_source_methods|
     Functions                             |vim-lsp-functions|
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|
@@ -109,6 +110,7 @@ CONTENTS                                                  *vim-lsp-contents*
     Autocomplete                          |vim-lsp-autocomplete|
       omnifunc                              |vim-lsp-omnifunc|
       asyncomplete.vim                      |vim-lsp-asyncomplete|
+    Tagfunc                               |vim-lsp-tagfunc|
     Snippets                              |vim-lsp-snippets|
     Folding                               |vim-lsp-folding|
     Semantic highlighting                 |vim-lsp-semantic|
@@ -691,6 +693,13 @@ g:lsp_completion_resolve_timeout         *g:lsp_completion_resolve_timeout*
 
     The `completionItem/resolve` request's timeout value.
     If your vim freeze at `CompleteDone`, you can set this value to 0.
+
+g:lsp_tagfunc_source_methods                 *g:lsp_tagfunc_source_methods*
+    Type: |List|
+    Default: `['definition', 'declaration', 'implementation', 'typeDefinition']`
+
+    The LSP methods to call to get symbols for tag lookup. See
+    |vim-lsp-tagfunc|.
 
 ==============================================================================
 FUNCTIONS                                               *vim-lsp-functions*
@@ -1398,6 +1407,15 @@ Example: >
     Plug 'prabirshrestha/asyncomplete-lsp.vim'
 
 For additional configuration refer to asyncomplete.vim docs.
+
+==============================================================================
+Tagfunc                                                    *vim-lsp-tagfunc*
+
+vim-lsp can integrate with vim's native tag functionality for navigating code
+using the |'tagfunc'| option (requires vim/neovim with patch-8.1.1228).
+
+    Example: >
+	autocmd FileType typescript setlocal tagfunc=lsp#tagfunc
 
 ==============================================================================
 Snippets                                                  *vim-lsp-snippets*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -45,6 +45,7 @@ let g:lsp_ignorecase = get(g:, 'lsp_ignorecase', &ignorecase)
 let g:lsp_semantic_enabled = get(g:, 'lsp_semantic_enabled', 0)
 let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_delay', -1)
 let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
+let g:lsp_tagfunc_source_methods = get(g:, 'lsp_tagfunc_source_methods', ['definition', 'declaration', 'implementation', 'typeDefinition'])
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
 let g:lsp_get_vim_completion_item_set_kind = get(g:, 'lsp_get_vim_completion_item_set_kind', 0)


### PR DESCRIPTION
Adds a new function that can be used with the `tagfunc` option added in vim patch 8.1.1228 (neovim/neovim#11199).

Also consolidates various synchronous wait implementations in favor of a polyfill based on the neovim `wait` function.