### PR TITLE
Reimplement semantic highlights by using semantic tokens

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -63,6 +63,9 @@ function! lsp#enable() abort
     if g:lsp_signature_help_enabled
         call lsp#ui#vim#signature_help#setup()
     endif
+    if g:lsp_semantic_enabled
+        call lsp#ui#vim#semantic#setup()
+    endif
     call lsp#ui#vim#completion#_setup()
     call lsp#internal#diagnostics#_enable()
     call lsp#internal#highlight_references#_enable()
@@ -80,6 +83,7 @@ function! lsp#disable() abort
     call lsp#ui#vim#diagnostics#textprop#disable()
     call lsp#ui#vim#signature_help#_disable()
     call lsp#ui#vim#completion#_disable()
+    call lsp#ui#vim#semantic#_disable()
     call lsp#internal#diagnostics#_disable()
     call lsp#internal#highlight_references#_disable()
     call lsp#internal#show_message_request#_disable()

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -503,7 +503,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'semanticTokens': {
     \           'requests': {
     \               'range': v:false,
-    \               'full': { 'delta': v:true },
+    \               'full': { 'delta': v:false },
     \           },
     \           'tokenTypes': lsp#ui#vim#semantic#get_default_supported_token_types(),
     \           'tokenModifiers': lsp#ui#vim#semantic#get_default_supported_token_modifiers(),

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -496,8 +496,14 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'foldingRange': {
     \           'lineFoldingOnly': v:true
     \       },
-    \       'semanticHighlightingCapabilities': {
-    \           'semanticHighlighting': lsp#ui#vim#semantic#is_enabled()
+    \       'semanticTokens': {
+    \           'requests': {
+    \               'range': v:false,
+    \               'full': { 'delta': v:false },
+    \           },
+    \           'tokenTypes': lsp#ui#vim#semantic#get_default_supported_token_types(),
+    \           'tokenModifiers': lsp#ui#vim#semantic#get_default_supported_token_modifiers(),
+    \           'formats': ['relative'],
     \       },
     \       'typeHierarchy': v:false,
     \   }

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -503,7 +503,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'semanticTokens': {
     \           'requests': {
     \               'range': v:false,
-    \               'full': { 'delta': v:false },
+    \               'full': { 'delta': v:true },
     \           },
     \           'tokenTypes': lsp#ui#vim#semantic#get_default_supported_token_types(),
     \           'tokenModifiers': lsp#ui#vim#semantic#get_default_supported_token_modifiers(),

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -89,22 +89,40 @@ function! lsp#capabilities#has_folding_range_provider(server_name) abort
     return s:has_provider(a:server_name, 'foldingRangeProvider')
 endfunction
 
-function! lsp#capabilities#has_semantic_highlight(server_name) abort
+function! lsp#capabilities#has_semantic_tokens(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)
-
-    if empty(l:capabilities) || type(l:capabilities) != type({}) || !has_key(l:capabilities, 'semanticHighlighting')
+    if empty(l:capabilities) || type(l:capabilities) != type({}) || !has_key(l:capabilities, 'semanticTokensProvider')
         return 0
     endif
 
-    let l:semantic_hl = l:capabilities['semanticHighlighting']
+    let l:capability = l:capabilities['semanticTokensProvider']
 
-    if type(l:semantic_hl) != type({}) || !has_key(l:semantic_hl, 'scopes')
+    if type(l:capability) != type({}) || !has_key(l:capability, 'legend')
         return 0
     endif
 
-    let l:scopes = l:semantic_hl['scopes']
+    " FIXME: only support 'full' for now
+    if !has_key(l:capability, 'full')
+        return 0
+    endif
 
-    if type(l:scopes) != type([]) || empty(l:scopes)
+    let l:full = l:capability['full']
+
+    if type(l:full) != type({}) && !l:full
+        return 0
+    endif
+
+    let l:legend = l:capability['legend']
+
+    if type(l:legend) != type({}) || !has_key(l:legend, 'tokenTypes') || !has_key(l:legend, 'tokenModifiers')
+        return 0
+    endif
+
+    let l:token_types = l:legend['tokenTypes']
+    let l:token_modifiers = l:legend['tokenModifiers']
+
+    if type(l:token_types) != type([]) || empty(l:token_types) || type(l:token_modifiers) != type([])
+        " FIXME: Is there any needs to check 'tokenModifiers' is not empty?
         return 0
     endif
 

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -129,16 +129,6 @@ function! lsp#capabilities#has_semantic_tokens(server_name) abort
     return 1
 endfunction
 
-function! lsp#capabilities#has_semantic_tokens_delta(server) abort
-    if !lsp#capabilities#has_semantic_tokens(a:server)
-        return 0
-    endif
-    let l:capabilities = lsp#get_server_capabilities(a:server)
-    return type(l:capabilities['semanticTokensProvider']['full']) == type({})
-    \   && has_key(l:capabilities['semanticTokensProvider']['full'], 'delta')
-    \   && l:capabilities['semanticTokensProvider']['full']['delta']
-endfunction
-
 " [supports_did_save (boolean), { 'includeText': boolean }]
 function! lsp#capabilities#get_text_document_save_registration_options(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -129,6 +129,16 @@ function! lsp#capabilities#has_semantic_tokens(server_name) abort
     return 1
 endfunction
 
+function! lsp#capabilities#has_semantic_tokens_delta(server) abort
+    if !lsp#capabilities#has_semantic_tokens(a:server)
+        return 0
+    endif
+    let l:capabilities = lsp#get_server_capabilities(a:server)
+    return type(l:capabilities['semanticTokensProvider']['full']) == type({})
+    \   && has_key(l:capabilities['semanticTokensProvider']['full'], 'delta')
+    \   && l:capabilities['semanticTokensProvider']['full']['delta']
+endfunction
+
 " [supports_did_save (boolean), { 'includeText': boolean }]
 function! lsp#capabilities#get_text_document_save_registration_options(server_name) abort
     let l:capabilities = lsp#get_server_capabilities(a:server_name)

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -11,6 +11,48 @@ if !hlexists('LspUnknownScope')
 endif
 
 " Global functions {{{1
+function! lsp#ui#vim#semantic#get_default_supported_token_types() abort
+    return [
+    \   'namespace',
+    \   'type',
+    \   'class',
+    \   'enum',
+    \   'interface',
+    \   'struct',
+    \   'typeParameter',
+    \   'parameter',
+    \   'variable',
+    \   'property',
+    \   'enumMember',
+    \   'event',
+    \   'function',
+    \   'method',
+    \   'macro',
+    \   'keyword',
+    \   'modifier',
+    \   'comment',
+    \   'string',
+    \   'number',
+    \   'regexp',
+    \   'operator',
+    \ ]
+endfunction
+
+function! lsp#ui#vim#semantic#get_default_supported_token_modifiers() abort
+    return [
+    \   'declaration',
+    \   'definition',
+    \   'readonly',
+    \   'static',
+    \   'deprecated',
+    \   'abstract',
+    \   'async',
+    \   'modification',
+    \   'documentation',
+    \   'defaultLibrary',
+    \ ]
+endfunction
+
 function! lsp#ui#vim#semantic#is_enabled() abort
     return g:lsp_semantic_enabled && (s:use_vim_textprops || s:use_nvim_highlight) ? v:true : v:false
 endfunction

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -39,71 +39,130 @@ function! lsp#ui#vim#semantic#get_default_supported_token_types() abort
 endfunction
 
 function! lsp#ui#vim#semantic#get_default_supported_token_modifiers() abort
-    return [
-    \   'declaration',
-    \   'definition',
-    \   'readonly',
-    \   'static',
-    \   'deprecated',
-    \   'abstract',
-    \   'async',
-    \   'modification',
-    \   'documentation',
-    \   'defaultLibrary',
-    \ ]
+    " TODO: support these
+    " return [
+    " \   'declaration',
+    " \   'definition',
+    " \   'readonly',
+    " \   'static',
+    " \   'deprecated',
+    " \   'abstract',
+    " \   'async',
+    " \   'modification',
+    " \   'documentation',
+    " \   'defaultLibrary',
+    " \ ]
+    return []
 endfunction
 
 function! lsp#ui#vim#semantic#is_enabled() abort
     return g:lsp_semantic_enabled && (s:use_vim_textprops || s:use_nvim_highlight) ? v:true : v:false
 endfunction
 
-function! lsp#ui#vim#semantic#get_scopes(server) abort
-    if !lsp#capabilities#has_semantic_highlight(a:server)
+function! lsp#ui#vim#semantic#get_legend(server) abort
+    if !lsp#capabilities#has_semantic_tokens(a:server)
         return []
     endif
 
     let l:capabilities = lsp#get_server_capabilities(a:server)
-    return l:capabilities['semanticHighlighting']['scopes']
+    return l:capabilities['semanticTokensProvider']['legend']
 endfunction
 
-function! lsp#ui#vim#semantic#handle_semantic(server, data) abort
-    if !g:lsp_semantic_enabled | return | endif
+function! lsp#ui#vim#semantic#do_semantic_highlight() abort
+    let l:bufnr = bufnr('%')
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
 
-    if lsp#client#is_error(a:data['response'])
-        call lsp#log('Skipping semantic highlight: response is invalid')
+    if len(l:servers) == 0
+        call lsp#utils#error('Semantic tokens not supported for ' . &filetype)
         return
     endif
 
-    let l:uri = a:data['response']['params']['textDocument']['uri']
-    let l:path = lsp#utils#uri_to_path(l:uri)
-    let l:bufnr = bufnr(l:path)
+    let l:server = l:servers[0]
+    call lsp#send_request(l:server, {
+    \   'method': 'textDocument/semanticTokens/full',
+    \   'params': {
+    \       'textDocument': lsp#get_text_document_identifier(),
+    \   },
+    \   'on_notification': function('s:handle_full_semantic_highlight', [l:server, l:bufnr]),
+    \ })
+endfunction
+
+function! s:handle_full_semantic_highlight(server, bufnr, data) abort
+    call lsp#log('semantic token: got semantic tokens!')
+    if !g:lsp_semantic_enabled | return | endif
+
+    if lsp#client#is_error(a:data['response'])
+        call lsp#log('Skipping semantic token: response is invalid')
+        return
+    endif
 
     " Skip if the buffer doesn't exist. This might happen when a buffer is
     " opened and quickly deleted.
