### PR TITLE
Fix documentation preview window

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -40,7 +40,7 @@ function! s:show_documentation(event) abort
         let s:last_popup_id = popup_create('(no documentation available)', {'line': l:line, 'col': l:col, 'pos': l:right ? 'topleft' : 'topright', 'padding': [0, 1, 0, 1]})
     elseif s:use_nvim_float
         let l:height = float2nr(winheight(0) - l:line + 1)
-        let l:width = l:right ? winwidth(0) - l:col + 1 : l:col
+        let l:width = float2nr(l:right ? winwidth(0) - l:col + 1 : l:col)
         if l:width <= 0
           let l:width = 1
         endif

--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -39,7 +39,7 @@ function! s:show_documentation(event) abort
     if s:use_vim_popup
         let s:last_popup_id = popup_create('(no documentation available)', {'line': l:line, 'col': l:col, 'pos': l:right ? 'topleft' : 'topright', 'padding': [0, 1, 0, 1]})
     elseif s:use_nvim_float
-        let l:height = winheight(0) - l:line + 1
+        let l:height = float2nr(winheight(0) - l:line + 1)
         let l:width = l:right ? winwidth(0) - l:col + 1 : l:col
         if l:width <= 0
           let l:width = 1


### PR DESCRIPTION
After applying https://github.com/prabirshrestha/vim-lsp/pull/852, I still suffer a similar error:

![screenshot_2020-06-29_12-50-30](https://user-images.githubusercontent.com/15262528/85971071-2cf4ce80-ba07-11ea-8ddf-edc02386f679.png)

I found out that `l:height` is float, not integer. So I apply `float2nr` to cast it integer.

I'm not good at VimL, and I don't know why `l:height` is float. But it works for me.