### PR TITLE
Fix width of documentation popup

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -118,14 +118,14 @@ function! s:show_documentation(event) abort
     if l:right
         let l:line = a:event['row'] + 1
         let l:col = a:event['col'] + a:event['width'] + 1 + (a:event['scrollbar'] ? 1 : 0)
-        if l:col > &columns
+        if l:col > &columns - 2
             let l:col -= winwidth(0) / 2
         endif
     else
         let l:line = a:event['row'] + 1
         let l:col = a:event['col'] - 1
     endif
-    let s:last_popup_id = popup_create('(no documentation available)', {'line': l:line, 'col': l:col, 'pos': l:right ? 'topleft' : 'topright', 'padding': [0, 1, 0, 1]})
+    let s:last_popup_id = popup_create('(no documentation available)', {'line': l:line, 'col': l:col, 'pos': l:right ? 'topleft' : 'topright', 'padding': [0, 1, 0, 1], 'border': [1, 1, 1, 1]})
     call setbufvar(winbufnr(s:last_popup_id), 'lsp_syntax_highlights', l:syntax_lines)
     call setbufvar(winbufnr(s:last_popup_id), 'lsp_do_conceal', 1)
     call lsp#ui#vim#output#setcontent(s:last_popup_id, l:lines, l:ft)

--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -118,6 +118,9 @@ function! s:show_documentation(event) abort
     if l:right
         let l:line = a:event['row'] + 1
         let l:col = a:event['col'] + a:event['width'] + 1 + (a:event['scrollbar'] ? 1 : 0)
+        if l:col > &columns
+            let l:col -= winwidth(0) / 2
+        endif
     else
         let l:line = a:event['row'] + 1
         let l:col = a:event['col'] - 1


### PR DESCRIPTION
When the popupmenu is wider filled with window width, documentation window become too narrow.

![image](https://user-images.githubusercontent.com/10111/99396119-b2c8d600-2924-11eb-97bb-749ce0f4a632.png)

After this change:

![image](https://user-images.githubusercontent.com/10111/99396495-28cd3d00-2925-11eb-99fc-68555389c1b1.png)
