### PR TITLE
doc: remove a stray line from echo_delay

### DIFF
--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -392,7 +392,6 @@ g:lsp_diagnostics_echo_delay                *g:lsp_diagnostics_echo_delay*
     Default: `500`
 
     Delay milliseconds to echo diagnostic error for the current line to status. Requires
-    Enables echo of diagnostic error for the current line to status. Requires
     |g:lsp_diagnostics_enabled| and |g:lsp_diagnostics_echo_cursor| set to 1.
 
     Example: >


### PR DESCRIPTION
This was most likely a copy-paste error.