### PR TITLE
Improve error message at unsupported feature

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -1,5 +1,5 @@
 function! s:not_supported(what) abort
-    return lsp#utils#error(a:what.' not supported for '.&filetype)
+    return lsp#utils#error(printf("%s not supported for filetype '%s'", a:what, &filetype))
 endfunction
 
 function! lsp#ui#vim#implementation(in_preview, ...) abort


### PR DESCRIPTION
This change will work fine even if the filetype is empty:

e.g.

```
Renaming not supported for filetype ''
```

Current implementation shows an error message like below:

```
Renaming not supported for 
```