### PR TITLE
lsp_server_init does not fire if (Neo)Vim does not support CompleteChanged event

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -76,7 +76,9 @@ endfunction
 function! lsp#ui#vim#documentation#setup() abort
     augroup lsp_documentation_popup
         autocmd!
-        autocmd CompleteChanged * call s:complete_done()
+        if exists('##CompleteChanged')
+            autocmd CompleteChanged * call s:complete_done()
+        endif
         autocmd CompleteDone * call s:close_popup()
     augroup end
 endfunction


### PR DESCRIPTION
I was debugging why my `asyncomplete-lsp` did not work and got to the point where I noticed that `vim-lsp` never fired [`doautocmd User lsp_server_init`](https://github.com/prabirshrestha/vim-lsp/blob/e6912a01cd9da01596f3d9149ad2d8f17c8a7d81/autoload/lsp.vim#L814).

So I added `breakadd func *handle_initialize` into my `.vimrc` and stepped through `vim-lsp`'s [`handle_initialize`](https://github.com/prabirshrestha/vim-lsp/blob/e6912a01cd9da01596f3d9149ad2d8f17c8a7d81/autoload/lsp.vim#L784-L815). Everything works fine until it reaches `call lsp#ui#vim#documentation#setup()`. That function defines autocommands for the `CompleteChanged` and `CompleteDone` events [since June 20](https://github.com/prabirshrestha/vim-lsp/commit/a3673dde7887098c45aea1e477ab5c7269c356fa), which [requires Vim 8.1.1138 or NeoVim ≥ 0.4.0](https://github.com/neovim/neovim/pull/10644). It is for example not available in the Vim or NeoVim versions that ship with a current Debian.

So that `autocmd` call fails, and since `handle_initialize` is defined as `abort`, the next line that is supposed to be triggering `lsp_server_init` does not get executed. The error is:

```
Exception thrown: Vim(autocmd):E216: No such group or event: CompleteChanged * call s:complete_done()
function <SNR>56_on_stdout[4]..<SNR>55_on_stdout[71]..<SNR>41_on_notification[25]..<SNR>41_handle_initialize
```

My suggestion would be to wrap the `CompleteChanged` definition into something like `if exists('##CompleteChanged')`? Or am I missing something here?