### PR TITLE
fix LspNextReference

### DIFF
--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -194,7 +194,8 @@ endfunction
 
 " Cyclically move between references by `offset` occurrences.
 function! lsp#internal#document_highlight#jump(offset) abort
-    if s:use_vim_textprops && !exists('b:lsp_reference_positions') || !exists('w:lsp_reference_positions')
+    if s:use_vim_textprops && !exists('b:lsp_reference_positions') ||
+          \ !s:use_vim_textprops && !exists('w:lsp_reference_positions')
         echohl WarningMsg
         echom 'References not available'
         echohl None

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -114,8 +114,8 @@ command! -range -nargs=? LspDocumentRangeFormatSync call lsp#internal#document_r
 command! LspImplementation call lsp#ui#vim#implementation(0, <q-mods>)
 command! LspPeekImplementation call lsp#ui#vim#implementation(1)
 command! -nargs=0 LspStatus call lsp#print_server_status()
-command! LspNextReference call lsp#internal#highlight_references#jump(+1)
-command! LspPreviousReference call lsp#internal#highlight_references#jump(-1)
+command! LspNextReference call lsp#internal#document_highlight#jump(+1)
+command! LspPreviousReference call lsp#internal#document_highlight#jump(-1)
 command! -nargs=? -complete=customlist,lsp#server_complete LspStopServer call lsp#ui#vim#stop_server(<f-args>)
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspSignatureHelp call lsp#ui#vim#signature_help#get_signature_help_under_cursor()
 command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
@@ -158,6 +158,6 @@ xnoremap <plug>(lsp-document-range-format) :<Home>silent <End>call lsp#internal#
 nnoremap <plug>(lsp-implementation) :<c-u>call lsp#ui#vim#implementation(0)<cr>
 nnoremap <plug>(lsp-peek-implementation) :<c-u>call lsp#ui#vim#implementation(1)<cr>
 nnoremap <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
-nnoremap <plug>(lsp-next-reference) :<c-u>call lsp#internal#highlight_references#jump(+1)<cr>
-nnoremap <plug>(lsp-previous-reference) :<c-u>call lsp#internal#highlight_references#jump(-1)<cr>
+nnoremap <plug>(lsp-next-reference) :<c-u>call lsp#internal#document_highlight#jump(+1)<cr>
+nnoremap <plug>(lsp-previous-reference) :<c-u>call lsp#internal#document_highlight#jump(-1)<cr>
 nnoremap <plug>(lsp-signature-help) :<c-u>call lsp#ui#vim#signature_help#get_signature_help_under_cursor()<cr>


### PR DESCRIPTION
Currently, LspNextReference and LspPreviousReference is broken.
There are 2 reasons.

1. Incorrect judgment of start condition of lsp#internal#document_highlight#jump()
    https://github.com/prabirshrestha/vim-lsp/commit/29f93922c3f4d2b074fe724cf9a5bd03814ac856
2. Correction was forgotten during rename.
   https://github.com/prabirshrestha/vim-lsp/commit/f9c8184c742baf2be3c8aaa17ef34771d44fba4f