### PR TITLE
improve perf by not calling get_position() in lsp#omni#default_get_vim_completion_item if already exists

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -250,7 +250,7 @@ endfunction
 
 function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     let l:server_name = get(a:, 1, '')
-    let l:complete_position = get(a:, 2, lsp#get_position())
+    let l:complete_position = a:0 >= 2 ? a:2 : lsp#get_position()
 
     let l:word = ''
     let l:expandable = v:false


### PR DESCRIPTION
Before:

```
FUNCTION  lsp#omni#default_get_vim_completion_item()
    Defined: ~/.config/nvim/plugins/vim-lsp/autoload/lsp/omni.vim:251
Called 2105 times
Total time:   0.824796
 Self time:   0.463570

count  total (s)   self (s)
 2105              0.015179     let l:server_name = get(a:, 1, '')
 2105   0.150932   0.021467     let l:complete_position = get(a:, 2, lsp#get_position())
```

After:

```
FUNCTION  lsp#omni#default_get_vim_completion_item()
    Defined: ~/.config/nvim/plugins/vim-lsp/autoload/lsp/omni.vim:251
Called 2158 times
Total time:   0.652004
 Self time:   0.428521

count  total (s)   self (s)
 2158              0.014703     let l:server_name = get(a:, 1, '')
 2158              0.015377     let l:complete_position = a:0 >= 2 ? a:2 : lsp#get_position()
```
