### PR TITLE
Make languageId configurable per lsp

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -873,9 +873,13 @@ function! s:get_text_document_text(buf, server_name) abort
 endfunction
 
 function! s:get_text_document(buf, server_name, buffer_info) abort
+    if has_key(s:servers, a:server_name)
+        let server_info = get(s:servers, a:server_name).server_info
+        let language_id = get(server_info, 'languageId', &filetype)
+    endif
     return {
         \ 'uri': lsp#utils#get_buffer_uri(a:buf),
-        \ 'languageId': &filetype,
+        \ 'languageId': language_id,
         \ 'version': a:buffer_info['version'],
         \ 'text': s:get_text_document_text(a:buf, a:server_name),
         \ }

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -880,10 +880,9 @@ function! s:get_text_document_text(buf, server_name) abort
 endfunction
 
 function! s:get_text_document(buf, server_name, buffer_info) abort
-    if has_key(s:servers, a:server_name)
-        let l:server_info = get(s:servers, a:server_name).server_info
-        let l:language_id = get(l:server_info, 'languageId', &filetype)
-    endif
+    let l:server = s:servers[a:server_name]
+    let l:server_info = l:server['server_info']
+    let l:language_id = has_key(l:server_info, 'languageId') ?  l:server_info['languageId'](l:server_info) : &filetype
     return {
         \ 'uri': lsp#utils#get_buffer_uri(a:buf),
         \ 'languageId': l:language_id,

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -881,12 +881,12 @@ endfunction
 
 function! s:get_text_document(buf, server_name, buffer_info) abort
     if has_key(s:servers, a:server_name)
-        let server_info = get(s:servers, a:server_name).server_info
-        let language_id = get(server_info, 'languageId', &filetype)
+        let l:server_info = get(s:servers, a:server_name).server_info
+        let l:language_id = get(l:server_info, 'languageId', &filetype)
     endif
     return {
         \ 'uri': lsp#utils#get_buffer_uri(a:buf),
-        \ 'languageId': language_id,
+        \ 'languageId': l:language_id,
         \ 'version': a:buffer_info['version'],
         \ 'text': s:get_text_document_text(a:buf, a:server_name),
         \ }

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -710,7 +710,7 @@ one parameter which is a vim |dict| and is refered to as |vim-lsp-server_info|
 		\ 'blocklist': ['filetype to blocklist'],
 		\ 'config': {},
 		\ 'workspace_config': {'param': {'enabled': v:true}},
-		\ 'languageId': 'language name',
+		\ 'languageId': {server_info->'python'},
 		\ })
 	endif
 <
@@ -731,7 +731,7 @@ The vim |dict| containing information about the server.
 	'blocklist': ['filetype'],
 	'config': {},
 	'workspace_config': {},
-	'languageId': '',
+	'languageId': {server_info->'filetype'},
     }
 <
  * name:
@@ -811,14 +811,14 @@ The vim |dict| containing information about the server.
 		{'pydocstyle': {'enabled': v:true}}}}
 <
   * languageId:
-    optional vim |string|
+    optional function returning |string|
     By default the languageId is the current filetype. If you're using a sub
     filetype like 'ios.swift' your language server may not return anything
     because it does not know this language.
     In this case you might want to overwrite the languageId with this key.
 
     Example: >
-	'languageId': 'typescript'
+	'languageId': {server_info->'typescript'}
 <
   * config:
     optional vim |dict|

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -709,6 +709,7 @@ one parameter which is a vim |dict| and is refered to as |vim-lsp-server_info|
 		\ 'blocklist': ['filetype to blocklist'],
 		\ 'config': {},
 		\ 'workspace_config': {'param': {'enabled': v:true}},
+		\ 'languageId': 'language name',
 		\ })
 	endif
 <
@@ -729,6 +730,7 @@ The vim |dict| containing information about the server.
 	'blocklist': ['filetype'],
 	'config': {},
 	'workspace_config': {},
+	'languageId': '',
     }
 <
  * name:
@@ -806,6 +808,16 @@ The vim |dict| containing information about the server.
     Example: >
 	'workspace_config': {'pyls': {'plugins': \
 		{'pydocstyle': {'enabled': v:true}}}}
+<
+  * languageId:
+    optional vim |string|
+    By default the languageId is the current filetype. If you're using a sub
+    filetype like 'ios.swift' your language server may not return anything
+    because it does not know this language.
+    In this case you might want to overwrite the languageId with this key.
+
+    Example: >
+	'languageId': 'typescript'
 <
   * config:
     optional vim |dict|


### PR DESCRIPTION
This PR allows the `languageId` provided to the lsp to be modified when registering the lsp.

Closes #879 