### PR TITLE
Fix linecount

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -297,8 +297,14 @@ function! lsp#ui#vim#output#get_size_info(winid) abort
         let l:bufferlines += max([l:num_lines, 1])
       endfor
     else
-        if s:use_vim_popup
-          let l:bufferlines = getbufinfo(l:buffer)[0].linecount
+      if s:use_vim_popup
+        let l:bufferlines = getbufinfo(l:buffer)[0].linecount
+        let l:info = getbufinfo(l:buffer)[0]
+        if has_key(l:info, 'linecount')
+          let l:bufferlines = l:info.linecount
+        else
+          let l:bufferlines = line('$', bufwinid(l:info))
+        endif
       elseif s:use_nvim_float
           let l:bufferlines = nvim_buf_line_count(winbufnr(a:winid))
       endif

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -298,15 +298,9 @@ function! lsp#ui#vim#output#get_size_info(winid) abort
       endfor
     else
       if s:use_vim_popup
-        let l:bufferlines = getbufinfo(l:buffer)[0].linecount
-        let l:info = getbufinfo(l:buffer)[0]
-        if has_key(l:info, 'linecount')
-          let l:bufferlines = l:info.linecount
-        else
-          let l:bufferlines = line('$', bufwinid(l:info))
-        endif
+        let l:bufferlines = line('$', a:winid)
       elseif s:use_nvim_float
-          let l:bufferlines = nvim_buf_line_count(winbufnr(a:winid))
+        let l:bufferlines = nvim_buf_line_count(winbufnr(a:winid))
       endif
     endif
 


### PR DESCRIPTION
Using `getbufinfo(bufid)[0].linecount` require Vim 8.2.0019. `line('$', winid)` require 8.1.1967.