### PR TITLE
Set Vim variables directly instead of win_execute

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -155,7 +155,7 @@ function! lsp#ui#vim#output#setcontent(winid, lines, ft) abort
     if s:use_vim_popup
         " vim popup
         call setbufline(winbufnr(a:winid), 1, a:lines)
-        call win_execute(s:winid, 'setlocal filetype=' . a:ft . '.lsp-hover')
+        call setbufvar(winbufnr(a:winid), '&filetype', a:ft . '.lsp-hover')
     else
         " nvim floating or preview
         call setline(1, a:lines)

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -298,8 +298,8 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 	    autocmd!
 	    if !has('nvim')
 		autocmd User lsp_float_opened
-		    \ call win_execute(lsp#ui#vim#output#getpreviewwinid(),
-		    \		       'setlocal wincolor=PopupWindow')
+		    \ call setwinvar(lsp#ui#vim#output#getpreviewwinid(),
+		    \		       '&wincolor', 'PopupWindow')
 	    else
 		autocmd User lsp_float_opened
 		    \ call nvim_win_set_option(


### PR DESCRIPTION
- `lsp#ui#vim#output#setcontent` can use `setbufvar`, as suggested in
  https://github.com/tpope/vim-sleuth/issues/68#issuecomment-699512260.
- The example customizing the popup highlighting can use `setwinvar`,
  just like the example in [Vim's popup documentation][1].

[1]: https://github.com/vim/vim/blob/373863ed48c02b5df52574aa7d50aeecb1037d40/runtime/doc/popup.txt#L49