-    if !bufloaded(l:bufnr) | return | endif
+    if !bufloaded(a:bufnr) | return | endif
 
-    call s:init_highlight(a:server, l:bufnr)
+    call s:init_highlight(a:server, a:bufnr)
+    if type(a:data['response']) != type({}) || !has_key(a:data['response'], 'result') || type(a:data['response']['result']) != type({}) || !has_key(a:data['response']['result'], 'data') || type(a:data['response']['result']['data']) != type([])
+        call lsp#log('Skipping semantic token: server returned nothing or invalid data')
+        return
+    endif
 
-    for l:info in a:data['response']['params']['lines']
-        let l:linenr = l:info['line']
-        let l:tokens = has_key(l:info, 'tokens') ? l:info['tokens'] : ''
-        call s:add_highlight(a:server, l:bufnr, l:linenr, l:tokens)
+    call lsp#log('semantic tokens: do semantic highlighting')
+
+    let l:data = a:data['response']['result']['data']
+    let l:num_data = len(l:data)
+    if l:num_data % 5 != 0
+        call lsp#log(printf('Skipping semantic token: invalid number of data (%d) returned', l:num_data))
+        return
+    endif
+
+    " Process highlights line by line.
+    let l:tokens_in_line = {}
+    let l:legend = lsp#ui#vim#semantic#get_legend(a:server)
+    let l:current_line = 0
+    let l:current_char = 0
+    for l:idx in range(0, l:num_data - 1, 5)
+        let l:delta_line = l:data[l:idx]
+        let l:delta_start_char = l:data[l:idx + 1]
+        let l:length = l:data[l:idx + 2]
+        let l:token_type = l:data[l:idx + 3]
+        " TODO: support token modifiers
+        " let l:token_modifiers = l:data[l:idx + 4]
+
+        " Calculate the absolute position from relative coordinates
+        let l:line = l:current_line + l:delta_line
+        let l:char = l:delta_line == 0 ? l:current_char + l:delta_start_char : l:delta_start_char
+        let l:current_line = l:line
+        let l:current_char = l:char
+
+        if !has_key(l:tokens_in_line, l:line)
+            let l:tokens_in_line[l:line] = []
+        endif
+
+        call add(l:tokens_in_line[l:line], {
+        \   'start_char': l:char,
+        \   'length': l:length,
+        \   'token_type': l:token_type,
+        \ })
+    endfor
+
+    for [l:line, l:tokens] in sort(items(l:tokens_in_line))
+        " l:line is always string, conversion needed
+        call s:add_highlight_for_line(a:server, a:bufnr, l:legend, str2nr(l:line), l:tokens)
     endfor
 endfunction
 
