### PR TITLE
Add I/F to get window/workDoneProgress

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -31,6 +31,7 @@ augroup _lsp_silent_
     autocmd User lsp_float_closed silent
     autocmd User lsp_buffer_enabled silent
     autocmd User lsp_diagnostics_updated silent
+    autocmd User lsp_progress_updated silent
 augroup END
 
 function! lsp#log_verbose(...) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1124,6 +1124,10 @@ function! lsp#get_buffer_first_error_line() abort
     return lsp#ui#vim#diagnostics#get_buffer_first_error_line()
 endfunction
 
+" Return dict with window/workDoneProgress
+" { 'server': 'clangd', 'token': 'token', 'title': 'indexing', 'messages': '50/100', 'percentage': 50 }
+" 'percentage': 0.0 - 100.0, or -1.0
+" -1.0 indicates that no 'percentage' was received
 function! lsp#get_progress() abort
     return lsp#internal#work_done_progress#get_progress()
 endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1126,10 +1126,9 @@ endfunction
 
 " Return UI list with window/workDoneProgress
 " The list is most recently update order.
-" [{ 'server': 'clangd', 'token': 'backgroundIndexProgress', 'title': 'indexing', 'messages': '50/100', 'percentage': 50.0 },
-"  { 'server': 'rust-analyzer', 'token': 'rustAnalyzer/indexing', 'title': 'indexing', 'messages': '9/262 (std)', 'percentage': 3.4 }]
-" 'percentage': 0.0 - 100.0, or -1.0
-" -1.0 indicates that no 'percentage' was received
+" [{ 'server': 'clangd', 'token': 'backgroundIndexProgress', 'title': 'indexing', 'messages': '50/100', 'percentage': 50 },
+"  { 'server': 'rust-analyzer', 'token': 'rustAnalyzer/indexing', 'title': 'indexing', 'messages': '9/262 (std)', 'percentage': 3 }]
+" 'percentage': 0 - 100 or not exist
 function! lsp#get_progress() abort
     return lsp#internal#work_done_progress#get_progress()
 endfunction

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -67,6 +67,7 @@ function! lsp#enable() abort
     call lsp#internal#document_highlight#_enable()
     call lsp#internal#diagnostics#_enable()
     call lsp#internal#show_message_request#_enable()
+    call lsp#internal#work_done_progress#_enable()
     call s:register_events()
 endfunction
 
@@ -83,6 +84,7 @@ function! lsp#disable() abort
     call lsp#internal#document_highlight#_disable()
     call lsp#internal#diagnostics#_disable()
     call lsp#internal#show_message_request#_disable()
+    call lsp#internal#work_done_progress#_disable()
     call s:unregister_events()
     let s:enabled = 0
 endfunction
@@ -1120,6 +1122,10 @@ endfunction
 " Return first error line or v:null if there are no errors
 function! lsp#get_buffer_first_error_line() abort
     return lsp#ui#vim#diagnostics#get_buffer_first_error_line()
+endfunction
+
+function! lsp#get_progress() abort
+    return lsp#internal#work_done_progress#get_progress()
 endfunction
 
 function! s:merge_dict(dict_old, dict_new) abort

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1124,8 +1124,10 @@ function! lsp#get_buffer_first_error_line() abort
     return lsp#ui#vim#diagnostics#get_buffer_first_error_line()
 endfunction
 
-" Return dict with window/workDoneProgress
-" { 'server': 'clangd', 'token': 'token', 'title': 'indexing', 'messages': '50/100', 'percentage': 50 }
+" Return UI list with window/workDoneProgress
+" The list is most recently update order.
+" [{ 'server': 'clangd', 'token': 'backgroundIndexProgress', 'title': 'indexing', 'messages': '50/100', 'percentage': 50.0 },
+"  { 'server': 'rust-analyzer', 'token': 'rustAnalyzer/indexing', 'title': 'indexing', 'messages': '9/262 (std)', 'percentage': 3.4 }]
 " 'percentage': 0.0 - 100.0, or -1.0
 " -1.0 indicates that no 'percentage' was received
 function! lsp#get_progress() abort

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -18,10 +18,10 @@ function! lsp#internal#work_done_progress#_enable() abort
           \ )
 endfunction
 
