### PR TITLE
Add support for codeLens/resolve

### DIFF
--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -137,7 +137,6 @@ function! s:handle_code_lens_resolve(ctx, server_name, command_id, sync, bufnr, 
 endfunction
 
 function! s:handle_one_code_lens(server_name, sync, bufnr, code_lens) abort
-  let g:executed_code_lens = a:code_lens
     call lsp#ui#vim#execute_command#_execute({
     \   'server_name': a:server_name,
     \   'command_name': get(a:code_lens['command'], 'command', ''),

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -77,6 +77,53 @@ function! s:handle_code_lens(ctx, server_name, command_id, sync, bufnr, data) ab
     endif
     call lsp#log('s:handle_code_lens', l:total_code_lenses)
 
+    let l:resolve_ctx = {
+    \ 'count': len(l:total_code_lenses),
+    \ 'results': [],
+    \}
+
+    for l:code_lens in l:total_code_lenses
+      call lsp#send_request(l:server_name, {
+            \ 'method': 'codeLens/resolve',
+            \ 'params': l:code_lens['code_lens'],
+            \ 'sync': a:sync,
+            \ 'on_notification': function('s:handle_code_lens_resolve', [l:resolve_ctx, l:code_lens['server_name'], a:command_id, a:sync, a:bufnr]),
+            \ })
+    endfor
+endfunction
+
+function! s:handle_code_lens_resolve(ctx, server_name, command_id, sync, bufnr, data) abort
+    if a:command_id != lsp#_last_command()
+        return
+    endif
+
+    call add(a:ctx['results'], {
+    \    'server_name': a:server_name,
+    \    'data': a:data,
+    \})
+    let a:ctx['count'] -= 1
+    if a:ctx['count'] ># 0
+        return
+    endif
+
+    let l:total_code_lenses = []
+    for l:result in a:ctx['results']
+        let l:server_name = l:result['server_name']
+        let l:data = l:result['data']
+        " Check response error.
+        if lsp#client#is_error(l:data['response'])
+            call lsp#utils#error('Failed to CodeLens for ' . l:server_name . ': ' . lsp#client#error_message(l:data['response']))
+            continue
+        endif
+
+        " Check code lenses.
+        let l:code_lens = l:data['response']['result']
+        call add(l:total_code_lenses, {
+              \ 'server_name': l:server_name,
+              \ 'code_lens': l:code_lens,
+              \ })
+    endfor
+
     " Prompt to choose code lenses.
     let l:index = inputlist(map(copy(l:total_code_lenses), { i, lens ->
                 \   printf('%s - [%s] %s', i + 1, lens['server_name'], lens['code_lens']['command']['title'])
@@ -90,6 +137,7 @@ function! s:handle_code_lens(ctx, server_name, command_id, sync, bufnr, data) ab
 endfunction
 
 function! s:handle_one_code_lens(server_name, sync, bufnr, code_lens) abort
+  let g:executed_code_lens = a:code_lens
     call lsp#ui#vim#execute_command#_execute({
     \   'server_name': a:server_name,
     \   'command_name': get(a:code_lens['command'], 'command', ''),


### PR DESCRIPTION
This PR updates the code lens action to invoke `codeLens/resolve` on each result. According to the [spec](https://microsoft.github.io/language-server-protocol/specification#codeLens_resolve), the result of `textDocument/codeLens` is partial. In particular, the `command` value is missing, and an explicit call to resolve the lens is required in order to populate it.