### PR TITLE
Convert lowercase drive letters to uppercase

### DIFF
--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -8,6 +8,7 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     let l:uri = a:data['response']['params']['uri']
     if s:is_win
         let l:uri = substitute(l:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
+        let l:uri = substitute(l:uri, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
     endif
     if !has_key(s:diagnostics, l:uri)
         let s:diagnostics[l:uri] = {}

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -7,8 +7,7 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
     endif
     let l:uri = a:data['response']['params']['uri']
     if s:is_win
-        let l:uri = substitute(l:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
-        let l:uri = substitute(l:uri, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
+        let l:uri = lsp#utils#normalize_uri(l:uri)
     endif
     if !has_key(s:diagnostics, l:uri)
         let s:diagnostics[l:uri] = {}

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -6,9 +6,7 @@ function! lsp#ui#vim#diagnostics#handle_text_document_publish_diagnostics(server
         return
     endif
     let l:uri = a:data['response']['params']['uri']
-    if s:is_win
-        let l:uri = lsp#utils#normalize_uri(l:uri)
-    endif
+    let l:uri = lsp#utils#normalize_uri(l:uri)
     if !has_key(s:diagnostics, l:uri)
         let s:diagnostics[l:uri] = {}
     endif

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -47,13 +47,14 @@ if has('win32') || has('win64')
         else
             " You must not encode the volume information on the path if
             " present
-            let l:end_pos_volume = matchstrpos(a:path, '\c[A-Z]:')[2]
+            let l:path = substitute(a:path, '\(\c[A-Z]:\)', "\\=toupper(submatch(1))", '')
+            let l:end_pos_volume = matchstrpos(l:path, '\c[A-Z]:')[2]
 
             if l:end_pos_volume == -1
                 let l:end_pos_volume = 0
             endif
 
-            return s:encode_uri(substitute(a:path, '\', '/', 'g'), l:end_pos_volume, 'file:///')
+            return s:encode_uri(substitute(l:path, '\', '/', 'g'), l:end_pos_volume, 'file:///')
         endif
     endfunction
 else

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -78,9 +78,8 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#normalize_uri(uri) abort
-        " Now, it is discussing about normalization of uri.
-        " The issue is https://github.com/microsoft/language-server-protocol/pull/1019
-        " After this descussion is settled, it's need to modify this function.
+        " Refer to https://github.com/microsoft/language-server-protocol/pull/1019 on normalization of urls.
+        " TODO: after the discussion is settled, modify this function.
         let l:ret = substitute(a:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
         return substitute(l:ret, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
     endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -78,6 +78,9 @@ endif
 
 if has('win32') || has('win64')
     function! lsp#utils#normalize_uri(uri) abort
+        " Now, it is discussing about normalization of uri.
+        " The issue is https://github.com/microsoft/language-server-protocol/pull/1019
+        " After this descussion is settled, it's need to modify this function.
         let l:ret = substitute(a:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
         return substitute(l:ret, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
     endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -76,6 +76,17 @@ else
     endfunction
 endif
 
+if has('win32') || has('win64')
+    function! lsp#utils#normalize_uri(uri) abort
+        let l:ret = substitute(a:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
+        return substitute(l:ret, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
+    endfunction
+else
+    function! lsp#utils#normalize_uri(uri) abort
+        return a:uri
+    endfunction
+endif
+
 function! lsp#utils#get_default_root_uri() abort
     return lsp#utils#path_to_uri(getcwd())
 endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -47,14 +47,13 @@ if has('win32') || has('win64')
         else
             " You must not encode the volume information on the path if
             " present
-            let l:path = substitute(a:path, '\(\c[A-Z]:\)', "\\=toupper(submatch(1))", '')
-            let l:end_pos_volume = matchstrpos(l:path, '\c[A-Z]:')[2]
+            let l:end_pos_volume = matchstrpos(a:path, '\c[A-Z]:')[2]
 
             if l:end_pos_volume == -1
                 let l:end_pos_volume = 0
             endif
 
-            return s:encode_uri(substitute(l:path, '\', '/', 'g'), l:end_pos_volume, 'file:///')
+            return s:encode_uri(substitute(a:path, '\', '/', 'g'), l:end_pos_volume, 'file:///')
         endif
     endfunction
 else

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -80,6 +80,38 @@ Describe lsp#utils
         End
     End
 
+    Describe lsp#utils#normalize_uri
+        It should return normalized uri (Windows)
+            if !has('win32')
+              Skip This tests is not for UNIX
+            endif
+            let tests = [
+            \  {'path': 'file:///C:\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
+            \  {'path': 'file:///c:\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
+            \  {'path': 'file:///C%3A\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
+            \  {'path': 'file:///c%3a\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
+            \  {'path': 'http://foo/bar.txt', 'uri': 'http://foo/bar.txt'},
+            \]
+            for test in tests
+                let uri = lsp#utils#normalize_uri(test.path)
+                Assert Equals(uri, test.uri)
+            endfor
+        End
+
+        It should return normalized uri (UNIX)
+            if has('win32')
+              Skip This tests is not for Windows
+            endif
+            let tests = [
+            \  {'path': 'file:///path/to/the/file.txt', 'uri': 'file:///path/to/the/file.txt'},
+            \]
+            for test in tests
+                let uri = lsp#utils#normalize_uri(test.path)
+                Assert Equals(uri, test.uri)
+            endfor
+        End
+    End
+
     Describe lsp#utils#find_nearest_parent_file_directory
         It should return the root directory if it is found
             let tests = [

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -56,7 +56,6 @@ Describe lsp#utils
             \  {'path': 'C:\path\to\the\file+name.txt', 'uri': 'file:///C:/path/to/the/file%2Bname.txt'},
             \  {'path': 'C:\path\to\the\file name.txt', 'uri': 'file:///C:/path/to/the/file%20name.txt'},
             \  {'path': 'http://foo/bar.txt', 'uri': 'http://foo/bar.txt'},
-            \  {'path': 'c:\path\to\the\file.txt', 'uri': 'file:///C:/path/to/the/file.txt'},
             \]
             for test in tests
                 let uri = lsp#utils#path_to_uri(test.path)

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -56,6 +56,7 @@ Describe lsp#utils
             \  {'path': 'C:\path\to\the\file+name.txt', 'uri': 'file:///C:/path/to/the/file%2Bname.txt'},
             \  {'path': 'C:\path\to\the\file name.txt', 'uri': 'file:///C:/path/to/the/file%20name.txt'},
             \  {'path': 'http://foo/bar.txt', 'uri': 'http://foo/bar.txt'},
+            \  {'path': 'c:\path\to\the\file.txt', 'uri': 'file:///C:/path/to/the/file.txt'},
             \]
             for test in tests
                 let uri = lsp#utils#path_to_uri(test.path)


### PR DESCRIPTION
I faced a problem that error diagnostics message does not shown in golang source code. In a result of my investigation, this problem occurs when I change the current directory with lowercase driveletter like `cd c:\dev\go\test001`. When `cd C:\dev\go\test001` is no problem. To avoid this problem, we need to convert driver letter to uppercase in lsp#utils#path_to_uri function.