-function! s:handle_work_done_progress(server, progress) abort
-    let l:value = a:progress['params']['value']
+function! s:handle_work_done_progress(server, response) abort
+    let l:value = a:response['params']['value']
     " Add the server name to distinguish the server
-    let l:token = a:server . ':' . a:progress['params']['token']
+    let l:token = a:server . ':' . a:response['params']['token']
     let l:new = {
       \ 'server': a:server,
       \ 'token': l:token,

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -8,6 +8,7 @@ function! lsp#internal#work_done_progress#_enable() abort
 
     if s:enabled | return | endif
     let s:enabled = 1
+    let s:progress_ui = []
 
     let s:Dispose = lsp#callbag#pipe(
           \ lsp#stream(),
@@ -61,6 +62,7 @@ function! lsp#internal#work_done_progress#_disable() abort
     endif
 
     let s:enabled = 0
+    let s:progress_ui = []
 endfunction
 
 function! lsp#internal#work_done_progress#get_progress() abort

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -35,7 +35,8 @@ function! s:handle_work_done_progress(server, progress) abort
         let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})
     elseif l:value['kind'] ==# 'begin'
         let l:new['title'] = l:value['title']
-        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)
+        call filter(s:progress_ui, {_, x->x['token'] !=# l:token})
+        call insert(s:progress_ui, l:new)
     elseif l:value['kind'] ==# 'report'
         let l:new['messages'] = get(l:value, 'message', '')
         if has_key(l:value, 'percentage')
@@ -46,7 +47,8 @@ function! s:handle_work_done_progress(server, progress) abort
         endif
         let l:idx = match(s:progress_ui, l:token)
         let l:new['title'] = s:progress_ui[l:idx]['title']
-        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)
+        call filter(s:progress_ui, {_, x->x['token'] !=# l:token})
+        call insert(s:progress_ui, l:new)
     endif
 endfunction
 

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -16,14 +16,14 @@ function! lsp#internal#work_done_progress#_enable() abort
           \ lsp#callbag#filter({x->has_key(x, 'response') && has_key(x['response'], 'method')
           \  && x['response']['method'] ==# '$/progress' && has_key(x['response'], 'params')
           \  && has_key(x['response']['params'], 'value') && type(x['response']['params']['value']) == type({})}),
-          \  lsp#callbag#subscribe({'next': function('s:handle_work_done_progress')})
+          \  lsp#callbag#subscribe({'next': {x->s:handle_work_done_progress(x['server'], x['response'])}})
           \ )
 endfunction
 
