### PR TITLE
support for non-boolean values in serverCapabilities

### DIFF
--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -1,4 +1,4 @@
-function! s:has_bool_provider(server_name, ...) abort
+function! s:has_provider(server_name, ...) abort
     let l:value = lsp#get_server_capabilities(a:server_name)
     for l:provider in a:000
         if empty(l:value) || type(l:value) != type({}) || !has_key(l:value, l:provider)
@@ -6,51 +6,51 @@ function! s:has_bool_provider(server_name, ...) abort
         endif
         let l:value = l:value[l:provider]
     endfor
-    return type(l:value) == type(v:true) && l:value == v:true
+    return (type(l:value) == type(v:true) && l:value == v:true) || type(l:value) == type({})
 endfunction
 
 function! lsp#capabilities#has_declaration_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'declarationProvider')
+    return s:has_provider(a:server_name, 'declarationProvider')
 endfunction
 
 function! lsp#capabilities#has_definition_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'definitionProvider')
+    return s:has_provider(a:server_name, 'definitionProvider')
 endfunction
 
 function! lsp#capabilities#has_references_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'referencesProvider')
+    return s:has_provider(a:server_name, 'referencesProvider')
 endfunction
 
 function! lsp#capabilities#has_hover_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'hoverProvider')
+    return s:has_provider(a:server_name, 'hoverProvider')
 endfunction
 
 function! lsp#capabilities#has_rename_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'renameProvider')
+    return s:has_provider(a:server_name, 'renameProvider')
 endfunction
 
 function! lsp#capabilities#has_rename_prepare_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'renameProvider', 'prepareProvider')
+    return s:has_provider(a:server_name, 'renameProvider', 'prepareProvider')
 endfunction
 
 function! lsp#capabilities#has_document_formatting_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'documentFormattingProvider')
+    return s:has_provider(a:server_name, 'documentFormattingProvider')
 endfunction
 
 function! lsp#capabilities#has_document_range_formatting_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'documentRangeFormattingProvider')
+    return s:has_provider(a:server_name, 'documentRangeFormattingProvider')
 endfunction
 
 function! lsp#capabilities#has_document_symbol_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'documentSymbolProvider')
+    return s:has_provider(a:server_name, 'documentSymbolProvider')
 endfunction
 
 function! lsp#capabilities#has_workspace_symbol_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'workspaceSymbolProvider')
+    return s:has_provider(a:server_name, 'workspaceSymbolProvider')
 endfunction
 
 function! lsp#capabilities#has_implementation_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'implementationProvider')
+    return s:has_provider(a:server_name, 'implementationProvider')
 endfunction
 
 function! lsp#capabilities#has_code_action_provider(server_name) abort
@@ -62,7 +62,7 @@ function! lsp#capabilities#has_code_action_provider(server_name) abort
             endif
         endif
     endif
-    return s:has_bool_provider(a:server_name, 'codeActionProvider')
+    return s:has_provider(a:server_name, 'codeActionProvider')
 endfunction
 
 function! lsp#capabilities#has_code_lens_provider(server_name) abort
@@ -74,19 +74,19 @@ function! lsp#capabilities#has_code_lens_provider(server_name) abort
 endfunction
 
 function! lsp#capabilities#has_type_definition_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'typeDefinitionProvider')
+    return s:has_provider(a:server_name, 'typeDefinitionProvider')
 endfunction
 
 function! lsp#capabilities#has_type_hierarchy_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'typeHierarchyProvider')
+    return s:has_provider(a:server_name, 'typeHierarchyProvider')
 endfunction
 
 function! lsp#capabilities#has_document_highlight_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'documentHighlightProvider')
+    return s:has_provider(a:server_name, 'documentHighlightProvider')
 endfunction
 
 function! lsp#capabilities#has_folding_range_provider(server_name) abort
-    return s:has_bool_provider(a:server_name, 'foldingRangeProvider')
+    return s:has_provider(a:server_name, 'foldingRangeProvider')
 endfunction
 
 function! lsp#capabilities#has_semantic_highlight(server_name) abort


### PR DESCRIPTION
In the current ServerCapabilities, the type of each provider can be other than boolean, but the current implementation only accepts boolean.

