### PR TITLE
Load `retriggerCharacters` for signature help.

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -160,10 +160,16 @@ endfunction
 function! lsp#capabilities#get_signature_help_trigger_characters(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)
     if !empty(l:capabilities) && has_key(l:capabilities, 'signatureHelpProvider')
+		let l:trigger_chars = []
         if type(l:capabilities['signatureHelpProvider']) == type({})
             if  has_key(l:capabilities['signatureHelpProvider'], 'triggerCharacters')
-                return l:capabilities['signatureHelpProvider']['triggerCharacters']
+                let l:trigger_chars = l:capabilities['signatureHelpProvider']['triggerCharacters']
             endif
+			" If retriggerChars exist, just treat them like triggerChars.
+            if  has_key(l:capabilities['signatureHelpProvider'], 'retriggerCharacters')
+                let l:trigger_chars += l:capabilities['signatureHelpProvider']['retriggerCharacters']
+            endif
+            return l:trigger_chars
         endif
     endif
     return []

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -160,12 +160,12 @@ endfunction
 function! lsp#capabilities#get_signature_help_trigger_characters(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)
     if !empty(l:capabilities) && has_key(l:capabilities, 'signatureHelpProvider')
-		let l:trigger_chars = []
+    let l:trigger_chars = []
         if type(l:capabilities['signatureHelpProvider']) == type({})
             if  has_key(l:capabilities['signatureHelpProvider'], 'triggerCharacters')
                 let l:trigger_chars = l:capabilities['signatureHelpProvider']['triggerCharacters']
             endif
-			" If retriggerChars exist, just treat them like triggerChars.
+            " If retriggerChars exist, just treat them like triggerChars.
             if  has_key(l:capabilities['signatureHelpProvider'], 'retriggerCharacters')
                 let l:trigger_chars += l:capabilities['signatureHelpProvider']['retriggerCharacters']
             endif


### PR DESCRIPTION
Fixes #903

The LSP (v3.15) specification dictates both `triggerCharacters` and
`retriggerCharacters` in SignatureHelpOptions to trigger Signature
Help.  Currently, vim-lsp only loads `triggerCharacters` and not
`retriggerCharacters`.

This PR detects if the LSP server also sent `retriggerCharacters` along
`triggerCharacters`.  If so, we append them to the list of
`triggerChars` and treat them as if they were regular `triggerChars`.

Note: Only uses `retriggerCharacters` if `triggerCharacters` exists.