### PR TITLE
Do not remove empty lines in popup

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -331,18 +331,12 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
 
     let l:current_window_id = win_getid()
 
+    let s:winid = s:open_preview(a:data)
+
     let s:preview_data = a:data
     let l:lines = []
     let l:syntax_lines = []
     let l:ft = lsp#ui#vim#output#append(a:data, l:lines, l:syntax_lines)
-
-    " If the server response is empty content, we don't display anything.
-    if empty(l:lines) && empty(l:syntax_lines)
-        echo ''
-        return
-    endif
-
-    let s:winid = s:open_preview(a:data)
 
     if has_key(a:options, 'filetype')
         let l:ft = a:options['filetype']
@@ -405,29 +399,23 @@ function! lsp#ui#vim#output#append(data, lines, syntax_lines) abort
 
         return 'markdown'
     elseif type(a:data) ==# type('')
-        if !empty(a:data)
-            call extend(a:lines, split(s:escape_string_for_display(a:data), "\n", v:true))
-        endif
+        call extend(a:lines, split(s:escape_string_for_display(a:data), "\n", v:true))
 
         return 'markdown'
     elseif type(a:data) ==# type({}) && has_key(a:data, 'language')
-        if !empty(a:data.value)
-            let l:new_lines = split(s:escape_string_for_display(a:data.value), '\n')
+        let l:new_lines = split(s:escape_string_for_display(a:data.value), '\n')
 
-            let l:i = 1
-            while l:i <= len(l:new_lines)
-                call add(a:syntax_lines, { 'line': len(a:lines) + l:i, 'language': a:data.language })
-                let l:i += 1
-            endwhile
+        let l:i = 1
+        while l:i <= len(l:new_lines)
+            call add(a:syntax_lines, { 'line': len(a:lines) + l:i, 'language': a:data.language })
+            let l:i += 1
+        endwhile
 
-            call extend(a:lines, l:new_lines)
-        endif
+        call extend(a:lines, l:new_lines)
 
         return 'markdown'
     elseif type(a:data) ==# type({}) && has_key(a:data, 'kind')
-        if !empty(a:data.value)
-            call extend(a:lines, split(s:escape_string_for_display(a:data.value), '\n', v:true))
-        endif
+        call extend(a:lines, split(s:escape_string_for_display(a:data.value), '\n', v:true))
 
         return a:data.kind ==? 'plaintext' ? 'text' : a:data.kind
     endif


### PR DESCRIPTION
By removing empty lines in the popup window, the location information for `:LspPeekDefinition` etc. is wrong.

Fixes #937 
Reverts #553 

// cc: @h-michael 