-" Highlight helper functions {{{1
 function! s:init_highlight(server, buf) abort
     if !empty(getbufvar(a:buf, 'lsp_did_semantic_setup'))
         return
     endif
 
     if s:use_vim_textprops
-        let l:scopes = lsp#ui#vim#semantic#get_scopes(a:server)
-        for l:scope_idx in range(len(l:scopes))
-            let l:scope = l:scopes[l:scope_idx]
-            let l:hl = s:get_hl_name(a:server, l:scope)
+        let l:token_types = lsp#ui#vim#semantic#get_legend(a:server)["tokenTypes"]
+        for l:token_idx in range(len(l:token_types))
+            let l:token_type = l:token_types[l:token_idx]
+            let l:highlight = s:token_type_to_highlight(a:server, l:token_type)
 
-            silent! call prop_type_add(s:get_textprop_name(a:server, l:scope_idx), {'bufnr': a:buf, 'highlight': l:hl, 'combine': v:true})
+            silent! call prop_type_add(s:get_textprop_name(a:server, l:token_idx), {'bufnr': a:buf, 'highlight': l:highlight, 'combine': v:true})
         endfor
 
         silent! call prop_type_add(s:textprop_cache, {'bufnr': a:buf})
@@ -112,49 +171,26 @@ function! s:init_highlight(server, buf) abort
     call setbufvar(a:buf, 'lsp_did_semantic_setup', 1)
 endfunction
 
