### PR TITLE
Set <nomodeline> to all of doautocmd

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -50,7 +50,7 @@ function! lsp#enable() abort
         return
     endif
     if !s:already_setup
-        doautocmd User lsp_setup
+        doautocmd <nomodeline> User lsp_setup
         let s:already_setup = 1
     endif
     let s:enabled = 1
@@ -171,7 +171,7 @@ function! lsp#register_server(server_info) abort
         \ 'buffers': {},
         \ }
     call lsp#log('lsp#register_server', 'server registered', l:server_name)
-    doautocmd User lsp_register_server
+    doautocmd <nomodeline> User lsp_register_server
 endfunction
 
 "
@@ -224,7 +224,7 @@ function! s:unregister_events() abort
     augroup lsp
         autocmd!
     augroup END
-    doautocmd User lsp_unregister_server
+    doautocmd <nomodeline> User lsp_unregister_server
 endfunction
 
 function! s:on_text_document_did_open(...) abort
@@ -343,10 +343,10 @@ endfunction
 
 function! s:fire_lsp_buffer_enabled(server_name, buf, ...) abort
     if a:buf == bufnr('%')
-        doautocmd User lsp_buffer_enabled
+        doautocmd <nomodeline> User lsp_buffer_enabled
     else
         " Not using ++once in autocmd for compatibility of VIM8.0
-        let l:cmd = printf('autocmd BufEnter <buffer=%d> doautocmd User lsp_buffer_enabled', a:buf)
+        let l:cmd = printf('autocmd BufEnter <buffer=%d> doautocmd <nomodeline> User lsp_buffer_enabled', a:buf)
         exec printf('augroup _lsp_fire_buffer_enabled | exec "%s | autocmd! _lsp_fire_buffer_enabled BufEnter <buffer>" | augroup END', l:cmd)
     endif
 endfunction
@@ -720,7 +720,7 @@ function! s:on_exit(server_name, id, data, event) abort
         if has_key(l:server, 'init_result')
             unlet l:server['init_result']
         endif
-        doautocmd User lsp_server_exit
+        doautocmd <nomodeline> User lsp_server_exit
     endif
 endfunction
 
@@ -802,7 +802,7 @@ function! s:handle_initialize(server_name, data) abort
 
     call lsp#ui#vim#documentation#setup()
 
-    doautocmd User lsp_server_init
+    doautocmd <nomodeline> User lsp_server_init
 endfunction
 
 function! lsp#get_whitelisted_servers(...) abort

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -32,7 +32,7 @@ function! s:on_complete_done() abort
   " Somtimes, vim occurs `CompleteDone` unexpectedly.
   " We try to detect it by checking empty completed_item.
   if empty(v:completed_item) || get(v:completed_item, 'word', '') ==# '' && get(v:completed_item, 'abbr', '') ==# ''
-    doautocmd User lsp_complete_done
+    doautocmd <nomodeline> User lsp_complete_done
     return
   endif
 
@@ -44,7 +44,7 @@ function! s:on_complete_done() abort
 
   " If managed user_data does not exists, skip it.
   if empty(l:managed_user_data)
-    doautocmd User lsp_complete_done
+    doautocmd <nomodeline> User lsp_complete_done
     return
   endif
 
@@ -73,13 +73,13 @@ function! s:on_complete_done_after() abort
 
   " check the commit characters are <BS> or <C-w>.
   if strlen(getline('.')) < strlen(l:line)
-    doautocmd User lsp_complete_done
+    doautocmd <nomodeline> User lsp_complete_done
     return ''
   endif
 
   " Do nothing if text_edit is disabled.
   if !g:lsp_text_edit_enabled
-    doautocmd User lsp_complete_done
+    doautocmd <nomodeline> User lsp_complete_done
     return ''
   endif
 
@@ -118,7 +118,7 @@ function! s:on_complete_done_after() abort
     endif
   endif
 
-  doautocmd User lsp_complete_done
+  doautocmd <nomodeline> User lsp_complete_done
   return ''
 endfunction
 

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -19,7 +19,7 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     call lsp#ui#vim#diagnostics#textprop#set(a:server_name, a:data)
     call lsp#ui#vim#signs#set(a:server_name, a:data)
 
-    doautocmd User lsp_diagnostics_updated
+    doautocmd <nomodeline> User lsp_diagnostics_updated
 endfunction
 
 function! lsp#ui#vim#diagnostics#force_refresh(bufnr) abort

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -29,7 +29,7 @@ function! lsp#ui#vim#output#closepreview() abort
     augroup lsp_float_preview_close
     augroup end
     autocmd! lsp_float_preview_close CursorMoved,CursorMovedI,VimResized *
-    doautocmd User lsp_float_closed
+    doautocmd <nomodeline> User lsp_float_closed
 endfunction
 
 function! lsp#ui#vim#output#focuspreview() abort
@@ -379,7 +379,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
         " Vim popups
         call s:set_cursor(l:current_window_id, a:options)
       endif
-	  doautocmd User lsp_float_opened
+	  doautocmd <nomodeline> User lsp_float_opened
     endif
 
     if !g:lsp_preview_keep_focus


### PR DESCRIPTION
If the modeline contains foldenable, the text is frequently folded.