### PR TITLE
fix API call error

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -45,7 +45,7 @@ function! s:show_documentation(event) abort
           let l:width = 1
         endif
         let s:last_popup_id = lsp#ui#vim#output#floatingpreview([])
-        call nvim_win_set_config(s:last_popup_id, {'relative': 'win', 'anchor': l:right ? 'NW' : 'NE', 'row': l:line - 1, 'col': l:col - 1, 'height': l:height, 'width': l:width})
+        call nvim_win_set_config(s:last_popup_id, {'relative': 'win', 'anchor': l:right ? 'NW' : 'NE', 'row': l:line - 1, 'col': l:col - 1, 'height': float2nr(l:height), 'width': float2nr(l:width)})
     endif
 
     call setbufvar(winbufnr(s:last_popup_id), 'lsp_syntax_highlights', l:syntax_lines)


### PR DESCRIPTION
Fixed an error when passing a floating value to parameter `width` and `height` in `nvim_win_set_config`.

<img width="653" alt="スクリーンショット 2020-06-29 13 39 51" src="https://user-images.githubusercontent.com/1496543/85973637-6250ea80-ba0e-11ea-909a-809708bf3e3e.png">
