### PR TITLE
add internal/diagnostics/state.vim

### DIFF
--- a/autoload/lsp/internal/diagnostics.vim
+++ b/autoload/lsp/internal/diagnostics.vim
@@ -1,4 +1,8 @@
 function! lsp#internal#diagnostics#_enable() abort
+    " don't even bother registering if the feature is disabled
+    if !g:lsp_diagnostics_enabled | return | endif
+
+    call lsp#internal#diagnostics#state#_enable() " Needs to be the first one to register
     call lsp#internal#diagnostics#echo#_enable()
     call lsp#internal#diagnostics#float#_enable()
 endfunction
@@ -6,4 +10,5 @@ endfunction
 function! lsp#internal#diagnostics#_disable() abort
     call lsp#internal#diagnostics#echo#_disable()
     call lsp#internal#diagnostics#float#_disable()
+    call lsp#internal#diagnsotics#state#disable() " Needs to be the last one to register
 endfunction

--- a/autoload/lsp/internal/diagnostics.vim
+++ b/autoload/lsp/internal/diagnostics.vim
@@ -10,5 +10,5 @@ endfunction
 function! lsp#internal#diagnostics#_disable() abort
     call lsp#internal#diagnostics#echo#_disable()
     call lsp#internal#diagnostics#float#_disable()
-    call lsp#internal#diagnsotics#state#disable() " Needs to be the last one to register
+    call lsp#internal#diagnsotics#state#disable() " Needs to be the last one to unregister
 endfunction

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -1,0 +1,61 @@
+let s:diagnostics_state = {} " { 'normalized_uri': { 'server_name': { uri: '', diagnostics[], version?  } } }
+
+function! lsp#internal#diagnostics#state#_enable() abort
+    " don't even bother registering if the feature is disabled
+    if !g:lsp_diagnostics_enabled | return | endif
+
+    call lsp#internal#diagnostics#state#_reset()
+
+    " TODO:
+    " * remove when buffer unloads
+    " * remove when server exits
+
+    let s:Dispose = lsp#callbag#pipe(
+        \ lsp#stream(),
+        \ lsp#callbag#filter({x->has_key(x, 'server') && has_key(x, 'response')
+        \   && get(x['response'], 'method', '') ==# 'textDocument/publishDiagnostics'}),
+        \ lsp#callbag#subscribe({
+        \   'next':{x->lsp#internal#diagnostics#state#_on_text_document_publish_diagnostics(x['server'], x['response'])}
+        \ }),
+        \ )
+endfunction
+
+function! lsp#internal#diagnostics#state#_disable() abort
+    call lsp#internal#diagnostics#state#_reset()
+    if exists('s:Dispose')
+        call s:Dispose()
+        unlet s:Dispose
+    endif
+endfunction
+
+function! lsp#internal#diagnostics#state#_reset() abort
+    let s:diagnostics_state = {}
+endfunction
+
+" callers should always treat the return value as immutable
+" @return {
+"   'servername': { 'uri': 'non normalized uri', 'diagnostics': [], 'version': 1 }
+" }
+function! lsp#internal#diagnostics#state#_get_all_diagnostics_by_server_for_uri(uri) abort
+    return get(s:diagnostics_state, lsp#utils#normalize_uri(a:uri), {})
+endfunction
+
+" callers should always treat the return value as immutable
+" @return {
+"   'normalized_uri': {
+"       'servername': { 'uri': 'non normalized uri', 'diagnostics': [], 'version': 1 }
+"   }
+" }
+function! lsp#internal#diagnostics#state#_get_all_diagnostics_by_uri() abort
+    return s:diagnostics_state
+endfunction
+
+function! lsp#internal#diagnostics#state#_on_text_document_publish_diagnostics(server, response) abort
+    if lsp#client#is_error(a:response) | return | endif
+    let l:normalized_uri = lsp#utils#normalize_uri(a:response['params']['uri'])
+    if !has_key(s:diagnostics_state, l:normalized_uri)
+        let s:diagnostics_state[l:normalized_uri] = {}
+    endif
+    let s:diagnostics_state[l:normalized_uri] = a:response
+endfunction
+

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -14,7 +14,8 @@
 "   }
 " Note: Do not remove when buffer unloads or doesn't exist since some server
 " may send diagnsotics information regardless of textDocument/didOpen.
-" TODO: remove when server exits.
+" buffer state is removed when server exists.
+" TODO: reset buffer state when server initializes.
 let s:diagnostics_state = {}
 let s:enabled = 0
 
@@ -90,7 +91,6 @@ endfunction
 
 function! s:on_exit(response) abort
     let l:server = a:response['params']['server']
-    echom l:server
     for [l:key, l:value] in items(s:diagnostics_state)
         if has_key(l:value, l:server)
             call remove(l:value, l:server)

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -46,7 +46,7 @@ function! lsp#internal#diagnostics#state#_enable() abort
         \ lsp#callbag#subscribe(),
         \ )
 
