### PR TITLE
optimize lsp#omni#get_vim_completion_items()

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -198,6 +198,20 @@ function! lsp#omni#get_kind_text(completion_item, ...) abort
                 \ ? l:completion_item_kinds[a:completion_item['kind']] : ''
 endfunction
 
+function! s:get_kind_text_mappings(server) abort
+	let l:server_name = a:server['name']
+	if has_key(s:completion_item_kinds, l:server_name)
+		return s:completion_item_kinds[l:server_name]
+	else
+		if has_key(a:server, 'config') && has_key(a:server['config'], 'completion_item_kinds')
+			let s:completion_item_kinds[l:server_name] = extend(copy(s:default_completion_item_kinds), a:server['config']['completion_item_kinds'])
+		else
+			let s:completion_item_kinds[l:server_name] = s:default_completion_item_kinds
+		endif
+		return s:completion_item_kinds[l:server_name]
+	endif
+endfunction
+
 " auxiliary functions {{{
 
 function! s:find_complete_servers() abort
@@ -230,25 +244,21 @@ endfunction
 function! s:get_completion_result(server_name, data) abort
     let l:result = a:data['response']['result']
 
-    if type(l:result) == type([])
-        let l:items = l:result
-        let l:incomplete = 0
-    elseif type(l:result) == type({})
-        let l:items = l:result['items']
-        let l:incomplete = l:result['isIncomplete']
-    else
-        let l:items = []
-        let l:incomplete = 0
-    endif
+    let l:options = {
+        \ 'server': lsp#get_server_info(a:server_name),
+        \ 'position': lsp#get_position(),
+        \ 'response': a:data['response'],
+        \ }
 