-function! s:hash(str) abort
-    let l:hash = 1
+function! s:add_highlight_for_line(server, buf, legend, line, tokens) abort
+    let l:token_types = a:legend['tokenTypes']
 
-    for l:char in split(a:str, '\zs')
-        let l:hash = (l:hash * 31 + char2nr(l:char)) % 2147483647
-    endfor
-
-    return l:hash
-endfunction
-
-function! s:add_highlight(server, buf, line, tokens) abort
-    " Return quickly if the tokens for this line are already set correctly,
-    " according to the cached tokens.
-    " This only works for Vim at the moment, for Neovim, we need extended
-    " marks.
-    if s:use_vim_textprops
-        let l:props = filter(prop_list(a:line + 1, {'bufnr': a:buf}), {idx, prop -> prop['type'] ==# s:textprop_cache})
-        let l:hash = s:hash(a:tokens)
-
-        if !empty(l:props) && l:props[0]['id'] == l:hash
-            " No changes for this line, so just return.
-            return
-        endif
-    endif
-
-    let l:scopes = lsp#ui#vim#semantic#get_scopes(a:server)
-    let l:highlights = s:tokens_to_hl_info(a:tokens)
+    " Debug {{{
+    " let l:linestr = getbufline(a:buf, a:line + 1)[0]
+    " for l:token in a:tokens
+    "     let l:tokstr = strpart(l:linestr, l:token['start_char'], l:token['length'])
+    "     call lsp#log(printf("colorize token '%s' @ %d:%d as '%s'", l:tokstr, a:line + 1, l:token['start_char'] + 1, l:token_types[l:token['token_type']]))
+    " endfor
+    "}}}
 
     if s:use_vim_textprops
         " Clear text properties from the previous run
-        for l:scope_idx in range(len(l:scopes))
-            call prop_remove({'bufnr': a:buf, 'type': s:get_textprop_name(a:server, l:scope_idx), 'all': v:true}, a:line + 1)
+        for l:token_idx in range(len(l:token_types))
+            call prop_remove({'bufnr': a:buf, 'type': s:get_textprop_name(a:server, l:token_idx), 'all': v:true}, a:line + 1)
         endfor
 
-        " Clear cache from previous run
-        call prop_remove({'bufnr': a:buf, 'type': s:textprop_cache, 'all': v:true}, a:line + 1)
-
-        " Add textprop for cache
-        call prop_add(a:line + 1, 1, {'bufnr': a:buf, 'type': s:textprop_cache, 'id': l:hash})
-
-        for l:highlight in l:highlights
+        for l:token in a:tokens
             try
-                call prop_add(a:line + 1, l:highlight['char'] + 1, { 'length': l:highlight['length'], 'bufnr': a:buf, 'type': s:get_textprop_name(a:server, l:highlight['scope'])})
+                call prop_add(a:line + 1, l:token['start_char'] + 1, { 'length': l:token['length'], 'bufnr': a:buf, 'type': s:get_textprop_name(a:server, l:token['token_type'])})
             catch
                 call lsp#log('SemanticHighlight: error while adding prop on line ' . (a:line + 1), v:exception)
             endtry
@@ -163,113 +199,55 @@ function! s:add_highlight(server, buf, line, tokens) abort
         " Clear text properties from the previous run
         call nvim_buf_clear_namespace(a:buf, s:namespace_id, a:line, a:line + 1)
 
-        for l:highlight in l:highlights
-            call nvim_buf_add_highlight(a:buf, s:namespace_id, s:get_hl_name(a:server, l:scopes[l:highlight['scope']]), a:line, l:highlight['char'], l:highlight['char'] + l:highlight['length'])
+        for l:token in a:tokens
+            let l:highlight = s:token_type_to_highlight(a:server, l:token_types[l:token['token_type']])
+            call nvim_buf_add_highlight(a:buf, s:namespace_id, l:highlight, a:line, l:token['start_char'], l:token['start_char'] + l:token['length'])
         endfor
     endif
 endfunction
 
-function! s:get_hl_name(server, scope) abort
-    let l:hl = 'LspUnknownScope'
-
-    " Iterate over scopes in the order most general to most specific,
-    " returning the last scope encountered. This is accomplished by a try
-    " catch which ensures we always return the last scope even if an error is
-    " encountered midway.
+function! s:token_type_to_highlight(server, token_type) abort
+    " Iterate over token_type in the order most general to most specific,
+    " returning the last token_type encountered. This is accomplished by a try
+    " catch which ensures we always return the last token_type even if an
+    " error is encountered midway.
     try
         let l:info = lsp#get_server_info(a:server)
-        let l:hl = l:info['semantic_highlight']
+        let l:highlight = l:info['semantic_highlight']
         let l:i = 0
 
-        while (l:i < len(a:scope)) && has_key(l:hl, a:scope[l:i])
-            let l:hl = l:hl[a:scope[l:i]]
-            let l:i += 1
-        endwhile
+        if has_key(l:highlight, a:token_type)
+            return l:highlight[a:token_type]
+        endif
     catch
     endtry
-
-    return type(l:hl) == type('') ? l:hl : 'LspUnknownScope'
+    return 'LspUnknownScope'
 endfunction
 
-function! s:get_textprop_name(server, scope_index) abort
-    return 'vim-lsp-semantic-' . a:server . '-' . a:scope_index
+function! s:get_textprop_name(server, token_type_index) abort
+    return 'vim-lsp-semantic-' . a:server . '-' . a:token_type_index
 endfunction
 
-" Response parsing functions {{{1
-
-" Converts a list of bytes (MSB first) to a Number.
-function! s:octets_to_number(octets) abort
-    let l:ret = 0
-
-    for l:octet in a:octets
-        let l:ret *= 256
-        let l:ret += l:octet
-    endfor
-
-    return l:ret
-endfunction
-
-function! s:tokens_to_hl_info(token) abort
-    let l:ret = []
-    let l:octets = lsp#utils#base64_decode(a:token)
-
-    for l:i in range(0, len(l:octets) - 1, 8)
-        let l:char = s:octets_to_number(l:octets[l:i : l:i+3])
-        let l:length = s:octets_to_number(l:octets[l:i+4 : l:i+5])
-        let l:scope = s:octets_to_number(l:octets[l:i+6 : l:i+7])
-
-        call add(l:ret, { 'char': l:char, 'length': l:length, 'scope': l:scope })
-    endfor
-
-    return l:ret
-endfunction
-
-" Display scope tree {{{1
-function! lsp#ui#vim#semantic#display_scope_tree(...) abort
-    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_highlight(v:val)')
+function! lsp#ui#vim#semantic#display_token_types() abort
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
 
     if len(l:servers) == 0
-        call lsp#utils#error('Semantic highlighting not supported for ' . &filetype)
+        call lsp#utils#error('Semantic tokens not supported for ' . &filetype)
         return
     endif
 
     let l:server = l:servers[0]
     let l:info = lsp#get_server_info(l:server)
-    let l:hl_mapping = get(l:info, 'semantic_highlight', {})
-    let l:scopes = copy(lsp#ui#vim#semantic#get_scopes(l:server))
+    let l:highlight_mappings = get(l:info, 'semantic_highlight', {})
+    let l:legend = lsp#ui#vim#semantic#get_legend(l:server)
+    let l:token_types = uniq(sort(copy(l:legend['tokenTypes'])))
 
-    " Convert scope array to tree
-    let l:tree = {}
-
-    for l:scope in l:scopes
-        let l:cur = l:tree
-
-        for l:scope_part in l:scope
-            if !has_key(l:cur, l:scope_part)
-                let l:cur[l:scope_part] = {}
-            endif
-            let l:cur = l:cur[l:scope_part]
-        endfor
-    endfor
-
-    call s:display_tree(l:hl_mapping, l:tree, 0, a:0 > 0 ? a:1 - 1 : 20)
-endfunction
-
-function! s:display_tree(hl_tree, tree, indent, maxindent) abort
-    for [l:item, l:rest] in sort(items(a:tree))
-        if has_key(a:hl_tree, l:item) && type(a:hl_tree[l:item]) == type('')
-            execute 'echohl ' . a:hl_tree[l:item]
+    for l:token_type in l:token_types
+        if has_key(l:highlight_mappings, l:token_type)
+            execute 'echohl ' . l:highlight_mappings[l:token_type]
         endif
-        echo repeat(' ', 4 * a:indent) . l:item
+        echo l:token_type
         echohl None
-
-        if a:indent < a:maxindent
-            let l:new_hl_info = get(a:hl_tree, l:item, {})
-            if type(l:new_hl_info) != type({})
-                let l:new_hl_info = {}
-            endif
-            call s:display_tree(l:new_hl_info, l:rest, a:indent + 1, a:maxindent)
-        endif
     endfor
 endfunction
 

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -70,7 +70,7 @@ endfunction
 
 function! lsp#ui#vim#semantic#do_semantic_highlight() abort
     let l:bufnr = bufnr('%')
-    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
+    let l:servers = s:get_supported_servers()
 
     if len(l:servers) == 0
         call lsp#utils#error('Semantic tokens not supported for ' . &filetype)
@@ -85,6 +85,10 @@ function! lsp#ui#vim#semantic#do_semantic_highlight() abort
     \   },
     \   'on_notification': function('s:handle_full_semantic_highlight', [l:server, l:bufnr]),
     \ })
