### PR TITLE
Add window/workDoneProgress/create response

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -811,6 +811,8 @@ function! s:on_request(server_name, id, request) abort
     elseif a:request['method'] ==# 'workspace/configuration'
         let l:response_items = map(a:request['params']['items'], { key, val -> lsp#utils#workspace_config#get_value(a:server_name, val) })
         call s:send_response(a:server_name, { 'id': a:request['id'], 'result': l:response_items })
+    elseif a:request['method'] ==# 'window/workDoneProgress/create'
+        call s:send_response(a:server_name, { 'id': a:request['id'], 'result': v:null})
     else
         " TODO: for now comment this out until we figure out a better solution.
         " We need to comment this out so that others outside of vim-lsp can


### PR DESCRIPTION
Thank you for implementation workDoneProgress feature.
I've been waiting for it.

But current implementation can't work at clangd11.
(clangd11 is first support version of workDoneProgress )

rust-analyzer is always enable workDoneProgress.
But clangd is not.
It expect for `window/workDoneProgress/create` response.

This PR is response it.