### PR TITLE
fix sign_place error, need 1 or more lnum

### DIFF
--- a/autoload/lsp/internal/diagnostics/signs.vim
+++ b/autoload/lsp/internal/diagnostics/signs.vim
@@ -134,9 +134,11 @@ function! s:place_signs(server, diagnostics_response, bufnr) abort
             let l:sign_priority = get(g:lsp_diagnostics_signs_priority_map, l:sign_name, g:lsp_diagnostics_signs_priority)
             let l:sign_priority = get(g:lsp_diagnostics_signs_priority_map,
                 \ a:server . '_' . l:sign_name, l:sign_priority)
-            " pass 0 and let vim generate sign id
-            let l:sign_id = sign_place(0, s:sign_group, l:sign_name, a:bufnr,
-                \{ 'lnum': l:line, 'priority': l:sign_priority })
+            if l:line > 0 "sig_place need lnum 1 to max, see :h sign_place, :h line()
+              " pass 0 and let vim generate sign id
+              let l:sign_id = sign_place(0, s:sign_group, l:sign_name, a:bufnr,
+                \ { 'lnum': l:line, 'priority': l:sign_priority })
+            endif
         endif
     endfor
 endfunction


### PR DESCRIPTION
close #1018 

see help 

```
:h sign_place()
...
		The optional {dict} argument supports the following entries:
			lnum		line number in the file or buffer
					{expr} where the sign is to be placed.
					For the accepted values, see |line()|.
```

```
:h line()
line({expr} [, {winid}])				*line()*
		The result is a Number, which is the line number of the file
		position given with {expr}.  The accepted positions are:
```

`line('.')` return at first line, 1. (1 base counting)

---

Locally test are OK.