+endfunction
+
+function! s:get_supported_servers() abort
+    return filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
 endfunction
 
 function! s:handle_full_semantic_highlight(server, bufnr, data) abort
@@ -229,7 +233,7 @@ function! s:get_textprop_name(server, token_type_index) abort
 endfunction
 
 function! lsp#ui#vim#semantic#display_token_types() abort
-    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
+    let l:servers = s:get_supported_servers()
 
     if len(l:servers) == 0
         call lsp#utils#error('Semantic tokens not supported for ' . &filetype)
@@ -249,6 +253,21 @@ function! lsp#ui#vim#semantic#display_token_types() abort
         echo l:token_type
         echohl None
     endfor
+endfunction
+
+function! lsp#ui#vim#semantic#setup() abort
+    augroup _lsp_semantic_tokens
+        autocmd!
+        autocmd BufEnter,CursorHold,CursorHoldI * if len(s:get_supported_servers()) > 0 | call lsp#ui#vim#semantic#do_semantic_highlight() | endif
+    augroup END
+endfunction
+
+function! lsp#ui#vim#semantic#_disable() abort
+    augroup _lsp_semantic_tokens
+        autocmd!
+    augroup END
+
+    " TODO: remove all semantic highlighting --- but how?
 endfunction
 
 " vim: fdm=marker

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -78,59 +78,50 @@ function! lsp#ui#vim#semantic#do_semantic_highlight() abort
     endif
 
     let l:server = l:servers[0]
