### PR TITLE
use allowlist and blocklist instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ if executable('pyls')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'pyls',
         \ 'cmd': {server_info->['pyls']},
-        \ 'whitelist': ['python'],
+        \ 'allowlist': ['python'],
         \ })
 endif
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -151,8 +151,8 @@ endfunction
 
 " @params {server_info} = {
 "   'name': 'go-langserver',        " requried, must be unique
-"   'whitelist': ['go'],            " optional, array of filetypes to whitelist, * for all filetypes
-"   'blacklist': [],                " optional, array of filetypes to blacklist, * for all filetypes,
+"   'allowlist': ['go'],            " optional, array of filetypes to allow, * for all filetypes
+"   'blocklist': [],                " optional, array of filetypes to block, * for all filetypes,
 "   'cmd': {server_info->['go-langserver]} " function that takes server_info and returns array of cmd and args, return empty if you don't want to start the server
 " }
 function! lsp#register_server(server_info) abort
@@ -825,23 +825,33 @@ function! lsp#get_whitelisted_servers(...) abort
 
     for l:server_name in keys(s:servers)
         let l:server_info = s:servers[l:server_name]['server_info']
-        let l:blacklisted = 0
+        let l:blocked = 0
 
-        if has_key(l:server_info, 'blacklist')
-            for l:filetype in l:server_info['blacklist']
+        if has_key(l:server_info, 'blocklist')
+            let l:blocklistkey = 'blocklist'
+        else
+            let l:blocklistkey = 'blacklist'
+        endif
+        if has_key(l:server_info, l:blocklistkey)
+            for l:filetype in l:server_info[l:blocklistkey]
                 if l:filetype ==? l:buffer_filetype || l:filetype ==# '*'
-                    let l:blacklisted = 1
+                    let l:blocked = 1
                     break
                 endif
             endfor
         endif
 
-        if l:blacklisted
+        if l:blocked
             continue
         endif
 
-        if has_key(l:server_info, 'whitelist')
-            for l:filetype in l:server_info['whitelist']
+        if has_key(l:server_info, 'allowlist')
+            let l:allowlistkey = 'allowlist'
+        else
+            let l:allowlistkey = 'whitelist'
+        endif
+        if has_key(l:server_info, l:allowlistkey)
+            for l:filetype in l:server_info[l:allowlistkey]
                 if l:filetype ==? l:buffer_filetype || l:filetype ==# '*'
                     let l:active_servers += [l:server_name]
                     break

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -216,7 +216,7 @@ endfunction
 
 function! s:find_complete_servers() abort
     let l:server_names = []
-    for l:server_name in lsp#get_whitelisted_servers()
+    for l:server_name in lsp#get_allowed_servers()
         let l:init_capabilities = lsp#get_server_capabilities(l:server_name)
         if has_key(l:init_capabilities, 'completionProvider')
             " TODO: support triggerCharacters

--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -77,7 +77,7 @@ function! s:tag_view_sub(ctx, method, params) abort
     let l:operation = substitute(a:method, '\u', ' \l\0', 'g')
 
     let l:capabilities_func = printf('lsp#capabilities#has_%s_provider(v:val)', substitute(l:operation, ' ', '_', 'g'))
