### PR TITLE
Supply first argument to bufnr()

### DIFF
--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -128,7 +128,7 @@ function! s:handle_references(ctx, data) abort
 
     " Apply highlights to the buffer
     if g:lsp_highlight_references_enabled
-        let l:bufnr = bufnr()
+        let l:bufnr = bufnr('')
         call s:init_reference_highlight(l:bufnr)
         if s:use_vim_textprops
             for l:position in l:position_list
@@ -155,7 +155,7 @@ function! s:init_reference_highlight(buf) abort
 
     if s:use_vim_textprops
         call prop_type_add('vim-lsp-reference-highlight',
-        \   {'bufnr': bufnr(),
+        \   {'bufnr': bufnr(''),
         \    'highlight': 'lspReference',
         \    'combine': v:true})
     endif
@@ -210,7 +210,7 @@ function! lsp#ui#vim#references#clean_references() abort
     let s:pending[&filetype] = v:false
     if exists('w:lsp_reference_matches')
         if s:use_vim_textprops
-            let l:bufnr = bufnr()
+            let l:bufnr = bufnr('')
             for l:line in w:lsp_reference_matches
                 silent! call prop_remove(
                 \   {'id': s:prop_id,

--- a/autoload/lsp/ui/vim/references.vim
+++ b/autoload/lsp/ui/vim/references.vim
@@ -128,7 +128,7 @@ function! s:handle_references(ctx, data) abort
 
     " Apply highlights to the buffer
     if g:lsp_highlight_references_enabled
-        let l:bufnr = bufnr('')
+        let l:bufnr = bufnr('%')
         call s:init_reference_highlight(l:bufnr)
         if s:use_vim_textprops
             for l:position in l:position_list
@@ -155,7 +155,7 @@ function! s:init_reference_highlight(buf) abort
 
     if s:use_vim_textprops
         call prop_type_add('vim-lsp-reference-highlight',
-        \   {'bufnr': bufnr(''),
+        \   {'bufnr': bufnr('%'),
         \    'highlight': 'lspReference',
         \    'combine': v:true})
     endif
@@ -210,7 +210,7 @@ function! lsp#ui#vim#references#clean_references() abort
     let s:pending[&filetype] = v:false
     if exists('w:lsp_reference_matches')
         if s:use_vim_textprops
-            let l:bufnr = bufnr('')
+            let l:bufnr = bufnr('%')
             for l:line in w:lsp_reference_matches
                 silent! call prop_remove(
                 \   {'id': s:prop_id,


### PR DESCRIPTION
Three lines in `references.vim` do not supply the first argument when calling Vim’s `bufnr()` function. This argument [only became optional recently](https://github.com/vim/vim/commit/a8eee21e75324d199acb1663cb5009e03014a13a).

The problem manifests in the message `E119: Not enough arguments for function: bufnr` for example when clearing reference highlights.

According to `:h patches-8` (in Vim), the argument to `bufnr()` can be optional since Vim 8.1.1924 (which is [included in NeoVim since 0.4.0](https://github.com/neovim/neovim/commit/66c06dad62638106fadad389f585dc11f482c6b1)), but on versions older than that, you have to supply an empty string or `%` as the first parameter instead. The current version of vim-lsp will not work on these older versions, which are still in widespread use (e.g. in Debian).

This pull request supplies a first argument of `'%'` in all three calls to `bufnr()`, instead of calling it without arguments, which is equivalent to `''`. I’ve seen both `''` and `'%'` used in the codebase, `''` is shorter, which is why I’ve used that at first, but changed it to `'%'` on request.