### PR TITLE
add support for codeLens/resolve

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -467,6 +467,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           }
     \         }
     \       },
+    \       'codeLens': {
+    \           'dynamicRegistration': v:false,
+    \       },
     \       'completion': {
     \           'dynamicRegistration': v:false,
     \           'completionItem': {


### PR DESCRIPTION
Fixes https://github.com/prabirshrestha/vim-lsp/pull/938

- [x] add support for codeLens/resolve
- [x] add auto cancellation when there is a new command by takeUntil new command
- [ ] check for `codeLens/resolve` support before making the resolve request


Seems like we need an operator to merge all next calls to array in callbag. for now manually calling add on s:items