### PR TITLE
add addtionalTextEdits for resolve support capability

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -461,7 +461,10 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'completion': {
     \           'completionItem': {
     \              'documentationFormat': ['plaintext'],
-    \              'snippetSupport': v:false
+    \              'snippetSupport': v:false,
+    \              'resolveSupport': {
+    \                  'properties': ['additionalTextEdits']
+    \              }
     \           },
     \           'completionItemKind': {
     \              'valueSet': lsp#omni#get_completion_item_kinds()


### PR DESCRIPTION
rust-analyzer passes the following capabilities in vscode plugin. for now only pass `addtionalTextEdits` so we can get autoimports.

```json
        "resolveSupport": {
            "properties": [
              "documentation",
              "detail",
              "additionalTextEdits"
            ]
          }
```

This requires changes in vim-lsp-settings.

```
      \ 'initialization_options': lsp_settings#get('rust-analyzer', 'initialization_options', {
      \     'completion': {
      \         'autoimport': { 'enable': v:true },
      \     },
      \ }),
```

https://asciinema.org/a/UduLTZrT3gJmQOLFYrUaulqeG