### PR TITLE
fix Invalid window id when calling close preview (fixes #858)

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -20,7 +20,7 @@ function! lsp#ui#vim#output#closepreview() abort
     if s:use_vim_popup && s:winid
         call popup_close(s:winid)
     elseif s:use_nvim_float && s:winid
-        call nvim_win_close(s:winid, 0)
+        silent! call nvim_win_close(s:winid, 0)
     else
         pclose
     endif


### PR DESCRIPTION
PR for https://github.com/prabirshrestha/vim-lsp/issues/858. //cc @lighttiger2505 