### PR TITLE
add $/vimlsp/lsp_server_exit notification to the stream

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -761,6 +761,8 @@ function! s:on_exit(server_name, id, data, event) abort
         if has_key(l:server, 'init_result')
             unlet l:server['init_result']
         endif
+        call lsp#stream(1, { 'server': '$vimlsp',
+            \ 'response': { 'method': '$/vimlsp/lsp_server_exit', 'params': { 'server': a:server_name } } })
         doautocmd <nomodeline> User lsp_server_exit
     endif
 endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1097,6 +1097,24 @@ au User lsp_setup call lsp#callbag#pipe(
     \ )
 <
 
+Custom vim-lsp notifications streams:
+vimp-lsp events mimic lsp server notifications.
+* `server` is always `$vimlsp`.
+* `response` `method` is always prefixed with ``$/vimlsp/`
+
+
+|$/vimlsp/lsp_server_exit|
+    This is similar to |lsp_server_exit| autocommand.
+
+    Example: >
+	{
+	  "server": "$vimlsp",
+	  "response": {
+	    "method": "$/vimlsp/lsp_server_exit",
+	    "params": { "server": "$vimlsp" }
+	  }
+	}
+<
 lsp#stop_server({name-of-server})                        *lsp#stop_server()*
 
 Used to stop the server.


### PR DESCRIPTION
`autocommands` doesnt' allows us to pass params so add a new stream notification when a server exists so others can subscribe too.