-    let l:matches = type(l:items) == type([]) ? map(l:items, {_, item -> lsp#omni#get_vim_completion_item(item, a:server_name) }) : []
+    let l:completion_result = lsp#omni#get_vim_completion_items(l:options)
 
-    return {'matches': l:matches, 'incomplete': l:incomplete}
+    return {'matches': l:completion_result['items'], 'incomplete': l:completion_result['incomplete'] }
 endfunction
 
-function! lsp#omni#default_get_vim_completion_item(item, ...) abort
-    let l:server_name = get(a:, 1, '')
-    let l:complete_position = a:0 >= 2 ? a:2 : lsp#get_position()
+function! s:get_vim_completion_item(item, options) abort
+    let l:server_name = a:options['server']['name']
+    let l:complete_position = a:options['position']
+    let l:kind_text_mappings = a:options['kind_text_mappings']
 
     let l:word = ''
     let l:expandable = v:false
@@ -276,15 +286,18 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
         let l:word = substitute(l:word, '\$[0-9]\+\|\${\%(\\.\|[^}]\)\+}', '', 'g')
     endif
 
+    let l:word = lsp#utils#_trim(l:word)
+    let l:kind = has_key(a:item, 'kind') ? get(l:kind_text_mappings, a:item['kind'], '') : ''
+
     let l:completion = {
-                \ 'word': lsp#utils#_trim(l:word),
+                \ 'word': l:word,
                 \ 'abbr': l:abbr . (l:expandable ? '~' : ''),
                 \ 'menu': '',
                 \ 'info': '',
                 \ 'icase': 1,
                 \ 'dup': 1,
                 \ 'empty': 1,
-                \ 'kind': g:lsp_get_vim_completion_item_set_kind ? lsp#omni#get_kind_text(a:item, l:server_name) : ''
+                \ 'kind': l:kind,
                 \ }
 
     " check support user_data.
@@ -318,11 +331,6 @@ function! lsp#omni#default_get_vim_completion_item(item, ...) abort
     return l:completion
 endfunction
 
-" deprecated. use lsp#omni#get_vim_completion_items(options) instead
-function! lsp#omni#get_vim_completion_item(...) abort
-    return call(g:lsp_get_vim_completion_item[0], a:000)
-endfunction
-
 " options = {
 "   server: {}, " needs to be server_info and not server_name
 "   position: lsp#get_position(),
@@ -347,8 +355,13 @@ function! lsp#omni#get_vim_completion_items(options) abort
 
     let l:vim_complete_items = []
     let l:server_name = l:server['name']
+    let l:item_options = {
+        \ 'server': l:server,
+        \ 'position': l:complete_position,
+        \ 'kind_text_mappings': s:get_kind_text_mappings(l:server),
+        \ }
     for l:item in l:items
-        call add(l:vim_complete_items, lsp#omni#get_vim_completion_item(l:item, l:server_name, l:complete_position))
+        call add(l:vim_complete_items, s:get_vim_completion_item(l:item, l:item_options))
     endfor
 
     return { 'items': l:vim_complete_items, 'incomplete': l:incomplete }

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -32,8 +32,6 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_textprop_enabled                |g:lsp_textprop_enabled|
       g:lsp_use_event_queue                 |g:lsp_use_event_queue|
       g:lsp_highlight_references_enabled    |g:lsp_highlight_references_enabled|
-      g:lsp_get_vim_completion_item         |g:lsp_get_vim_completion_item|
-      g:lsp_get_vim_completion_item_set_kind |g:lsp_get_vim_completion_item_set_kind|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
       g:lsp_peek_alignment                  |g:lsp_peek_alignment|
       g:lsp_preview_max_width               |g:lsp_preview_max_width|
@@ -155,7 +153,6 @@ http://downloads.sourceforge.net/luabinaries/lua-5.3.2_Win32_dllw4_lib.zip
 64bit:
 http://downloads.sourceforge.net/luabinaries/lua-5.3.2_Win64_dllw4_lib.zip
 
-Set |g:lsp_get_vim_completion_item_set_kind| to `0`.
 Set |g:lsp_semantic_enabled| to 0.
 
 ==============================================================================
@@ -550,39 +547,6 @@ g:lsp_highlight_references_enabled      *g:lsp_highlight_references_enabled*
 
     Example: >
     highlight lspReference ctermfg=red guifg=red ctermbg=green guibg=green
-
-
-g:lsp_get_vim_completion_item               *g:lsp_get_vim_completion_item*
-    Type: |List|
-    Default: `[function('lsp#omni#default_get_vim_completion_item')]`
-
-    A |List| containing one element of type |Funcref|. This element is a
-    reference to the function that vim-lsp should use to produce the items in
-    the completion menu. Changing this variable allows customizing how items
-    are displayed in the completion menu, or adding custom `user_data` to
-    items (see |complete-items|).
-
-    Note: You can reuse functionality provided by vim-lsp by calling
-    `lsp#omni#default_get_vim_completion_item` from within your function.
-
-    Example: >
-    function! LspGetCompletionItem(item, ...) abort
-        let l:DefaultFn = function('lsp#omni#default_get_vim_completion_item')
-        let l:completion = call(l:DefaultFn, [a:item] + a:000)
-        " customize completion item here
-        return l:completion
-    endfunction
-
-    let g:lsp_get_vim_completion_item = [function('LspGetCompletionItem')]
-
-g:lsp_get_vim_completion_item_set_kind     *g:lsp_get_vim_completion_item_set_kind*
-    Type: |Number|
-    Default: `0`
-
-    Sets the flag to enable or disabling setting the kind.
-
-    Example: >
-    let g:lsp_get_vim_completion_item_set_kind = 1
 
 g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     Type: |List|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -47,8 +47,6 @@ let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_del
 let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
 let g:lsp_tagfunc_source_methods = get(g:, 'lsp_tagfunc_source_methods', ['definition', 'declaration', 'implementation', 'typeDefinition'])
 
-let g:lsp_get_vim_completion_item = get(g:, 'lsp_get_vim_completion_item', [function('lsp#omni#default_get_vim_completion_item')])
-let g:lsp_get_vim_completion_item_set_kind = get(g:, 'lsp_get_vim_completion_item_set_kind', 0)
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 
 if g:lsp_auto_enable

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -58,22 +58,31 @@ Describe lsp#omni
             \  }
             \}
 
-            let want = {
-            \ 'word': 'my-label',
-            \ 'abbr': 'my-label~',
-            \ 'info': 'my documentation.',
-            \ 'icase': 1,
-            \ 'dup': 1,
-            \ 'empty': 1,
-            \ 'kind': 'function',
-            \ 'menu': 'my-detail',
-            \ 'user_data': '{"vim-lsp/key":"0"}'
+            let options = {
+            \ 'server': { 'name': 'dummy-server' },
+            \ 'position': { 'line': 1, 'character': 1 },
+            \ 'response': { 'result': [item] },
             \}
 
-            let got = lsp#omni#get_vim_completion_item(item, '', { 'line': 1, 'character': 1 })
+            let want = {
+            \ 'items': [{
+            \  'word': 'my-label',
+            \  'abbr': 'my-label~',
+            \  'info': 'my documentation.',
+            \  'icase': 1,
+            \  'dup': 1,
+            \  'empty': 1,
+            \  'kind': 'function',
+            \  'menu': 'my-detail',
+            \  'user_data': '{"vim-lsp/key":"0"}',
+            \  }],
+            \  'incomplete': 0,
+            \}
+
+            let got = lsp#omni#get_vim_completion_items(options)
             Assert Equals(got, want)
-            Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got), {
-                        \   'server_name': '',
+            Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got['items'][0]), {
+                        \   'server_name': 'dummy-server',
                         \   'completion_item': item,
                         \   'complete_position': { 'line': 1, 'character': 1 }
                         \ })

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -6,7 +6,7 @@ Describe lsp#omni
         call lsp#omni#_clear_managed_user_data_map()
     End
 