-    call lsp#send_request(l:server, {
-    \   'method': 'textDocument/semanticTokens/full',
-    \   'params': {
-    \       'textDocument': lsp#get_text_document_identifier(),
-    \   },
-    \   'on_notification': function('s:handle_full_semantic_highlight', [l:server, l:bufnr]),
-    \ })
+
+    " If there was previous request, use full/delta method.
+    let l:previous_highlights = getbufvar(l:bufnr, 'previous_highlights')
+    if type(l:previous_highlights) == type({}) && lsp#capabilities#has_semantic_tokens_delta(l:server)
+        call lsp#send_request(l:server, {
+        \   'method': 'textDocument/semanticTokens/full/delta',
+        \   'params': {
+        \       'textDocument': lsp#get_text_document_identifier(),
+        \       'previousResultId': l:previous_highlights['result_id'],
+        \   },
+        \   'on_notification': function('s:handle_full_delta_semantic_highlight', [l:server, l:bufnr]),
+        \ })
+    else
+        call lsp#send_request(l:server, {
+        \   'method': 'textDocument/semanticTokens/full',
+        \   'params': {
+        \       'textDocument': lsp#get_text_document_identifier(),
+        \   },
+        \   'on_notification': function('s:handle_full_semantic_highlight', [l:server, l:bufnr]),
+        \ })
+    endif
 endfunction
 
 function! s:get_supported_servers() abort
     return filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_semantic_tokens(v:val)')
 endfunction
 
