### PR TITLE
Don't call buf_clear_namespace if can't get buffer number from bufnr

### DIFF
--- a/autoload/lsp/ui/vim/virtual.vim
+++ b/autoload/lsp/ui/vim/virtual.vim
@@ -81,7 +81,9 @@ function! s:clear_virtual(server_name, path) abort
     let l:ns = s:get_virtual_group(a:server_name)
     let l:bufnr = bufnr(a:path)
 
-    call nvim_buf_clear_namespace(l:bufnr, l:ns, 0, -1)
+    if bufnr(a:path) >= 0
+        call nvim_buf_clear_namespace(l:bufnr, l:ns, 0, -1)
+    endif
 endfunction
 
 function! s:place_virtual(server_name, path, diagnostics) abort


### PR DESCRIPTION
Language server can send textDocument/publishDiagnostics on starting the
server and it can make vim call error because the uri that language
server publish can be un-opened file. Fix by checking buffer is exist
before calling buf_clear_namespace.

Fixes #886