### PR TITLE
Add support for code lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Refer to `:h vim-lsp-semantic` for more info.
 | Command | Description|
 |--|--|
 |`:LspCodeAction`| Gets a list of possible commands that can be applied to a file so it can be fixed (quick fix) |
+|`:LspCodeLens`| Gets a list of possible commands that can be executed on the current document |
 |`:LspDeclaration`| Go to the declaration of the word under the cursor, and open in the current window |
 |`:LspDefinition`| Go to the definition of the word under the cursor, and open in the current window |
 |`:LspDocumentDiagnostics`| Get current document diagnostics information |

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -65,6 +65,14 @@ function! lsp#capabilities#has_code_action_provider(server_name) abort
     return s:has_bool_provider(a:server_name, 'codeActionProvider')
 endfunction
 
+function! lsp#capabilities#has_code_lens_provider(server_name) abort
+    let l:capabilities = lsp#get_server_capabilities(a:server_name)
+    if !empty(l:capabilities) && has_key(l:capabilities, 'codeLensProvider')
+        return 1
+    endif
+    return 0
+endfunction
+
 function! lsp#capabilities#has_type_definition_provider(server_name) abort
     return s:has_bool_provider(a:server_name, 'typeDefinitionProvider')
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -538,3 +538,9 @@ function! lsp#ui#vim#code_action() abort
         \   'query': '',
         \ })
 endfunction
+
+function! lsp#ui#vim#code_lens() abort
+    call lsp#ui#vim#code_lens#do({
+        \   'sync': v:false,
+        \ })
+endfunction

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -1,0 +1,100 @@
+" vint: -ProhibitUnusedVariable
+
+"
+" @param option = {
+"   sync: v:true | v:false = Specify enable synchronous request.
+" }
+"
+function! lsp#ui#vim#code_lens#do(option) abort
+    let l:sync = get(a:option, 'sync', v:false)
+
+    let l:server_names = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_code_lens_provider(v:val)')
+    if len(l:server_names) == 0
+        return lsp#utils#error('Code lens not supported for ' . &filetype)
+    endif
+
+    let l:ctx = {
+    \ 'count': len(l:server_names),
+    \ 'results': [],
+    \}
+    let l:bufnr = bufnr('%')
+    let l:command_id = lsp#_new_command()
+    for l:server_name in l:server_names
+        call lsp#send_request(l:server_name, {
+                    \ 'method': 'textDocument/codeLens',
+                    \ 'params': {
+                    \   'textDocument': lsp#get_text_document_identifier(),
+                    \ },
+                    \ 'sync': l:sync,
+                    \ 'on_notification': function('s:handle_code_lens', [l:ctx, l:server_name, l:command_id, l:sync, l:bufnr]),
+                    \ })
+    endfor
+    echo 'Retrieving code lenses ...'
+endfunction
+
+function! s:handle_code_lens(ctx, server_name, command_id, sync, bufnr, data) abort
+    " Ignore old request.
+    if a:command_id != lsp#_last_command()
+        return
+    endif
+
+    call add(a:ctx['results'], {
+    \    'server_name': a:server_name,
+    \    'data': a:data,
+    \})
+    let a:ctx['count'] -= 1
+    if a:ctx['count'] ># 0
+        return
+    endif
+
+    let l:total_code_lenses = []
+    for l:result in a:ctx['results']
+        let l:server_name = l:result['server_name']
+        let l:data = l:result['data']
+        " Check response error.
+        if lsp#client#is_error(l:data['response'])
+            call lsp#utils#error('Failed to CodeLens for ' . l:server_name . ': ' . lsp#client#error_message(l:data['response']))
+            continue
+        endif
+
+        " Check code lenses.
+        let l:code_lenses = l:data['response']['result']
+        if empty(l:code_lenses)
+            continue
+        endif
+
+        for l:code_lens in l:code_lenses
+            call add(l:total_code_lenses, {
+            \    'server_name': l:server_name,
+            \    'code_lens': l:code_lens,
+            \})
+        endfor
+    endfor
+
+    if len(l:total_code_lenses) == 0
+        echo 'No code lenses found'
+        return
+    endif
+    call lsp#log('s:handle_code_lens', l:total_code_lenses)
+
+    " Prompt to choose code lenses.
+    let l:index = inputlist(map(copy(l:total_code_lenses), { i, lens ->
+                \   printf('%s - [%s] %s', i + 1, lens['server_name'], lens['code_lens']['command']['title'])
+                \ }))
+
+    " Execute code lens.
+    if 0 < l:index && l:index <= len(l:total_code_lenses)
+        let l:selected = l:total_code_lenses[l:index - 1]
+        call s:handle_one_code_lens(l:selected['server_name'], a:sync, a:bufnr, l:selected['code_lens'])
+    endif
+endfunction
+
+function! s:handle_one_code_lens(server_name, sync, bufnr, code_lens) abort
+    call lsp#ui#vim#execute_command#_execute({
+    \   'server_name': a:server_name,
+    \   'command_name': get(a:code_lens['command'], 'command', ''),
+    \   'command_args': get(a:code_lens['command'], 'arguments', v:null),
+    \   'sync': a:sync,
+    \   'bufnr': a:bufnr,
+    \ })
+endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -61,6 +61,8 @@ CONTENTS                                                  *vim-lsp-contents*
     Commands                              |vim-lsp-commands|
       LspCodeAction                         |:LspCodeAction|
       LspCodeActionSync                     |:LspCodeActionSync|