-    " TODO: Notify diagnostics update
+    call s:notify_diagnostics_update()
 endfunction
 
 function! lsp#internal#diagnostics#state#_disable() abort
@@ -56,7 +56,7 @@ function! lsp#internal#diagnostics#state#_disable() abort
         unlet s:Dispose
     endif
     call lsp#internal#diagnostics#state#_reset()
-    " TODO: Notify diagnostics update
+    call s:notify_diagnostics_update()
     let s:enabled = 0
 endfunction
 
@@ -93,10 +93,16 @@ endfunction
 
 function! s:on_exit(response) abort
     let l:server = a:response['params']['server']
+    let l:notify = 0
     for [l:key, l:value] in items(s:diagnostics_state)
         if has_key(l:value, l:server)
+            let l:notify = 1
             call remove(l:value, l:server)
         endif
     endfor
-    " TODO: Notify diagnostics update
+    if l:notify | call s:notify_diagnostics_update() | endif
+endfunction
+
+function! s:notify_diagnostics_update() abort
+    " TODO: Notify diagnostics update when all diagnostics move to relying on state
 endfunction

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -26,6 +26,8 @@ function! lsp#internal#diagnostics#state#_enable() abort
     if s:enabled | return | endif
     let s:enabled = 1
 
+    call lsp#internal#diagnostics#state#_reset()
+
     let s:Dispose = lsp#callbag#pipe(
         \ lsp#callbag#merge(
         \   lsp#callbag#pipe(

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -1,3 +1,5 @@
+" https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic
+"
 " Refer to https://github.com/microsoft/language-server-protocol/pull/1019 on normalization of urls.
 " {
 "   'normalized_uri': {

--- a/test/lsp/internal/diagnostics/state.vimspec
+++ b/test/lsp/internal/diagnostics/state.vimspec
@@ -1,0 +1,50 @@
+Describe lsp#internal#diagnostics#state
+    Before
+        %bwipeout!
+        let g:lsp_diagnostics_enabled = 1
+    End
+
+    After all
+        %bwipeout!
+        let g:lsp_diagnostics_enabled = 0
+        call lsp#internal#diagnostics#state#_disable()
+    End
+
+    It should be able to subscribe to textDocument/publishDiagnostics stream and update state correctly
+        call lsp#internal#diagnostics#state#_disable()
+        call lsp#internal#diagnostics#state#_enable()
+
+        let l:uri = 'file://some/uri'
+
+        let l:server1_response1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
+            \ {'severity': 1, 'message': 'm1', 'range': { 'start': { 'line': 1, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
+            \ ]}}
+        let l:server2_response1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
+            \ {'severity': 1, 'message': 's2', 'range': { 'start': { 'line': 2, 'character': 3, 'end': { 'line': 4, 'character': 5 } } }},
+            \ ]}}
+        let l:server1_response2 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
+            \ ]}}
+
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), {})
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_response1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_response1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+
+        call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response1 })
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_response1, 'server2': l:server2_response1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_response1, 'server2': l:server2_response1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_response2, 'server2': l:server2_response1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_response2, 'server2': l:server2_response1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+    End
+End

--- a/test/lsp/internal/diagnostics/state.vimspec
+++ b/test/lsp/internal/diagnostics/state.vimspec
@@ -46,5 +46,11 @@ Describe lsp#internal#diagnostics#state
         let l:want = {}
         let l:want[l:uri] = { 'server1': l:server1_response2, 'server2': l:server2_response1 }
         Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+
+        call lsp#stream(1, { 'server': '$vimlsp',
+            \ 'response': { 'method': '$/vimlsp/lsp_server_exit', 'params': { 'server': 'server1' } } })
+        let l:want = {}
+        let l:want[l:uri] = { 'server2': l:server2_response1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
     End
 End


### PR DESCRIPTION
This is laying out the infra for re-implementing better diagnostics. This primarily involves the following tasks
- [x] use callbag
- [x] differentiate ui vs non ui logic by introducing  `lsp#internal#diagnostics#state`
- [x] save by uri 
- [x] expose appropriate internal diagnostics apis so internal vim-lsp can interact
- [x] add unit tests
- [ ] ~~add integration tests~~ not going to work. seems like need proper async test framework.
- [x] garbage collect state when server exists. requires new `server_Exit` notification in stream.
- [ ] ~~garbage collect state when buffer unloads~~. don't do this since we can show diagnostics information of buffers that doesn't exist some servers may send them even if not loaded.
- [ ] ~~reset state when server starts~~ for now skip this for perf. can revisit later if it becomes and issue.