-function! s:handle_full_semantic_highlight(server, bufnr, data) abort
-    call lsp#log('semantic token: got semantic tokens!')
-    if !g:lsp_semantic_enabled | return | endif
-
-    if lsp#client#is_error(a:data['response'])
-        call lsp#log('Skipping semantic token: response is invalid')
-        return
-    endif
-
-    " Skip if the buffer doesn't exist. This might happen when a buffer is
-    " opened and quickly deleted.
-    if !bufloaded(a:bufnr) | return | endif
-
-    call s:init_highlight(a:server, a:bufnr)
-    if type(a:data['response']) != type({}) || !has_key(a:data['response'], 'result') || type(a:data['response']['result']) != type({}) || !has_key(a:data['response']['result'], 'data') || type(a:data['response']['result']['data']) != type([])
-        call lsp#log('Skipping semantic token: server returned nothing or invalid data')
-        return
-    endif
-
-    call lsp#log('semantic tokens: do semantic highlighting')
-
-    let l:data = a:data['response']['result']['data']
-    let l:num_data = len(l:data)
+function! s:parse_tokens_for_each_lines(legend, array)
+    let l:num_data = len(a:array)
     if l:num_data % 5 != 0
         call lsp#log(printf('Skipping semantic token: invalid number of data (%d) returned', l:num_data))
-        return
+        return {}
     endif
 
-    " Process highlights line by line.
     let l:tokens_in_line = {}
-    let l:legend = lsp#ui#vim#semantic#get_legend(a:server)
     let l:current_line = 0
     let l:current_char = 0
     for l:idx in range(0, l:num_data - 1, 5)
-        let l:delta_line = l:data[l:idx]
-        let l:delta_start_char = l:data[l:idx + 1]
-        let l:length = l:data[l:idx + 2]
-        let l:token_type = l:data[l:idx + 3]
+        let l:delta_line = a:array[l:idx]
+        let l:delta_start_char = a:array[l:idx + 1]
+        let l:length = a:array[l:idx + 2]
+        let l:token_type = a:array[l:idx + 3]
         " TODO: support token modifiers
-        " let l:token_modifiers = l:data[l:idx + 4]
+        " let l:token_modifiers = a:array[l:idx + 4]
 
         " Calculate the absolute position from relative coordinates
         let l:line = l:current_line + l:delta_line
@@ -149,8 +140,129 @@ function! s:handle_full_semantic_highlight(server, bufnr, data) abort
         \ })
     endfor
 
+    return l:tokens_in_line
+endfunction
+
+function! s:handle_full_semantic_highlight(server, bufnr, data) abort
+    if !g:lsp_semantic_enabled | return | endif
+
+    if lsp#client#is_error(a:data['response'])
+        call lsp#log('Skipping semantic token: response is invalid')
+        return
+    endif
+
+    " Skip if the buffer doesn't exist. This might happen when a buffer is
+    " opened and quickly deleted.
+    if !bufloaded(a:bufnr) | return | endif
+
+    call s:init_highlight(a:server, a:bufnr)
+    if type(a:data['response']) != type({})
+    \   || !has_key(a:data['response'], 'result')
+    \   || type(a:data['response']['result']) != type({})
+    \       || !has_key(a:data['response']['result'], 'data')
+    \       || type(a:data['response']['result']['data']) != type([])
+        call lsp#log('Skipping semantic token: server returned nothing or invalid data')
+        return
+    endif
+
+    let l:data = a:data['response']['result']['data']
+
+    let l:legend = lsp#ui#vim#semantic#get_legend(a:server)
+    let l:tokens_in_line = s:parse_tokens_for_each_lines(l:legend, l:data)
+
+    " Save this result only if it has "resultId" parameter (i.e. supports
+    " delta uploading). Save it to the buffer-local variable.
+    if has_key(a:data['response']['result'], 'resultId')
+        call setbufvar(a:bufnr, 'previous_highlights', {
+        \   'result_id': a:data['response']['result']['resultId'],
+        \   'raw': l:data,
+        \ })
+    endif
+
     for [l:line, l:tokens] in sort(items(l:tokens_in_line))
         " l:line is always string, conversion needed