-    Describe lsp#omni#get_vim_completion_item
+    Describe lsp#omni#get_vim_completion_items
         It should return item with proper kind
             let item = {
             \ 'label': 'my-label',
@@ -15,19 +15,28 @@ Describe lsp#omni
             \ 'kind': '3'
             \}
 
-            let want = {
-            \ 'word': 'my-label',
-            \ 'abbr': 'my-label',
-            \ 'info': 'my documentation.',
-            \ 'icase': 1,
-            \ 'dup': 1,
-            \ 'empty': 1,
-            \ 'kind': 'function',
-            \ 'menu': 'my-detail',
-            \ 'user_data': '{"vim-lsp/key":"0"}'
+            let options = {
+            \ 'server': { 'name': 'dummy-server' },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': [item] },
             \}
 
-            Assert Equals(lsp#omni#get_vim_completion_item(item), want)
+            let want = {
+            \ 'items': [{
+            \   'word': 'my-label',
+            \   'abbr': 'my-label',
+            \   'info': 'my documentation.',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'menu': 'my-detail',
+            \   'user_data': '{"vim-lsp/key":"0"}',
+            \ }],
+            \ 'incomplete': 0,
+            \}
+
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
         End
 
         It should get user_data by the item
@@ -78,19 +87,28 @@ Describe lsp#omni
             \ 'kind': '3'
             \}
 
-            let want = {
-            \ 'word': 'my-label',
-            \ 'abbr': 'my-label',
-            \ 'info': 'my documentation.',
-            \ 'icase': 1,
-            \ 'dup': 1,
-            \ 'empty': 1,
-            \ 'kind': 'function',
-            \ 'menu': 'my-detail more-detail',
-            \ 'user_data': '{"vim-lsp/key":"0"}'
+            let options = {
+            \ 'server': { 'name': 'dummy-server' },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': [item] },
             \}
 
-            Assert Equals(lsp#omni#get_vim_completion_item(item), want)
+            let want = {
+            \ 'items': [{
+            \  'word': 'my-label',
+            \  'abbr': 'my-label',
+            \  'info': 'my documentation.',
+            \  'icase': 1,
+            \  'dup': 1,
+            \  'empty': 1,
+            \  'kind': 'function',
+            \  'menu': 'my-detail more-detail',
+            \  'user_data': '{"vim-lsp/key":"0"}',
+            \  }],
+            \  'incomplete': 0,
+            \}
+
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
         End
     End
 End


### PR DESCRIPTION
This now improves autocompletion when having large complete items i.e. >2,000 items.
The fix is by primarily caching. 

- [x] Cache as much as possible
- [x] Remove deprecated methods
- [x] Update asyncomplete-lsp to use the new methods
- [x] update omnifunc to use the new methods
- [x] fix tests

notify other plugin others for the breaking changes
- [x] [deoplete-vim-lsp](https://github.com/lighttiger2505/deoplete-vim-lsp/pull/19)
- [x] [ncm2-vim-lsp](https://github.com/ncm2/ncm2-vim-lsp/issues/12)

This does contain breaking changes will late it bake before merging.