-    let l:servers = filter(lsp#get_whitelisted_servers(), l:capabilities_func)
+    let l:servers = filter(lsp#get_allowed_servers(), l:capabilities_func)
     if empty(l:servers)
         call s:not_supported('retrieving ' . l:operation)
         return v:false
@@ -104,7 +104,7 @@ function! s:tag_view(ctx) abort
 endfunction
 
 function! s:tag_search(ctx) abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
     if empty(l:servers)
         call s:not_supported('retrieving workspace symbols')
         return v:false

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -19,7 +19,7 @@ function! lsp#ui#vim#type_definition(in_preview, ...) abort
 endfunction
 
 function! lsp#ui#vim#type_hierarchy() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_type_hierarchy_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_type_hierarchy_provider(v:val)')
     let l:command_id = lsp#_new_command()
 
     if len(l:servers) == 0
@@ -71,7 +71,7 @@ function! s:list_location(method, ctx, ...) abort
     let l:operation = substitute(a:method, '\u', ' \l\0', 'g')
 
     let l:capabilities_func = printf('lsp#capabilities#has_%s_provider(v:val)', substitute(l:operation, ' ', '_', 'g'))
-    let l:servers = filter(lsp#get_whitelisted_servers(), l:capabilities_func)
+    let l:servers = filter(lsp#get_allowed_servers(), l:capabilities_func)
     let l:command_id = lsp#_new_command()
 
 
@@ -120,10 +120,10 @@ function! s:rename(server, new_name, pos) abort
 endfunction
 
 function! lsp#ui#vim#rename() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_rename_prepare_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_rename_prepare_provider(v:val)')
     let l:prepare_support = 1
     if len(l:servers) == 0
-        let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_rename_provider(v:val)')
+        let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_rename_provider(v:val)')
         let l:prepare_support = 0
     endif
 
@@ -153,7 +153,7 @@ function! lsp#ui#vim#rename() abort
 endfunction
 
 function! s:document_format(sync) abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_document_formatting_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_formatting_provider(v:val)')
     let l:command_id = lsp#_new_command()
 
     if len(l:servers) == 0
@@ -196,7 +196,7 @@ endfunction
 
 function! lsp#ui#vim#stop_server(...) abort
     let l:name = get(a:000, 0, '')
-    for l:server in lsp#get_whitelisted_servers()
+    for l:server in lsp#get_allowed_servers()
         if !empty(l:name) && l:server != l:name
             continue
         endif
@@ -233,7 +233,7 @@ function! s:get_selection_pos(type) abort
 endfunction
 
 function! s:document_format_range(sync, type) abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_document_range_formatting_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_range_formatting_provider(v:val)')
     let l:command_id = lsp#_new_command()
 
     if len(l:servers) == 0
@@ -279,7 +279,7 @@ function! lsp#ui#vim#document_range_format_opfunc(type) abort
 endfunction
 
 function! lsp#ui#vim#workspace_symbol() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
     let l:command_id = lsp#_new_command()
 
     if len(l:servers) == 0
@@ -307,7 +307,7 @@ function! lsp#ui#vim#workspace_symbol() abort
 endfunction
 
 function! lsp#ui#vim#document_symbol() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
     let l:command_id = lsp#_new_command()
 
     if len(l:servers) == 0

--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -1,7 +1,7 @@
 " vint: -ProhibitUnusedVariable
 
 function! lsp#ui#vim#code_action#complete(input, command, len) abort
-    let l:server_names = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_code_action_provider(v:val)')
+    let l:server_names = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_code_action_provider(v:val)')
     let l:kinds = []
     for l:server_name in l:server_names
         let l:kinds += lsp#capabilities#get_code_action_kinds(l:server_name)
@@ -21,7 +21,7 @@ function! lsp#ui#vim#code_action#do(option) abort
     let l:sync = get(a:option, 'sync', v:false)
     let l:query = get(a:option, 'query', '')
 
-    let l:server_names = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_code_action_provider(v:val)')
+    let l:server_names = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_code_action_provider(v:val)')
     if len(l:server_names) == 0
         return lsp#utils#error('Code action not supported for ' . &filetype)
     endif

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -8,7 +8,7 @@
 function! lsp#ui#vim#code_lens#do(option) abort
     let l:sync = get(a:option, 'sync', v:false)
 
-    let l:server_names = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_code_lens_provider(v:val)')
+    let l:server_names = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_code_lens_provider(v:val)')
     if len(l:server_names) == 0
         return lsp#utils#error('Code lens not supported for ' . &filetype)
     endif

--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -2,7 +2,7 @@ let s:folding_ranges = {}
 let s:textprop_name = 'vim-lsp-folding-linenr'
 
 function! s:find_servers() abort
-    return filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_folding_range_provider(v:val)')
+    return filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_folding_range_provider(v:val)')
 endfunction
 
 function! lsp#ui#vim#folding#fold(sync) abort

--- a/autoload/lsp/ui/vim/hover.vim
+++ b/autoload/lsp/ui/vim/hover.vim
@@ -3,7 +3,7 @@ function! s:not_supported(what) abort
 endfunction
 
 function! lsp#ui#vim#hover#get_hover_under_cursor() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_hover_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_hover_provider(v:val)')
 
     if len(l:servers) == 0
         call s:not_supported('Retrieving hover')

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -150,7 +150,7 @@ function! lsp#ui#vim#references#highlight(force_refresh) abort
 
     " Check if any server provides document highlight
     let l:capability = 'lsp#capabilities#has_document_highlight_provider(v:val)'
-    let l:servers = filter(lsp#get_whitelisted_servers(), l:capability)
+    let l:servers = filter(lsp#get_allowed_servers(), l:capability)
 
     if len(l:servers) == 0
         return

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -180,7 +180,7 @@ endfunction
 
 " Display scope tree {{{1
 function! lsp#ui#vim#semantic#display_scope_tree(...) abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_semantic_highlight(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_highlight(v:val)')
 
     if len(l:servers) == 0
         call lsp#utils#error('Semantic highlighting not supported for ' . &filetype)

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -6,7 +6,7 @@ function! s:not_supported(what) abort
 endfunction
 
 function! lsp#ui#vim#signature_help#get_signature_help_under_cursor() abort
-    let l:servers = filter(lsp#get_whitelisted_servers(), 'lsp#capabilities#has_signature_help_provider(v:val)')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_signature_help_provider(v:val)')
 
     if len(l:servers) == 0
         call s:not_supported('Retrieving signature help')
@@ -132,7 +132,7 @@ function! s:on_text_changed_after(bufnr, timer) abort
     " Cache trigger chars since this loop is heavy
     let l:chars = get(b:, 'lsp_signature_help_trigger_character', [])
     if empty(l:chars)
-        for l:server_name in lsp#get_whitelisted_servers(a:bufnr)
+        for l:server_name in lsp#get_allowed_servers(a:bufnr)
             let l:chars += lsp#capabilities#get_signature_help_trigger_characters(l:server_name)
         endfor
         let b:lsp_signature_help_trigger_character = l:chars

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -175,7 +175,7 @@ on pyls (https://github.com/palantir/python-language-server)
 	    au User lsp_setup call lsp#register_server({
 		\ 'name': 'pyls',
 		\ 'cmd': {server_info->['pyls']},
-		\ 'whitelist': ['python']
+		\ 'allowlist': ['python']
 		\ })
 	endif
 <
@@ -705,8 +705,8 @@ one parameter which is a vim |dict| and is refered to as |vim-lsp-server_info|
 	    au User lsp_setup call lsp#register_server({
 		\ 'name': 'name-of-server',
 		\ 'cmd': {server_info->['server-exectuable']},
-		\ 'whitelist': ['filetype to whitelist'],
-		\ 'blacklist': ['filetype to blacklist'],
+		\ 'allowlist': ['filetype to allowlist'],
+		\ 'blocklist': ['filetype to blocklist'],
 		\ 'config': {},
 		\ 'workspace_config': {'param': {'enabled': v:true}},
 		\ })
@@ -725,8 +725,8 @@ The vim |dict| containing information about the server.
     {
 	'name': 'name of the server',
 	'cmd': {server_info->['server_executable']},
-	'whitelist': ['filetype'],
-	'blacklist': ['filetype'],
+	'allowlist': ['filetype'],
+	'blocklist': ['filetype'],
 	'config': {},
 	'workspace_config': {},
     }
@@ -773,30 +773,30 @@ The vim |dict| containing information about the server.
 	'cmd': {server_info->
 	    \ [&shell, &shellcmdflag, 'typescript-language-server --stdio']}
 <
- * whitelist:
+ * allowlist:
     optional
     String array of filetypes to run the language server.
 
     Example: >
-	'whitelist': ['javascript', 'typescript']
+	'allowlist': ['javascript', 'typescript']
 <
     '*' is treated as any filetype.
 
- * blacklist:
+ * blocklist:
     optional
     String array of filetypes not to run the language server.
 
     Example: >
-	'blacklist': ['javascript', 'typescript']
+	'blocklist': ['javascript', 'typescript']
 <
     '*' is treated as any filetype.
 
-    whitelist and blacklist can be used together. The following example
+    allowlist and blocklist can be used together. The following example
     says to run the language server for all filetypes except javascript
-    and typescript. blacklist always takes higher priority over whitelist.
+    and typescript. blocklist always takes higher priority over allowlist.
 >
-	'whitelist': ['*']
-	'blacklist': ['javascript', 'typescript']
+	'allowlist': ['*']
+	'blocklist': ['javascript', 'typescript']
 <
   * workspace_config:
     optional vim |dict|
@@ -1022,7 +1022,7 @@ This method is mainly used to generate 'root_uri' when registering server.
 		\		['.ccls', 'compile_commands.json', '.git/']
 		\	))},
 		\ 'initialization_options': {},
-		\ 'whitelist': ['c', 'cpp', 'objc', 'objcpp', 'cc'],
+		\ 'allowlist': ['c', 'cpp', 'objc', 'objcpp', 'cc'],
 		\ })
 	endif
 <