+      LspCodeLens                           |:LspCodeLens|
+      LspCodeLensSync                       |:LspCodeLensSync|
       LspDocumentDiagnostics                |:LspDocumentDiagnostics|
       LspDeclaration                        |:LspDeclaration|
       LspDefinition                         |:LspDefinition|
@@ -1079,6 +1081,14 @@ commands such as organize imports before save.
         autocmd BufWritePre <buffer>
                 \ call execute('LspCodeActionSync source.organizeImports')
 
+LspCodeLens                                                   *:LspCodeLens*
+
+Gets a list of possible commands that can be executed on the current document.
+
+LspCodeLensSync                                           *:LspCodeLensSync*
+
+Same as |:LspCodeLens| but synchronous.
+
 LspDocumentDiagnostics                             *:LspDocumentDiagnostics*
 
 Gets the current document diagnostics.
@@ -1328,6 +1338,7 @@ To map keys to the feature of vim-lsp, use <plug> mappings:
 Available plug mappings are following:
 
   nnoremap <plug>(lsp-code-action)
+  nnoremap <plug>(lsp-code-lens)
   nnoremap <plug>(lsp-declaration)
   nnoremap <plug>(lsp-peek-declaration)
   nnoremap <plug>(lsp-definition)

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -68,6 +68,12 @@ command! -range -nargs=* -complete=customlist,lsp#ui#vim#code_action#complete Ls
       \   'selection': <range> != 0,
       \   'query': '<args>'
       \ })
+command! LspCodeLens call lsp#ui#vim#code_lens#do({
+      \   'sync': v:false,
+      \ })
+command! LspCodeLensSync call lsp#ui#vim#code_lens#do({
+      \   'sync': v:true,
+      \ })
 command! LspDeclaration call lsp#ui#vim#declaration(0, <q-mods>)
 command! LspPeekDeclaration call lsp#ui#vim#declaration(1)
 command! LspDefinition call lsp#ui#vim#definition(0, <q-mods>)
@@ -103,6 +109,7 @@ command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
 command! -nargs=? LspSemanticScopes call lsp#ui#vim#semantic#display_scope_tree(<args>)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
+nnoremap <plug>(lsp-code-lens) :<c-u>call lsp#ui#vim#code_lens()<cr>
 nnoremap <plug>(lsp-declaration) :<c-u>call lsp#ui#vim#declaration(0)<cr>
 nnoremap <plug>(lsp-peek-declaration) :<c-u>call lsp#ui#vim#declaration(1)<cr>
 nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition(0)<cr>


### PR DESCRIPTION
Implemented the feature to send `textDocument/codeLens` requests and execute the command in the response via `workspace/executeCommand`.