+        call s:add_highlight_for_line(a:server, a:bufnr, l:legend, str2nr(l:line), l:tokens)
+    endfor
+endfunction
+
+function! s:handle_full_delta_semantic_highlight(server, bufnr, data) abort
+    if !g:lsp_semantic_enabled | return | endif
+
+    if lsp#client#is_error(a:data['response'])
+        call lsp#log('Skipping semantic token: response is invalid')
+        return
+    endif
+
+    " Skip if the buffer doesn't exist. This might happen when a buffer is
+    " opened and quickly deleted.
+    if !bufloaded(a:bufnr) | return | endif
+
+    " Skip if previous token cannot be fetched
+    let l:previous_highlights = getbufvar(a:bufnr, 'previous_highlights')
+    if type(l:previous_highlights) != type({})
+        call lsp#log('Skipping semantic token: failed to fetch previous highlights even if delta uploading was triggered')
+        return
+    endif
+
+    call s:init_highlight(a:server, a:bufnr)
+
+    if type(a:data['response']) != type({})
+    \   || !has_key(a:data['response'], 'result')
+    \   || type(a:data['response']['result']) != type({})
+        call lsp#log('Skipping semantic token: server returned nothing or invalid response')
+    endif
+
+    " According to the LSP specification, SemanticTokens can be returned
+    " instead of SemanticTokensDelta even if the method is '.../full/delta'.
+    " Handle that case.
+    if has_key(a:data['response']['result'], 'data')
+        return s:handle_full_semantic_highlight(a:server, a:bufnr, a:data)
+    endif
+
+    if !has_key(a:data['response']['result'], 'edits')
+    \  || type(a:data['response']['result']['edits']) != type([])
+        call lsp#log('Skipping semantic token: server returned nothing or invalid edits')
+        return
+    endif
+
+    let l:array = copy(l:previous_highlights['raw'])
+    let l:prev_tokens_in_line = s:parse_tokens_for_each_lines(l:legend, l:array)
+
+    let l:edits = a:data['response']['result']['edits']
+    for l:edit in l:edits
+        if type(l:edit) != type({}) || !has_key(l:edit, 'start') || !has_key(l:edit, 'deleteCount')
+            call lsp#log('Skipping semantic token: invalid edit')
+            return
+        endif
+        call remove(l:array, l:edit['start'], l:edit['start'] + l:edit['deleteCount'])
+        if has_key(l:edit, 'data')
+            call extend(l:array, l:edit['data'], l:edit['start'])
+        endif
+    endfor
+
+    let l:legend = lsp#ui#vim#semantic#get_legend(a:server)
+    let l:tokens_in_line = s:parse_tokens_for_each_lines(l:legend, l:array)
+
+    " Save this result only if it has "resultId" parameter (i.e. supports
+    " delta uploading). if there is not, remove the buffer variable
+    if has_key(a:data['response']['result'], 'resultId')
+        call setbufvar(a:bufnr, 'previous_highlights', {
+        \   'result_id': a:data['response']['result']['resultId'],
+        \   'raw': l:array,
+        \ })
+    else
+        call setbufvar(a:bufnr, 'previous_highlights', '')
+    endif
+
+    " Replace changed lines only
+    " TODO: it can be more effective to use relative position; adding newline
+    " always triggers re-highlighting all lines under that line, but actually
+    " it's not needed.
+    for l:line in sort(keys(l:tokens_in_line))
+        if l:prev_tokens_in_line[l:line] == l:tokens_in_line[l:line]
+            continue
+        endif
+
         call s:add_highlight_for_line(a:server, a:bufnr, l:legend, str2nr(l:line), l:tokens)
     endfor
 endfunction

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -110,7 +110,7 @@ command! -nargs=? -complete=customlist,lsp#server_complete LspStopServer call ls
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspSignatureHelp call lsp#ui#vim#signature_help#get_signature_help_under_cursor()
 command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
 command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
-command! -nargs=? LspSemanticScopes call lsp#ui#vim#semantic#display_scope_tree(<args>)
+command! -nargs=? LspSemanticTokens call lsp#ui#vim#semantic#display_token_types(<args>)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
 nnoremap <plug>(lsp-code-lens) :<c-u>call lsp#ui#vim#code_lens()<cr>


### PR DESCRIPTION
This is just a experiment to support semantic tokens. This implementation provides `:LspSemanticTokens` (which is replacing `:LspSemanticScopes`) and semantic highlighting feature based on semantic tokens defined in Language Server Protocol 3.16 (<https://microsoft.github.io/language-server-protocol/specification#textDocument_semanticTokens>).

This is incomplete and won't be completed by me (at least soon). It's not guaranteed that this implementation strictly complies with LSP, though it basically works with at least `clangd` and `rust-analyzer` (in my environment).

Vim highlight groups used for coloring any kind of tokens are determined by a configuration `semantic_highlight`. It was previously used for the same purpose, but now it is a map from token types instead of TextMate scopes.