### PR TITLE
Fix "innerTalkback" typo in autoload/lsp/callbag.vim

### DIFF
--- a/autoload/lsp/callbag.vim
+++ b/autoload/lsp/callbag.vim
@@ -1129,7 +1129,7 @@ function! s:flattenTalkbackCallback(data, t, d) abort
         endif
     endif
     if a:t == 2
-        if a:data['innertTalkback'] != 0 | call a:data['innerTalkback'](2, lsp#callbag#undefined()) | endif
+        if a:data['innerTalkback'] != 0 | call a:data['innerTalkback'](2, lsp#callbag#undefined()) | endif
         call a:data['outerTalkback'](2, lsp#callbag#undefined())
     endif
 endfunction


### PR DESCRIPTION
Namely allows `lsp#disable()` to run without throwing E716:

```
Error detected while processing function lsp#disable[12]..lsp#internal#show_message_request#_disable[2]..<SNR>55_subscribeDispose[1]..<SNR>55_flattenTalkbackCallback:
line    9:
E716: Key not present in Dictionary: "innertTalkback"
E15: Invalid expression: a:data['innertTalkback'] != 0 | call a:data['innerTalkback'](2, lsp#callbag#undefined()) | endif
```