### PR TITLE
add buffer state of disabled diagnostics state

### DIFF
--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -19,6 +19,18 @@
 " buffer state is removed when server exists.
 " TODO: reset buffer state when server initializes.
 let s:diagnostics_state = {}
+
+" Contains dictionary of buffers that have been asked to disable.
+" We always update the s:diagnostics_state regardless of disabled buffer
+" state. Instead all diagnotics UI extensions should check for this state and
+" ignore diagnostics if it is disabled for buffer.
+" { bufnr: 1 }
+" if key exist buffer should be disabled no matter the value.
+" if key doesn't exist buffer is enabled
+let s:diagnostics_disabled_buffers = {}
+
+" internal state for whether it is enabled or not to avoid multiple
+" subscriptions
 let s:enabled = 0
 
 function! lsp#internal#diagnostics#state#_enable() abort
@@ -64,6 +76,7 @@ endfunction
 
 function! lsp#internal#diagnostics#state#_reset() abort
     let s:diagnostics_state = {}
+    let s:diagnostics_disabled_buffers = {}
 endfunction
 
 " callers should always treat the return value as immutable
@@ -107,4 +120,22 @@ endfunction
 
 function! s:notify_diagnostics_update() abort
     " TODO: Notify diagnostics update when all diagnostics move to relying on state
+endfunction
+
+function! lsp#internal#diagnostics#state#_enable_for_buffer(bufnr) abort
+    if has_key(s:diagnostics_disabled_buffers, a:bufnr)
+        call remove(s:diagnostics_disabled_buffers, a:bufnr)
+        call s:notify_diagnostics_update()
+    endif
+endfunction
+
+function! lsp#internal#diagnostics#state#_disable_for_buffer(bufnr) abort
+    if !has_key(s:diagnostics_disabled_buffers, a:bufnr)
+        let s:diagnostics_disabled_buffers[a:bufnr] = 1
+        call s:notify_diagnostics_update()
+    endif
+endfunction
+
+function! lsp#internal#diagnostics#state#_is_enabled_for_buffer(bufnr) abort
+    return !has_key(s:diagnostics_disabled_buffers, a:bufnr)
 endfunction

--- a/test/lsp/internal/diagnostics/state.vimspec
+++ b/test/lsp/internal/diagnostics/state.vimspec
@@ -2,6 +2,8 @@ Describe lsp#internal#diagnostics#state
     Before
         %bwipeout!
         let g:lsp_diagnostics_enabled = 1
+        call lsp#internal#diagnostics#state#_disable()
+        call lsp#internal#diagnostics#state#_enable()
     End
 
     After all
@@ -11,9 +13,6 @@ Describe lsp#internal#diagnostics#state
     End
 
     It should be able to subscribe to textDocument/publishDiagnostics stream and update state correctly
-        call lsp#internal#diagnostics#state#_disable()
-        call lsp#internal#diagnostics#state#_enable()
-
         let l:uri = 'file://some/uri'
 
         let l:server1_response1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
@@ -52,5 +51,20 @@ Describe lsp#internal#diagnostics#state
         let l:want = {}
         let l:want[l:uri] = { 'server2': l:server2_response1 }
         Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+    End
+
+
+    It should correctly return the state of buffer
+        call lsp#internal#diagnostics#state#_disable()
+        call lsp#internal#diagnostics#state#_enable()
+
+        let l:bufnr = bufnr('%')
+        Assert True(lsp#internal#diagnostics#state#_is_enabled_for_buffer(l:bufnr))
+
+        call lsp#internal#diagnostics#state#_disable_for_buffer(l:bufnr)
+        Assert False(lsp#internal#diagnostics#state#_is_enabled_for_buffer(l:bufnr))
+
+        call lsp#internal#diagnostics#state#_enable_for_buffer(l:bufnr)
+        Assert True(lsp#internal#diagnostics#state#_is_enabled_for_buffer(l:bufnr))
     End
 End


### PR DESCRIPTION
This is part of [Diagnostics Revamp](https://github.com/prabirshrestha/vim-lsp/discussions/977).

Helps for issues like these related to easymotion. https://github.com/prabirshrestha/vim-lsp/issues/915

Currently this make sure the internal diagnostics state is up to date. It is still up to the ui implementations to respect the flag since `get_all_diagnostics*` function doesn't respect it for perf reasons. Updates to ui respecting this flag will come in separate PRs.

When I start updating UI to respect this I will expose a public documented api which will look something like this.

```vim
autocmd User EasyMotionPromptBegin call lsp#disable_diagnostics_for_buffer(bufnr('%'))<CR>
autocmd User EasyMotionPromptEnd call lsp#enable_diagnostics_for_buffer(bufnr('%'))<CR>
```

While I could have a method to disable per diagnsotics ui it made sense to do this for entire diagnostics features.