### PR TITLE
allow to enable or disable diagnostics per buffer

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1115,6 +1115,16 @@ function! s:send_didchange_queue(...) abort
     let s:didchange_queue = []
 endfunction
 
+function! lsp#enable_diagnostics_for_buffer(...) abort
+    let l:bufnr = a:0 > 0 ? a:1 : bufnr('%')
+    call lsp#internal#diagnostics#state#_enable_for_buffer(l:bufnr)
+endfunction
+
+function! lsp#disable_diagnostics_for_buffer(...) abort
+    let l:bufnr = a:0 > 0 ? a:1 : bufnr('%')
+    call lsp#internal#diagnostics#state#_disable_for_buffer(l:bufnr)
+endfunction
+
 " Return dict with diagnostic counts for current buffer
 " { 'error': 1, 'warning': 0, 'information': 0, 'hint': 0 }
 function! lsp#get_buffer_diagnostics_counts() abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -79,6 +79,8 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp#stop_server                       |lsp#stop_server()|
       lsp#utils#find_nearest_parent_file_directory()
                               |lsp#utils#find_nearest_parent_file_directory()|
+      lsp#enable_diagnostics_for_buffer() |lsp#enable_diagnostics_for_buffer()|
+      lsp#disable_diagnostics_for_buffer()|lsp#disable_diagnostics_for_buffer()|
       lsp#get_buffer_diagnostics_counts() |lsp#get_buffer_diagnostics_counts()|
       lsp#get_buffer_first_error_line()   |lsp#get_buffer_first_error_line()|
       lsp#get_progress()                  |lsp#get_progress()|
@@ -1267,6 +1269,34 @@ This method is mainly used to generate 'root_uri' when registering server.
 	  be regarded as a directory name, otherwise as a file name.
 	* If there is not directory with the specific files or diretories
 	  found, the method will return an empty string.
+
+lsp#enable_diagnostics_for_buffer()          *lsp#enable_diagnotics_for_buffer()*
+
+Re-enable diagnsostics for the specified buffer. By default diagnostics are
+enabled for all buffers.
+
+    Example: >
+	:call lsp#enable_diagnostics_for_buffer()
+	:call lsp#enable_diagnostics_for_buffer(bufnr('%'))
+
+lsp#disable_diagnostics_for_buffer()       *lsp#disable_diagnostics_for_buffer()*
+
+Diable diagnostics for the specified buffer. By default diagnostics are
+enabled for all buffers.
+
+    Example: >
+	:call lsp#enable_diagnostics_for_buffer()
+	:call lsp#enable_diagnostics_for_buffer(bufnr('%'))
+
+Diagnostics can be disabled for buffer to temporarily avoid conflicts with
+other plugins.
+
+    Example: >
+	augroup LspEasyMotion
+	    autocmd!
+	    autocmd User EasyMotionPromptBegin call lsp#disable_diagnostics_for_buffer()<CR>
+	    autocmd User EasyMotionPromptEnd call lsp#enable_diagnostics_for_buffer()<CR>
+	augroup END
 
 lsp#get_buffer_diagnostics_counts()    *lsp#get_buffer_diagnostics_counts()*
 


### PR DESCRIPTION
Part of [Diagnostics Revamp](https://github.com/prabirshrestha/vim-lsp/discussions/977). Fixes https://github.com/prabirshrestha/vim-lsp/issues/915

Example:

```vim
augroup LspEasyMotion
  autocmd!
  autocmd User EasyMotionPromptBegin call lsp#disable_diagnostics_for_buffer()<CR>
  autocmd User EasyMotionPromptEnd call lsp#enable_diagnostics_for_buffer()<CR>
augroup END
```

This will only for diagnostics ui's that respects `lsp#internal#diagnostics#state#_is_enabled_for_buffer` and watches for `$/vimlsp/lsp_diagnostics_updated` stream event. Currently `lsp#internal#diagnostics#state#_is_enabled_for_buffer` is an internal api we can revisit it later if this needs to be made public.