### PR TITLE
add support for window.workDoneProgress client capabilities - $/progress reports

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -532,6 +532,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'linkSupport' : v:true
     \       },
     \   },
+    \   'window': {
+    \       'workDoneProgress': g:lsp_work_done_progress_enabled ? v:true : v:false,
+    \   },
     \   'workspace': {
     \       'applyEdit': v:true,
     \       'configuration': v:true

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -54,6 +54,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_completion_resolve_timeout      |g:lsp_completion_resolve_timeout|
       g:lsp_tagfunc_source_methods          |g:lsp_tagfunc_source_methods|
       g:lsp_show_message_request_enabled    |g:lsp_show_message_request_enabled|
+      g:lsp_work_done_progress_enabled      |g:lsp_work_done_progress_enabled|
     Functions                             |vim-lsp-functions|
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|
@@ -774,6 +775,14 @@ g:lsp_show_message_request_enabled         *g:lsp_show_message_request_enabled*
 
     Determines whether or not `window/showMessageRequest` should show message to
     the user or if it should be ignored. Set to `1` to enable.
+
+g:lsp_work_done_progress_enabled         *g:lsp_work_done_progress_enabled*
+    Type: |Number|
+    Default: `0`
+
+    Determines whether or not to ask the server to send `$/progress`
+    notifications. This can be intercepted by listening to |lsp#stream()|.
+    Set to `1` to enable.
 
 ==============================================================================
 FUNCTIONS                                               *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -53,6 +53,7 @@ let g:lsp_text_document_did_save_delay = get(g:, 'lsp_text_document_did_save_del
 let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout', 200)
 let g:lsp_tagfunc_source_methods = get(g:, 'lsp_tagfunc_source_methods', ['definition', 'declaration', 'implementation', 'typeDefinition'])
 let g:lsp_show_message_request_enabled = get(g:, 'lsp_show_message_request_enabled', 1)
+let g:lsp_work_done_progress_enabled = get(g:, 'lsp_work_done_progress_enabled', 0)
 
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 


### PR DESCRIPTION
Add a generic `$/progress` reports by setting `window.workDoneProgress` to `true`. Disabled by default since it can be very noisy.

Use `let g:lsp_work_done_progress_enabled = 0` to enable and start listening to the stream.

```vim
let g:lsp_work_done_progress_enabled = 1
call lsp#callbag#pipe(
      \ lsp#stream(),
      \ lsp#callbag#filter({x->has_key(x, 'response') && has_key(x['response'], 'method')
      \  && x['response']['method'] ==# '$/progress' && has_key(x['response'], 'params')
      \  && has_key(x['response']['params'], 'value') && type(x['response']['params']['value']) == type({})}),
      \  lsp#callbag#map({x->x['response']['params']}),
      \  lsp#callbag#subscribe({x->lsp#utils#echo_with_truncation(x['token'] . ' ' . get(x['value'], 'message', '')) }),
      \ )
```

Demo: https://asciinema.org/a/380947

Useful for langservers that takes lot of time to initialize such as rust-analyzer. Unfortuantely it is generic and each lang servers may return it own value.

