### PR TITLE
check nvim_win availability before attempting to close

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -67,7 +67,7 @@ endfunction
 function! s:close_popup() abort
     if s:last_popup_id >= 0
         if s:use_vim_popup | call popup_close(s:last_popup_id) | endif
-        if s:use_nvim_float | call nvim_win_close(s:last_popup_id, 1) | endif
+        if s:use_nvim_float && nvim_win_is_valid(s:last_popup_id) | call nvim_win_close(s:last_popup_id, 1) | endif
 
         let s:last_popup_id = -1
     endif


### PR DESCRIPTION
Resolve https://github.com/prabirshrestha/vim-lsp/issues/868 .

Sometimes I would get the same errors, but in my case, I only encountered this once a week or so. ( It was today for this week. )

I tried to put the `autocmd CompleteDone * if pumvisible() == 0 | pclose | endif` to my `init.vim` and that reproduced.

This patch is tested with above setting, but it also resolves my rare cases as well.

But I'm sorry, I have no idea about his case and my rare case.