### PR TITLE
fix typo: diagnsotics & disable

### DIFF
--- a/autoload/lsp/internal/diagnostics.vim
+++ b/autoload/lsp/internal/diagnostics.vim
@@ -10,5 +10,5 @@ endfunction
 function! lsp#internal#diagnostics#_disable() abort
     call lsp#internal#diagnostics#echo#_disable()
     call lsp#internal#diagnostics#float#_disable()
-    call lsp#internal#diagnsotics#state#disable() " Needs to be the last one to unregister
+    call lsp#internal#diagnostics#state#_disable() " Needs to be the last one to unregister
 endfunction


### PR DESCRIPTION
An error was printed by `call lsp#disable()`, so it has been fixed.

```
Error detected while processing function lsp#disable[11]..lsp#internal#diagnostics#_disable:
line    3:
E117: Unknown function: lsp#internal#diagnsotics#state#disable
```