-function! s:handle_work_done_progress(progress) abort
-    let l:value = a:progress['response']['params']['value']
-    let s:lsp_progress['token'] = a:progress['response']['params']['token']
-    let s:lsp_progress['server'] = a:progress['server']
+function! s:handle_work_done_progress(server, progress) abort
+    let l:value = a:progress['params']['value']
+    let s:lsp_progress['token'] = a:progress['params']['token']
+    let s:lsp_progress['server'] = a:server
     if l:value['kind'] ==# 'end'
         let s:lsp_progress['messages'] = ''
         let s:lsp_progress['percentage'] = 100

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -1,3 +1,5 @@
+" https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress
+
 let s:lsp_progress = {
       \ 'server': '',
       \ 'token': '',

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -21,8 +21,7 @@ endfunction
 
 function! s:handle_work_done_progress(server, response) abort
     let l:value = a:response['params']['value']
-    " Add the server name to distinguish the server
-    let l:token = a:server . ':' . a:response['params']['token']
+    let l:token = a:response['params']['token']
     let l:new = {
       \ 'server': a:server,
       \ 'token': l:token,
@@ -33,10 +32,10 @@ function! s:handle_work_done_progress(server, response) abort
     if l:value['kind'] ==# 'end'
         let l:new['messages'] = ''
         let l:new['percentage'] = 100
-        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})
+        call filter(s:progress_ui, {_, x->x['token'] !=# l:token || x['server'] !=# a:server})
     elseif l:value['kind'] ==# 'begin'
         let l:new['title'] = l:value['title']
-        call filter(s:progress_ui, {_, x->x['token'] !=# l:token})
+        call filter(s:progress_ui, {_, x->x['token'] !=# l:token || x['server'] !=# a:server})
         call insert(s:progress_ui, l:new)
     elseif l:value['kind'] ==# 'report'
         let l:new['messages'] = get(l:value, 'message', '')
@@ -48,7 +47,7 @@ function! s:handle_work_done_progress(server, response) abort
         endif
         let l:idx = match(s:progress_ui, l:token)
         let l:new['title'] = s:progress_ui[l:idx]['title']
-        call filter(s:progress_ui, {_, x->x['token'] !=# l:token})
+        call filter(s:progress_ui, {_, x->x['token'] !=# l:token || x['server'] !=# a:server})
         call insert(s:progress_ui, l:new)
     endif
     doautocmd <nomodeline> User lsp_progress_updated

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -1,0 +1,45 @@
+let s:lsp_progress = {
+      \ 'server': '',
+      \ 'token': '',
+      \ 'title': '',
+      \ 'messages': '',
+      \ 'percentage': 100,
+      \ }
+
+function! lsp#internal#work_done_progress#_enable() abort
+    if !g:lsp_work_done_progress_enabled | return | endif
+
+    let s:Dispose = lsp#callbag#pipe(
+          \ lsp#stream(),
+          \ lsp#callbag#filter({x->has_key(x, 'response') && has_key(x['response'], 'method')
+          \  && x['response']['method'] ==# '$/progress' && has_key(x['response'], 'params')
+          \  && has_key(x['response']['params'], 'value') && type(x['response']['params']['value']) == type({})}),
+          \  lsp#callbag#subscribe({'next': function('s:handle_work_done_progress')})
+          \ )
+endfunction
+
+function! s:handle_work_done_progress(progress) abort
+    let l:value = a:progress['response']['params']['value']
+    let s:lsp_progress['token'] = a:progress['response']['params']['token']
+    let s:lsp_progress['server'] = a:progress['server']
+    if l:value['kind'] ==# 'end'
+        let s:lsp_progress['messages'] = ''
+        let s:lsp_progress['percentage'] = 100
+    elseif l:value['kind'] ==# 'begin'
+        let s:lsp_progress['title'] = l:value['title']
+    elseif l:value['kind'] ==# 'report'
+        let s:lsp_progress['messages'] = get(l:value, 'message', '')
+        let s:lsp_progress['percentage'] = get(l:value, 'percentage', '')
+    endif
+endfunction
+
+function! lsp#internal#work_done_progress#_disable() abort
+    if exists('s:Dispose')
+        call s:Dispose()
+        unlet s:Dispose
+    endif
+endfunction
+
+function! lsp#internal#work_done_progress#get_progress() abort
+    return s:lsp_progress
+endfunction

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -51,6 +51,7 @@ function! s:handle_work_done_progress(server, response) abort
         call filter(s:progress_ui, {_, x->x['token'] !=# l:token})
         call insert(s:progress_ui, l:new)
     endif
+    doautocmd <nomodeline> User lsp_progress_updated
 endfunction
 
 function! lsp#internal#work_done_progress#_disable() abort

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -1,12 +1,6 @@
 " https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress
 
-let s:lsp_progress = {
-      \ 'server': '',
-      \ 'token': '',
-      \ 'title': '',
-      \ 'messages': '',
-      \ 'percentage': 100,
-      \ }
+let s:progress_ui = []
 let s:enabled = 0
 
 function! lsp#internal#work_done_progress#_enable() abort
@@ -26,16 +20,29 @@ endfunction
 
 function! s:handle_work_done_progress(server, progress) abort
     let l:value = a:progress['params']['value']
-    let s:lsp_progress['token'] = a:progress['params']['token']
-    let s:lsp_progress['server'] = a:server
+    " Add the server name to distinguish the server
+    let l:token = a:server . ':' . a:progress['params']['token']
+    let l:new = {
+      \ 'server': a:server,
+      \ 'token': l:token,
+      \ 'title': '',
+      \ 'messages': '',
+      \ 'percentage': -1,
+      \ }
+
     if l:value['kind'] ==# 'end'
-        let s:lsp_progress['messages'] = ''
-        let s:lsp_progress['percentage'] = 100.0
+        let l:new['messages'] = ''
+        let l:new['percentage'] = 100.0
+        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})
     elseif l:value['kind'] ==# 'begin'
-        let s:lsp_progress['title'] = l:value['title']
+        let l:new['title'] = l:value['title']
+        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)
     elseif l:value['kind'] ==# 'report'
-        let s:lsp_progress['messages'] = get(l:value, 'message', '')
-        let s:lsp_progress['percentage'] = get(l:value, 'percentage', -1.0)
+        let l:new['messages'] = get(l:value, 'message', '')
+        let l:new['percentage'] = get(l:value, 'percentage', -1.0)
+        let l:idx = match(s:progress_ui, l:token)
+        let l:new['title'] = s:progress_ui[l:idx]['title']
+        let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)
     endif
 endfunction
 
@@ -51,5 +58,5 @@ function! lsp#internal#work_done_progress#_disable() abort
 endfunction
 
 function! lsp#internal#work_done_progress#get_progress() abort
-    return s:lsp_progress
+    return s:progress_ui
 endfunction

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -30,12 +30,12 @@ function! s:handle_work_done_progress(server, progress) abort
     let s:lsp_progress['server'] = a:server
     if l:value['kind'] ==# 'end'
         let s:lsp_progress['messages'] = ''
-        let s:lsp_progress['percentage'] = 100
+        let s:lsp_progress['percentage'] = 100.0
     elseif l:value['kind'] ==# 'begin'
         let s:lsp_progress['title'] = l:value['title']
     elseif l:value['kind'] ==# 'report'
         let s:lsp_progress['messages'] = get(l:value, 'message', '')
-        let s:lsp_progress['percentage'] = get(l:value, 'percentage', '')
+        let s:lsp_progress['percentage'] = get(l:value, 'percentage', -1.0)
     endif
 endfunction
 

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -7,9 +7,13 @@ let s:lsp_progress = {
       \ 'messages': '',
       \ 'percentage': 100,
       \ }
+let s:enabled = 0
 
 function! lsp#internal#work_done_progress#_enable() abort
     if !g:lsp_work_done_progress_enabled | return | endif
+
+    if s:enabled | return | endif
+    let s:enabled = 1
 
     let s:Dispose = lsp#callbag#pipe(
           \ lsp#stream(),
@@ -36,10 +40,14 @@ function! s:handle_work_done_progress(server, progress) abort
 endfunction
 
 function! lsp#internal#work_done_progress#_disable() abort
+    if !s:enabled | return | endif
+
     if exists('s:Dispose')
         call s:Dispose()
         unlet s:Dispose
     endif
+
+    let s:enabled = 0
 endfunction
 
 function! lsp#internal#work_done_progress#get_progress() abort

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -26,11 +26,11 @@ function! s:handle_work_done_progress(server, response) abort
       \ 'server': a:server,
       \ 'token': l:token,
       \ 'title': '',
-      \ 'messages': '',
+      \ 'message': '',
       \ }
 
     if l:value['kind'] ==# 'end'
-        let l:new['messages'] = ''
+        let l:new['message'] = ''
         let l:new['percentage'] = 100
         call filter(s:progress_ui, {_, x->x['token'] !=# l:token || x['server'] !=# a:server})
     elseif l:value['kind'] ==# 'begin'
@@ -38,7 +38,7 @@ function! s:handle_work_done_progress(server, response) abort
         call filter(s:progress_ui, {_, x->x['token'] !=# l:token || x['server'] !=# a:server})
         call insert(s:progress_ui, l:new)
     elseif l:value['kind'] ==# 'report'
-        let l:new['messages'] = get(l:value, 'message', '')
+        let l:new['message'] = get(l:value, 'message', '')
         if has_key(l:value, 'percentage')
             " l:value['percentage'] is uinteger in specification.
             " But some implementation return float. (e.g. clangd11)

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -27,19 +27,23 @@ function! s:handle_work_done_progress(server, progress) abort
       \ 'token': l:token,
       \ 'title': '',
       \ 'messages': '',
-      \ 'percentage': -1,
       \ }
 
     if l:value['kind'] ==# 'end'
         let l:new['messages'] = ''
-        let l:new['percentage'] = 100.0
+        let l:new['percentage'] = 100
         let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})
     elseif l:value['kind'] ==# 'begin'
         let l:new['title'] = l:value['title']
         let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)
     elseif l:value['kind'] ==# 'report'
         let l:new['messages'] = get(l:value, 'message', '')
-        let l:new['percentage'] = get(l:value, 'percentage', -1.0)
+        if has_key(l:value, 'percentage')
+            " l:value['percentage'] is uinteger in specification.
+            " But some implementation return float. (e.g. clangd11)
+            " So we round it.
+            let l:new['percentage'] = float2nr(l:value['percentage'] + 0.5)
+        endif
         let l:idx = match(s:progress_ui, l:token)
         let l:new['title'] = s:progress_ui[l:idx]['title']
         let s:progress_ui = filter(s:progress_ui, {_, x->x['token'] !=# l:token})->insert(l:new)

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -115,6 +115,7 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp_server_exit                       |lsp_server_exit|
       lsp_buffer_enabled                    |lsp_buffer_enabled|
       lsp_diagnostics_updated               |lsp_diagnostics_updated|
+      lsp_progress_updated                  |lsp_progress_updated|
     Mappings                              |vim-lsp-mappings|
        <plug>(lsp-preview-close)            |<plug>(lsp-preview-close)|
        <plug>(lsp-preview-focus)            |<plug>(lsp-preview-focus)|
@@ -1500,6 +1501,10 @@ processed by vim-lsp.
     autocmd User lsp_diagnostics_updated call DoSomething()
   augroup END
 <
+lsp_progress_updated                                  *lsp_progress_updated*
+
+This autocommand is run after every time after progress updated and
+processed by vim-lsp. Used for statusline plugins.
 
 ==============================================================================
 Mappings                                                  *vim-lsp-mappings*
@@ -1662,7 +1667,7 @@ You can check if semantic highlighting is enabled by running: >
     echo lsp#ui#vim#semantic#is_enabled()
 <
 Before you can use the semantic highlighting feature, you will also need to
-link language server semantic scopes to Vim highlight groups. For example, you
+link language server semantic scopes to Vim highlight groups. For example, yo
 have to specify that function calls need to be highlighted using the
 |Identifier| Vim group.
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1667,7 +1667,7 @@ You can check if semantic highlighting is enabled by running: >
     echo lsp#ui#vim#semantic#is_enabled()
 <
 Before you can use the semantic highlighting feature, you will also need to
-link language server semantic scopes to Vim highlight groups. For example, yo
+link language server semantic scopes to Vim highlight groups. For example, you
 have to specify that function calls need to be highlighted using the
 |Identifier| Vim group.
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -66,6 +66,7 @@ CONTENTS                                                  *vim-lsp-contents*
                               |lsp#utils#find_nearest_parent_file_directory()|
       lsp#get_buffer_diagnostics_counts() |lsp#get_buffer_diagnostics_counts()|
       lsp#get_buffer_first_error_line()   |lsp#get_buffer_first_error_line()|
+      lsp#get_progress()                  |lsp#get_progress()|
     Commands                              |vim-lsp-commands|
       LspCodeAction                         |:LspCodeAction|
       LspCodeActionSync                     |:LspCodeActionSync|
@@ -1179,6 +1180,23 @@ lsp#get_buffer_first_error_line()        *lsp#get_buffer_first_error_line()*
 Get line number of first error in current buffer.
 
     Returns |Number| or |v:null| if there are no errors.
+
+lsp#get_progress()                       *lsp#get_progress()*
+
+    Return UI |List| of |Dict| with window/workDoneProgress
+    The |List| is most recently update order.
+    The |Dict| has keys as follows.
+    * server
+	Type: |String|
+    * token
+	Type: |String|
+    * title
+	Type: |String|
+    * messages
+	Type: |String|
+    * percentage
+	Type: |Number|
+	0 - 100 or not exist
 
 ==============================================================================
 Commands                                                  *vim-lsp-commands*

--- a/test/lsp/utils/work_done_progress.vimspec
+++ b/test/lsp/utils/work_done_progress.vimspec
@@ -18,11 +18,11 @@ Describe lsp#internal#work_done_progress
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+            \ [{'message': '', 'token': 'token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': 'test message', 'token': 'server1:token text', 'percentage': 50, 'title': 'title', 'server': 'server1'}])
+            \ [{'message': 'test message', 'token': 'token text', 'percentage': 50, 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
@@ -41,31 +41,31 @@ Describe lsp#internal#work_done_progress
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+            \ [{'message': '', 'token': 'token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response1 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': '', 'token': 'server2:server2_token', 'title': 'title2', 'server': 'server2'},
-            \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+            \ [{'message': '', 'token': 'server2_token', 'title': 'title2', 'server': 'server2'},
+            \  {'message': '', 'token': 'token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response2 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'},
-            \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+            \ [{'message': 'msg2', 'token': 'server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'},
+            \  {'message': '', 'token': 'token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':50, 'title': 'title1', 'server': 'server1'},
-            \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+            \ [{'message': 'msg1', 'token': 'token text', 'percentage':50, 'title': 'title1', 'server': 'server1'},
+            \  {'message': 'msg2', 'token': 'server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':90, 'title': 'title1', 'server': 'server1'},
-            \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+            \ [{'message': 'msg1', 'token': 'token text', 'percentage':90, 'title': 'title1', 'server': 'server1'},
+            \  {'message': 'msg2', 'token': 'server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response4 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+            \ [{'message': 'msg2', 'token': 'server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response3 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
@@ -80,11 +80,11 @@ Describe lsp#internal#work_done_progress
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+            \ [{'message': '', 'token': 'token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(),
-            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+            \ [{'message': '', 'token': 'token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])

--- a/test/lsp/utils/work_done_progress.vimspec
+++ b/test/lsp/utils/work_done_progress.vimspec
@@ -1,0 +1,101 @@
+Describe lsp#internal#work_done_progress
+    Before
+        let g:lsp_work_done_progress_enabled = 1
+        call lsp#internal#work_done_progress#_enable()
+    End
+
+    After all
+        let g:lsp_work_done_progress_enabled = 0
+        call lsp#internal#work_done_progress#_disable()
+    End
+
+    It should be able to subscribe to $progress stream
+        call lsp#internal#work_done_progress#_disable()
+        call lsp#internal#work_done_progress#_enable()
+
+        let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title'}}}
+        let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':50,'message':'test message','kind':'report'}}}
+        let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'end'}}}
+
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': 'test message', 'token': 'server1:token text', 'percentage': 50, 'title': 'title', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+    End
+
+    It should be able to subscribe to multi $progress stream
+        call lsp#internal#work_done_progress#_disable()
+        call lsp#internal#work_done_progress#_enable()
+
+        let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title1'}}}
+        let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':50,'message':'msg1','kind':'report'}}}
+        let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':90,'message':'msg1','kind':'report'}}}
+        let l:server1_response4 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'end'}}}
+        let l:server2_response1 = {'method': '$/progress', 'params':{'token':'server2_token','value':{'kind':'begin', 'title':'title2'}}}
+        let l:server2_response2 = {'method': '$/progress', 'params':{'token':'server2_token','value':{'percentage':0,'message':'msg2','kind':'report'}}}
+        let l:server2_response3 = {'method': '$/progress', 'params':{'token':'server2_token','value':{'kind':'end'}}}
+
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response1 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': '', 'token': 'server2:server2_token', 'title': 'title2', 'server': 'server2'},
+            \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response2 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'},
+            \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':50, 'title': 'title1', 'server': 'server1'},
+            \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':90, 'title': 'title1', 'server': 'server1'},
+            \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response4 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
+
+        call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response3 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+    End
+
+    It should be returned correctly even if percentage and message do not exist.
+        call lsp#internal#work_done_progress#_disable()
+        call lsp#internal#work_done_progress#_enable()
+
+        let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title'}}}
+        let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'report'}}}
+        let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'end'}}}
+
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+            \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
+        Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
+    End
+End

--- a/test/lsp/utils/work_done_progress.vimspec
+++ b/test/lsp/utils/work_done_progress.vimspec
@@ -1,18 +1,15 @@
 Describe lsp#internal#work_done_progress
-    Before
+    Before each
         let g:lsp_work_done_progress_enabled = 1
         call lsp#internal#work_done_progress#_enable()
     End
 
-    After all
+    After each
         let g:lsp_work_done_progress_enabled = 0
         call lsp#internal#work_done_progress#_disable()
     End
 
     It should be able to subscribe to $progress stream
-        call lsp#internal#work_done_progress#_disable()
-        call lsp#internal#work_done_progress#_enable()
-
         let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title'}}}
         let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':50,'message':'test message','kind':'report'}}}
         let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'end'}}}
@@ -20,11 +17,11 @@ Describe lsp#internal#work_done_progress
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': 'test message', 'token': 'server1:token text', 'percentage': 50, 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
@@ -32,9 +29,6 @@ Describe lsp#internal#work_done_progress
     End
 
     It should be able to subscribe to multi $progress stream
-        call lsp#internal#work_done_progress#_disable()
-        call lsp#internal#work_done_progress#_enable()
-
         let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title1'}}}
         let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':50,'message':'msg1','kind':'report'}}}
         let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'percentage':90,'message':'msg1','kind':'report'}}}
