### PR TITLE
[perf] add g:lsp_get_vim_completion_item_set_kind to enable or disable kind

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -286,7 +286,7 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
                 \ 'icase': 1,
                 \ 'dup': 1,
                 \ 'empty': 1,
-                \ 'kind': lsp#omni#get_kind_text(a:item, l:server_name)
+                \ 'kind': g:lsp_get_vim_completion_item_set_kind ? lsp#omni#get_kind_text(a:item, l:server_name) : ''
                 \ }
 
     " check support user_data.

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -33,6 +33,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_use_event_queue                 |g:lsp_use_event_queue|
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
       g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
+      g:lsp_get_vim_completion_item_set_kind |g:lsp_get_vim_completion_item_set_kind|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
       g:lsp_peek_alignment                  |g:lsp_peek_alignment|
       g:lsp_preview_max_width               |g:lsp_preview_max_width|
@@ -151,6 +152,9 @@ http://downloads.sourceforge.net/luabinaries/lua-5.3.2_Win32_dllw4_lib.zip
 
 64bit:
 http://downloads.sourceforge.net/luabinaries/lua-5.3.2_Win64_dllw4_lib.zip
+
+Set |g:lsp_get_vim_completion_item_set_kind| to `0`.
+Set |g:lsp_semantic_enabled| to 0.
 
 ==============================================================================
 LANGUAGE SERVERS                                 *vim-lsp-language-servers*
@@ -563,6 +567,15 @@ g:lsp_get_vim_completion_item               *g:lsp_get_vim_completion_item*
     endfunction
 
     let g:lsp_get_vim_completion_item = [function('LspGetCompletionItem')]
+
+g:lsp_get_vim_completion_item_set_kind     *g:lsp_get_vim_completion_item_set_kind*
+    Type: |Number|
+    Default: `0`
+
+    Sets the flag to enable or disabling setting the kind.
+
+    Example: >
+    let g:lsp_get_vim_completion_item_set_kind = 1
 
 g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     Type: |List|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -47,6 +47,7 @@ let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_del
 let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
 
 let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
+let g:lsp_get_vim_completion_item_set_kind = get(g:, 'lsp_get_vim_completion_item_set_kind', 0)
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 
 if g:lsp_auto_enable

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -1,5 +1,7 @@
 Describe lsp#omni
 
+    let g:lsp_get_vim_completion_item_set_kind = 1
+
     Before each
         call lsp#omni#_clear_managed_user_data_map()
     End


### PR DESCRIPTION
`lsp#omni#get_kind_text` is very slow so disabling it by default.