### PR TITLE
Fix conflict with vim-sleuth

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -155,7 +155,7 @@ function! lsp#ui#vim#output#setcontent(winid, lines, ft) abort
     if s:use_vim_popup
         " vim popup
         call setbufline(winbufnr(a:winid), 1, a:lines)
-        call win_execute(s:winid, 'setlocal filetype=' . a:ft . '.lsp-hover')
+        noautocmd call win_execute(s:winid, 'setlocal filetype=' . a:ft . '.lsp-hover')
     else
         " nvim floating or preview
         call setline(1, a:lines)


### PR DESCRIPTION
This win_execute() causes vim-sleuth to be triggered (due to a filetype
change) and vim-sleuth uses redir(). This is apparently a bad thing.
If this command is prefixed with noautocmd it prevents the FileType
autocmd from triggering.