### PR TITLE
Add g:lsp_float_normal_highlight to configure normal text color in Neovim's float window

### DIFF
--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -108,6 +108,8 @@ function! s:show_documentation(event) abort
         let l:width = (l:width < 1 ? 1 : l:width)
 
         let s:last_popup_id = nvim_open_win(l:buffer, v:false, {'relative': 'editor', 'anchor': l:anchor, 'row': l:row, 'col': l:col, 'height': l:height, 'width': l:width, 'style': 'minimal'})
+        let l:winhl = 'Normal:'.g:lsp_float_normal_highlight.',NormalNC:'.g:lsp_float_normal_highlight
+        call nvim_win_set_option(s:last_popup_id, 'winhl', l:winhl)
         return
     endif
 

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -116,7 +116,8 @@ function! lsp#ui#vim#output#floatingpreview(data) abort
         let l:opts = s:get_float_positioning(l:height, l:width)
 
         let s:winid = nvim_open_win(l:buf, v:false, l:opts)
-        call nvim_win_set_option(s:winid, 'winhl', 'Normal:Pmenu,NormalNC:Pmenu')
+        let l:winhl = 'Normal:'.g:lsp_float_normal_highlight.',NormalNC:'.g:lsp_float_normal_highlight
+        call nvim_win_set_option(s:winid, 'winhl', l:winhl)
         call nvim_win_set_option(s:winid, 'foldenable', v:false)
         call nvim_win_set_option(s:winid, 'wrap', v:true)
         call nvim_win_set_option(s:winid, 'statusline', '')

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -70,6 +70,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_tagfunc_source_methods          |g:lsp_tagfunc_source_methods|
       g:lsp_show_message_request_enabled    |g:lsp_show_message_request_enabled|
       g:lsp_work_done_progress_enabled      |g:lsp_work_done_progress_enabled|
+      g:lsp_float_normal_highlight          |g:lsp_float_normal_highlight|
     Functions                             |vim-lsp-functions|
       lsp#enable                            |lsp#enable()|
       lsp#disable                           |lsp#disable()|
@@ -867,6 +868,17 @@ g:lsp_work_done_progress_enabled         *g:lsp_work_done_progress_enabled*
     Determines whether or not to ask the server to send `$/progress`
     notifications. This can be intercepted by listening to |lsp#stream()|.
     Set to `1` to enable.
+
+g:lsp_float_normal_highlight                 *g:lsp_float_normal_highlight*
+    Type: |String|
+    Default: `"Pmenu"`
+
+    Determines |hl-Normal| highlight group for highlighting a normal text in
+    floating windows on Neovim. This variable is effective only on Neovim.
+    By default, |hl-Pmenu| is used. Set the highlight group name as string.
+
+    Example: >
+	let g:lsp_float_normal_highlight = 'NormalFloat'
 
 ==============================================================================
 FUNCTIONS                                               *vim-lsp-functions*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -60,6 +60,7 @@ let g:lsp_completion_resolve_timeout = get(g:, 'lsp_completion_resolve_timeout',
 let g:lsp_tagfunc_source_methods = get(g:, 'lsp_tagfunc_source_methods', ['definition', 'declaration', 'implementation', 'typeDefinition'])
 let g:lsp_show_message_request_enabled = get(g:, 'lsp_show_message_request_enabled', 1)
 let g:lsp_work_done_progress_enabled = get(g:, 'lsp_work_done_progress_enabled', 0)
+let g:lsp_float_normal_highlight = get(g:, 'lsp_float_normal_highlight', 'Pmenu')
 
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 


### PR DESCRIPTION
### Problem

vim-lsp uses `Pmenu` for highlighting normal text in floating window of Neovim here:

https://github.com/prabirshrestha/vim-lsp/blob/7d15d0f5813f4af2f7efff3d6cf68092566da35b/autoload/lsp/ui/vim/output.vim#L119

However, `Pmenu` is sometimes not suitable for highlighting normal text with some colorscheme because `Pmenu` is a highlight group for selectable menus.

### Solution

Allow to customize the normal text color via variable.

```vim
let g:lsp_float_normal_highlight = 'NormalFloat'
```

By this PR, this configuration can use `NormalFloat` highlight group to highlight normal text. Since the default value of the variable is `"Pmenu"`, this PR does not break any current behavior.

I confirmed this PR branch works on my local machine (Neovim v0.4.4 and macOS 10.14).