@@ -46,31 +40,31 @@ Describe lsp#internal#work_done_progress
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response1 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': '', 'token': 'server2:server2_token', 'title': 'title2', 'server': 'server2'},
             \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response2 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'},
             \  {'messages': '', 'token': 'server1:token text', 'title': 'title1', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':50, 'title': 'title1', 'server': 'server1'},
             \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': 'msg1', 'token': 'server1:token text', 'percentage':90, 'title': 'title1', 'server': 'server1'},
             \  {'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response4 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': 'msg2', 'token': 'server2:server2_token', 'percentage':0, 'title': 'title2', 'server': 'server2'}])
 
         call lsp#stream(1, { 'server': 'server2', 'response': l:server2_response3 })
@@ -78,9 +72,6 @@ Describe lsp#internal#work_done_progress
     End
 
     It should be returned correctly even if percentage and message do not exist.
-        call lsp#internal#work_done_progress#_disable()
-        call lsp#internal#work_done_progress#_enable()
-
         let l:server1_response1 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'begin', 'title':'title'}}}
         let l:server1_response2 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'report'}}}
         let l:server1_response3 = {'method': '$/progress', 'params':{'token':'token text','value':{'kind':'end'}}}
@@ -88,11 +79,11 @@ Describe lsp#internal#work_done_progress
         Assert Equals(lsp#internal#work_done_progress#get_progress(), [])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
-        Assert Equals(lsp#internal#work_done_progress#get_progress(), 
+        Assert Equals(lsp#internal#work_done_progress#get_progress(),
             \ [{'messages': '', 'token': 'server1:token text', 'title': 'title', 'server': 'server1'}])
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response3 })


### PR DESCRIPTION
- sample screen shot
![simplescreenrecorder-2020-12-28_00 27 30](https://user-images.githubusercontent.com/23257067/103174258-eee84280-48a3-11eb-9448-9da9ee8d372e.gif)

Implement lsp#get_progress() for statusline plugins.
I initially created the following PR, but decided to introduce it to CORE.
https://github.com/mattn/vim-lsp-settings/pull/361

relating PR
prabirshrestha/vim-lsp#970

vim-airline sample implementation
https://github.com/micchy326/vim-airline

- remaining tasks
  * [X]  Write documents
  * [X] Consider the case where multiple servers are registered.
         https://github.com/mattn/vim-lsp-settings/pull/361#discussion_r548898953