### PR TITLE
Diagnostics for all buffers

### DIFF
--- a/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
+++ b/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
@@ -1,0 +1,21 @@
+" options = {
+"   buffers: '' . bufnr('%')     " optional, '*' for all buffers
+" }
+function! lsp#internal#diagnostics#document_diagnostics_command#do(options) abort
+    if !g:lsp_diagnostics_enabled
+        call lsp#utils#error(':LspDocumentDiagnostics', 'g:lsp_diagnostics_enabled must be enabled')
+        return
+    endif
+
+    let l:buffers = get(a:options, 'buffers', bufnr('%'))
+    if type(l:buffers) == type('')
+        let l:buffers = split(l:buffers, ',')
+    endif
+
+    for l:buffer in l:buffers
+    endfor
+
+    echom json_encode(l:buffers)
+endfunction
+
+" :LspDocumentDiagnostics --ui=quickfix --buffers=*

--- a/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
+++ b/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
@@ -22,9 +22,11 @@ function! lsp#internal#diagnostics#document_diagnostics_command#do(options) abor
 
     let l:result = []
     for [l:uri, l:value] in items(l:filtered_diagnostics)
-        for l:diagnostics in values(l:value)
-            let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list({ 'response': l:diagnostics })
-        endfor
+        if lsp#internal#diagnostics#state#_is_enabled_for_buffer(bufnr(lsp#utils#uri_to_path(l:uri)))
+            for l:diagnostics in values(l:value)
+                let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list({ 'response': l:diagnostics })
+            endfor
+        endif
     endfor
 
     if empty(l:result)

--- a/autoload/lsp/ui/vim/diagnostics.vim
+++ b/autoload/lsp/ui/vim/diagnostics.vim
@@ -36,37 +36,6 @@ function! lsp#ui#vim#diagnostics#get_document_diagnostics(bufnr) abort
     return get(s:diagnostics, lsp#utils#get_buffer_uri(a:bufnr), {})
 endfunction
 
-function! lsp#ui#vim#diagnostics#document_diagnostics() abort
-    if !g:lsp_diagnostics_enabled
-        call lsp#utils#error('Diagnostics manually disabled -- g:lsp_diagnostics_enabled = 0')
-        return
-    endif
-
-    let l:uri = lsp#utils#get_buffer_uri()
-
-    let [l:has_diagnostics, l:diagnostics] = s:get_diagnostics(l:uri)
-    if !l:has_diagnostics
-        call lsp#utils#error('No diagnostics results')
-        return
-    endif
-
-    let l:result = []
-    for l:data in values(l:diagnostics)
-        let l:result += lsp#ui#vim#utils#diagnostics_to_loc_list(l:data)
-    endfor
-
-    call setloclist(0, l:result)
-
-    " autocmd FileType qf setlocal wrap
-
-    if empty(l:result)
-        call lsp#utils#error('No diagnostics results found')
-    else
-        echo 'Retrieved diagnostics results'
-        botright lopen
-    endif
-endfunction
-
 " Returns a diagnostic object, or empty dictionary if no diagnostics are available.
 "
 " Note: Consider renaming this method (s/diagnostics/diagnostic) to make

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -131,7 +131,6 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
         endfor
     endif
 
-
     return l:list
 endfunction
 

--- a/autoload/lsp/utils/args.vim
+++ b/autoload/lsp/utils/args.vim
@@ -1,7 +1,9 @@
 function! lsp#utils#args#_parse(args, opt) abort
     let l:result = {}
     for l:item in split(a:args, ' ')
-        let [l:key, l:value] = split(l:item, '=')
+        let l:parts = split(l:item, '=')
+        let l:key = l:parts[0]
+        let l:value = get(l:parts, 1, '')
         let l:key = l:key[2:]
         if has_key(a:opt, l:key)
             if has_key(a:opt[l:key], 'type')

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1228,7 +1228,17 @@ Same as |:LspCodeLens| but synchronous.
 
 LspDocumentDiagnostics                             *:LspDocumentDiagnostics*
 
-Gets the current document diagnostics.
+Gets the document diagnostics and opens in |location-list|. By default
+diagnostics are filtered for current buffer.
+
+Arguments:
+
+    --buffers	Defaults to empty string, i.e. shows diagnostics for current
+		buffer. To show diagnotics for all buffer use `--buffers=*`.
+
+    Example: >
+	:LspDocumentDiagnostics
+	:LspDocumentDiagnostics --buffers=*
 
 LspDeclaration                                             *:LspDeclaration*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -86,7 +86,7 @@ command! LspDefinition call lsp#ui#vim#definition(0, <q-mods>)
 command! LspPeekDefinition call lsp#ui#vim#definition(1)
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
 command! -nargs=? LspDocumentDiagnostics call lsp#internal#diagnostics#document_diagnostics_command#do(
-            \ extend({'buffers': '' . bufnr('%')}, lsp#utils#args#_parse(<q-args>, {
+            \ extend({}, lsp#utils#args#_parse(<q-args>, {
             \   'buffers': {'type': type('')},
             \ })))
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover#get_hover_under_cursor()

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -85,7 +85,10 @@ command! LspPeekDeclaration call lsp#ui#vim#declaration(1)
 command! LspDefinition call lsp#ui#vim#definition(0, <q-mods>)
 command! LspPeekDefinition call lsp#ui#vim#definition(1)
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
-command! LspDocumentDiagnostics call lsp#ui#vim#diagnostics#document_diagnostics()
+command! -nargs=? LspDocumentDiagnostics call lsp#internal#diagnostics#document_diagnostics_command#do(
+            \ extend({'buffers': '' . bufnr('%')}, lsp#utils#args#_parse(<q-args>, {
+            \   'buffers': {'type': type('')},
+            \ })))
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#ui#vim#hover#get_hover_under_cursor()
 command! -nargs=* LspNextError call lsp#ui#vim#diagnostics#next_error(<f-args>)
 command! -nargs=* LspPreviousError call lsp#ui#vim#diagnostics#previous_error(<f-args>)

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -132,7 +132,7 @@ nnoremap <plug>(lsp-peek-declaration) :<c-u>call lsp#ui#vim#declaration(1)<cr>
 nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition(0)<cr>
 nnoremap <plug>(lsp-peek-definition) :<c-u>call lsp#ui#vim#definition(1)<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
-nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#ui#vim#diagnostics#document_diagnostics()<cr>
+nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#internal#diagnostics#document_diagnostics_command#do({})<cr>
 nnoremap <plug>(lsp-hover) :<c-u>call lsp#ui#vim#hover#get_hover_under_cursor()<cr>
 nnoremap <plug>(lsp-preview-close) :<c-u>call lsp#ui#vim#output#closepreview()<cr>
 nnoremap <plug>(lsp-preview-focus) :<c-u>call lsp#ui#vim#output#focuspreview()<cr>

--- a/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
+++ b/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
@@ -1,0 +1,52 @@
+Describe lsp#internal#diagnostics#document_diagnostics_command
+    Before
+        %bwipeout!
+        let g:lsp_diagnostics_enabled = 1
+        call lsp#internal#diagnostics#state#_disable()
+        call lsp#internal#diagnostics#state#_enable()
+    End
+
+    After all
+        %bwipeout!
+        let g:lsp_diagnostics_enabled = 0
+        call lsp#internal#diagnostics#state#_disable()
+    End
+
+    It should be able to show document diagnostics for a buffer
+        normal! m'
+        execute printf('keepalt keepjumps edit %s', lsp#test#projectdir('rust') . '/src/documentdiagnostics.rs')
+        let l:uri = lsp#utils#get_buffer_uri()
+        let l:uri2 = l:uri . '2'
+
+        let l:server1_response1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
+            \ {'severity': 1, 'message': 'm1', 'range': { 'start': { 'line': 1, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
+            \ ]}}
+
+        let l:server1_response2 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri2, 'diagnostics': [
+            \ {'severity': 1, 'message': 'm3', 'range': { 'start': { 'line': 2, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
+            \ {'severity': 1, 'message': 'm4', 'range': { 'start': { 'line': 3, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
+            \ ]}}
+
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
+        call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response2 })
+
+        execute ':LspDocumentDiagnostics'
+        let l:result = getloclist(0)
+        Assert Equals(l:result, [
+            \ {'lnum': 2, 'bufnr': 3, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': 3, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
+            \ ])
+        execute ':lclose'
+
+        execute ':LspDocumentDiagnostics --buffers=*'
+        let l:result = getloclist(0)
+        Assert Equals(l:result, [
+            \ {'lnum': 2, 'bufnr': 3, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': 3, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
+            \ {'lnum': 3, 'bufnr': 5, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m3'},
+            \ {'lnum': 4, 'bufnr': 5, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m4'},
+            \ ])
+        execute ':lclose'
+    End
+End

--- a/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
+++ b/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
@@ -17,6 +17,7 @@ Describe lsp#internal#diagnostics#document_diagnostics_command
         execute printf('keepalt keepjumps edit %s', lsp#test#projectdir('rust') . '/src/documentdiagnostics.rs')
         let l:uri = lsp#utils#get_buffer_uri()
         let l:uri2 = l:uri . '2'
+        let l:bufnr = bufnr('%')
 
         let l:server1_response1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': [
             \ {'severity': 1, 'message': 'm1', 'range': { 'start': { 'line': 1, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
@@ -34,18 +35,19 @@ Describe lsp#internal#diagnostics#document_diagnostics_command
         execute ':LspDocumentDiagnostics'
         let l:result = getloclist(0)
         Assert Equals(l:result, [
-            \ {'lnum': 2, 'bufnr': 3, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
-            \ {'lnum': 2, 'bufnr': 3, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
             \ ])
         execute ':lclose'
 
         execute ':LspDocumentDiagnostics --buffers=*'
         let l:result = getloclist(0)
+        " +2 for bufnr because original bufnr + loclist + new unopened file
         Assert Equals(l:result, [
-            \ {'lnum': 2, 'bufnr': 3, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
-            \ {'lnum': 2, 'bufnr': 3, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
-            \ {'lnum': 3, 'bufnr': 5, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m3'},
-            \ {'lnum': 4, 'bufnr': 5, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m4'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
+            \ {'lnum': 3, 'bufnr': l:bufnr + 2, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m3'},
+            \ {'lnum': 4, 'bufnr': l:bufnr + 2, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m4'},
             \ ])
         execute ':lclose'
     End

--- a/test/testproject-rust/src/documentdiagnostics.rs
+++ b/test/testproject-rust/src/documentdiagnostics.rs
@@ -1,0 +1,11 @@
+fn document_diagnostics() {
+    unimplemented!();
+}
+
+fn broken1(
+    print
+}
+
+fn broken2()
+    broken(1);
+}


### PR DESCRIPTION
This is part of [Diagnostics Revamp](https://github.com/prabirshrestha/vim-lsp/discussions/977) and [vim-lsp 2020](https://github.com/prabirshrestha/vim-lsp/issues/624)

This introduces a new flag to show diagnostics for all buffer using `:LspDocumentDiagnostics --buffers=*`. Documentation has more details.

- [x] implement support for show all document diagnostics for all buffers and servers
- [x] implement support for showing only the default buffer diagnostics
- [x] update documentation
- [x] respect `disabled buffer`
- [x] add unit tests
- [x] remove old code

![image](https://user-images.githubusercontent.com/287744/103188773-ab2f1200-487e-11eb-9a65-762b6328ecfd.png)

Not in this PR but something for the future in case we would like to support it:

In the future we could have `--ui=loclist` or `--ui=quickfix` or even custom ui via `lsp#register_ui` to register curstom ui. For now this is out of scope since lot of ideas still need to be flushed out. But if folks want to use `quickfix` for all buffers we can easily implement `--ui` support for it without custom ui support. 

One could then do `:LspDocumentDiagnostics --ui=quickfix --servers=vim,efm --buffers=* --exclude-buffers=1,2`