https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-15.md

```
interface ServerCapabilities {
	/**
	 * Defines how text documents are synced.
	 * Is either a detailed structure defining each notification
	 * or for backwards compatibility, the TextDocumentSyncKind number.
	 * If omitted, it defaults to `TextDocumentSyncKind.None`.
	 */
	textDocumentSync?: TextDocumentSyncOptions | number;

	/**
	 * The server provides completion support.
	 */
	completionProvider?: CompletionOptions;

	/**
	 * The server provides hover support.
	 */
	hoverProvider?: boolean | HoverOptions;

	/**
	 * The server provides signature help support.
	 */
	signatureHelpProvider?: SignatureHelpOptions;

	/**
	 * The server provides go to declaration support.
	 *
	 * @since 3.14.0
	 */
	declarationProvider?: boolean | DeclarationOptions
		| DeclarationRegistrationOptions;

	/**
	 * The server provides goto definition support.
	 */
	definitionProvider?: boolean | DefinitionOptions;

	/**
	 * The server provides goto type definition support.
	 *
	 * @since 3.6.0
	 */
	typeDefinitionProvider?: boolean | TypeDefinitionOptions
		| TypeDefinitionRegistrationOptions;

	/**
	 * The server provides goto implementation support.
	 *
	 * @since 3.6.0
	 */
	implementationProvider?: boolean | ImplementationOptions
		| ImplementationRegistrationOptions;

	/**
	 * The server provides find references support.
	 */
	referencesProvider?: boolean | ReferenceOptions;

	/**
	 * The server provides document highlight support.
	 */
	documentHighlightProvider?: boolean | DocumentHighlightOptions;

	/**
	 * The server provides document symbol support.
	 */
	documentSymbolProvider?: boolean | DocumentSymbolOptions;

	/**
	 * The server provides code actions.
	 * The `CodeActionOptions` return type is only valid if the client signals
	 * code action literal support via the property
	 * `textDocument.codeAction.codeActionLiteralSupport`.
	 */
	codeActionProvider?: boolean | CodeActionOptions;

	/**
	 * The server provides CodeLens.
	 */
	codeLensProvider?: CodeLensOptions;

	/**
	 * The server provides document link support.
	 */
	documentLinkProvider?: DocumentLinkOptions;

	/**
	 * The server provides color provider support.
	 *
	 * @since 3.6.0
	 */
	colorProvider?: boolean | DocumentColorOptions
		| DocumentColorRegistrationOptions;

	/**
	 * The server provides document formatting.
	 */
	documentFormattingProvider?: boolean | DocumentFormattingOptions;

	/**
	 * The server provides document range formatting.
	 */
	documentRangeFormattingProvider?: boolean | DocumentRangeFormattingOptions;

	/**
	 * The server provides document formatting on typing.
	 */
	documentOnTypeFormattingProvider?: DocumentOnTypeFormattingOptions;

	/**
	 * The server provides rename support. RenameOptions may only be
	 * specified if the client states that it supports
	 * `prepareSupport` in its initial `initialize` request.
	 */
	renameProvider?: boolean | RenameOptions;

	/**
	 * The server provides folding provider support.
	 *
	 * @since 3.10.0
	 */
	foldingRangeProvider?: boolean | FoldingRangeOptions
		| FoldingRangeRegistrationOptions;

	/**
	 * The server provides execute command support.
	 */
	executeCommandProvider?: ExecuteCommandOptions;

	/**
	 * The server provides selection range support.
	 *
	 * @since 3.15.0
	 */
	selectionRangeProvider?: boolean | SelectionRangeOptions
		| SelectionRangeRegistrationOptions;

	/**
	 * The server provides workspace symbol support.
	 */
	workspaceSymbolProvider?: boolean | WorkspaceSymbolOptions;

	/**
	 * Workspace specific server capabilities
	 */
	workspace?: {
		/**
		 * The server supports workspace folder.
		 *
		 * @since 3.6.0
		 */
		workspaceFolders?: WorkspaceFoldersServerCapabilities;
	}

	/**
	 * Experimental server capabilities.
	 */
	experimental?: any;
}
```