@@ -1519,7 +1519,7 @@ Suppose we want to highlight classes using |Identifier| and functions using
     autocmd User lsp_setup call lsp#register_server({
         \ 'name': 'eclipse.jdt.ls',
         \ 'cmd': {server_info->[...]},
-        \ 'whitelist': ['java'],
+        \ 'allowlist': ['java'],
         \ 'semantic_highlight': {
         \       'entity.name.type.class.java': 'Identifier',
         \       'entity.name.function.java': 'Label'
@@ -1533,7 +1533,7 @@ want function calls to still use the |Label| group, but use |Identifier| for
     autocmd User lsp_setup call lsp#register_server({
         \ 'name': 'eclipse.jdt.ls',
         \ 'cmd': {server_info->[...]},
-        \ 'whitelist': ['java'],
+        \ 'allowlist': ['java'],
         \ 'semantic_highlight': {
         \       'entity.name.type.class.java': 'Identifier',
         \       'entity.name.function.java': {

--- a/minimal.vimrc
+++ b/minimal.vimrc
@@ -30,6 +30,6 @@ if executable('pyls')
     au User lsp_setup call lsp#register_server({
         \ 'name': 'pyls',
         \ 'cmd': {server_info->['pyls']},
-        \ 'whitelist': ['python'],
+        \ 'allowlist': ['python'],
         \ })
 endif


### PR DESCRIPTION
This PR introduces `allowlist` and `blocklist`. Old keys are still compatible. In the next few days I will be migrating those to use these new keys. This should also give ample time for others to migrate the keys. I hope in the next few weeks to completely deprecate the old keys.

- [x] accept `allowlist`
- [x] accept `blocklist`
- [x] add `lsp#get_allowed_servers()` and use it everywhere. Might need to come up with a better name here.

asyncomplete.vim also had done similar migration at https://github.com/prabirshrestha/asyncomplete.vim/pull/204