### PR TITLE
Add title to Lsp(Document|Workspace)Symbol quickfix window

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -204,8 +204,13 @@ function! s:handle_symbol(server, last_command_id, type, data) abort
 
     let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:server, a:data)
 
-    call setqflist([])
-    call setqflist(l:list)
+    if has('patch-8.2.2147')
+      call setqflist(l:list)
+      call setqflist([], 'a', {'title': a:type})
+    else
+      call setqflist([])
+      call setqflist(l:list)
+    endif
 
     if empty(l:list)
         call lsp#utils#error('No ' . a:type .' found')


### PR DESCRIPTION
Enables user to get a more helpful title for Lsp(Document|Workspace)Symbol quickfix window via `w:quickfix_title`.

#### Before

<img width="700" alt="vim lsp pull-req before" src="https://user-images.githubusercontent.com/64692680/99852194-d6f61280-2bc3-11eb-8fb8-b3a8268b1955.png">

#### After

<img width="700" alt="vim lsp pull-req after" src="https://user-images.githubusercontent.com/64692680/99852202-dd848a00-2bc3-11eb-94f4-f91e3c02cc63.png">
