### PR TITLE
Vim8 popup scroll

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -176,11 +176,12 @@ endfunction
 
 function! lsp#ui#vim#output#popup_scroll(val) abort
     " Scroll a popup window by a:val lines downwards (or upwards if a:val is
-    " negative. Example usage:
-    " nnoremap <buffer><silent><expr><C-j>
-    "             \ pumvisible() ? LspPopupScroll(1) : "\<C-j>"
-    " nnoremap <buffer><silent><expr><C-k>
-    "             \ pumvisible() ? LspPopupScroll(-1) : "\<C-k>"
+    " negative. The command :LspPopupScroll(val) calls this function. For
+    " example, 
+    "     lsp#ui#vim#output#popup_scroll(1)
+    " and
+    "     lsp#ui#vim#output#popup_scroll(-1)
+    " scroll the popup window one line down and one line up respectively.
 
     " Return early if there is no popup, or if the popup is already focused
     if !s:winid || win_getid() ==# s:winid

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -173,6 +173,30 @@ function! lsp#ui#vim#output#adjust_float_placement(bufferlines, maxwidth) abort
     endif
 endfunction
 
+function! lsp#ui#vim#output#popup_scroll(val) abort
+    let l:pos = popup_getpos(s:winid)
+    " only for vim8 popup where focusing is not (yet) possible
+    if !s:use_vim_popup || !s:winid || !l:pos.scrollbar
+        return
+    endif
+
+    let l:new_firstline = l:pos.firstline + a:val
+    let l:new_lastline = l:pos.lastline + a:val
+    let l:bottom_line = str2nr(trim(win_execute(s:winid, "echo line ('$')")))
+
+    if l:new_firstline < 1 " scrolling too far up
+        let l:new_firstline = 1
+    elseif l:new_lastline > l:bottom_line " scrolling too far down
+        let l:new_firstline = l:new_firstline + l:bottom_line - l:new_lastline
+    endif
+
+    call popup_setoptions(s:winid, {
+        \ 'firstline': l:new_firstline,
+        \ 'minwidth': l:pos.core_width,
+        \ 'maxwidth': l:pos.core_width + 1,
+        \ }) " Constrain min and maxwidth so that they don't change when scrolling
+endfunction
+
 function! s:add_float_closing_hooks() abort
     if g:lsp_preview_autoclose
         augroup lsp_float_preview_close

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1554,6 +1554,16 @@ LspStopServer                                                *:LspStopServer*
 
 Stop all active servers.
 
+LspPopupScroll {num}                                        *:LspPopupScroll* 
+
+Scroll a Vim 8 popup window by {num} lines (positive to
+scroll down, negative to scroll up). For example, to remap
+<C-j> and <C-k> to scroll down and up in a popup window: >
+
+        nnoremap <buffer><silent><C-j> :LspPopupScroll(1)<CR>
+        nnoremap <buffer><silent><C-k> :LspPopupScroll(-1)<CR>
+
+
 ==============================================================================
 Autocommands                                          *vim-lsp-autocommands*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -108,6 +108,7 @@ CONTENTS                                                  *vim-lsp-contents*
       LspPeekDefinition                     |:LspPeekDefinition|
       LspPeekImplementation                 |:LspPeekImplementation|
       LspPeekTypeDefinition                 |:LspPeekTypeDefinition|
+      LspPopupScroll                        |:LspPopupScroll|
       LspPreviousDiagnostic                 |:LspPreviousDiagnostic|
       LspPreviousError                      |:LspPreviousError|
       LspPreviousReference                  |:LspPreviousReference|
@@ -1561,9 +1562,9 @@ down, negative to scroll up). For example, to remap <C-j>
 and <C-k> to scroll a popup window down and up respectively: >
 
     nnoremap <buffer><silent><expr><C-j>
-                \ pumvisible() ? LspPopupScroll(1) : "\<C-j>"
+	\ lsp#ui#vim#output#getpreviewwinid() ? ":LspPopupScroll 1<CR>" : "\<C-j>"
     nnoremap <buffer><silent><expr><C-k>
-                \ pumvisible() ? LspPopupScroll(-1) : "\<C-k>"
+	\ lsp#ui#vim#output#getpreviewwinid() ? ":LspPopupScroll -1<CR>" : "\<C-k>"
 
 
 ==============================================================================

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1450,7 +1450,7 @@ LspNextReference                                         *:LspNextReference*
 
 Jump to the next reference of the symbol under cursor.
 
-LspNextWarning [-wrap=0]                              :LspNextWarning*
+LspNextWarning [-wrap=0]                              *:LspNextWarning*
 
 Jump to Next warning diagnostics
 With '-wrap=0', stop wrapping around the end of file.
@@ -1556,12 +1556,14 @@ Stop all active servers.
 
 LspPopupScroll {num}                                        *:LspPopupScroll* 
 
-Scroll a Vim 8 popup window by {num} lines (positive to
-scroll down, negative to scroll up). For example, to remap
-<C-j> and <C-k> to scroll down and up in a popup window: >
+Scroll the popup window by {num} lines (positive to scroll
+down, negative to scroll up). For example, to remap <C-j>
+and <C-k> to scroll a popup window down and up respectively: >
 
-        nnoremap <buffer><silent><C-j> :LspPopupScroll(1)<CR>
-        nnoremap <buffer><silent><C-k> :LspPopupScroll(-1)<CR>
+    nnoremap <buffer><silent><expr><C-j>
+                \ pumvisible() ? LspPopupScroll(1) : "\<C-j>"
+    nnoremap <buffer><silent><expr><C-k>
+                \ pumvisible() ? LspPopupScroll(-1) : "\<C-k>"
 
 
 ==============================================================================

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -129,6 +129,7 @@ command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspSignatureHelp
 command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
 command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
 command! -nargs=? LspSemanticScopes call lsp#ui#vim#semantic#display_scope_tree(<args>)
+command! -nargs=1 LspPopupScroll call lsp#ui#vim#output#popup_scroll(<args>)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
 nnoremap <plug>(lsp-code-lens) :<c-u>call lsp#ui#vim#code_lens()<cr>

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -129,7 +129,7 @@ command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspSignatureHelp
 command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
 command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
 command! -nargs=? LspSemanticScopes call lsp#ui#vim#semantic#display_scope_tree(<args>)
-command! -nargs=1 LspPopupScroll call lsp#ui#vim#output#popup_scroll(<args>)
+command! -nargs=1 LspPopupScroll call lsp#ui#vim#output#popup_scroll(<f-args>)
 
 nnoremap <plug>(lsp-code-action) :<c-u>call lsp#ui#vim#code_action()<cr>
 nnoremap <plug>(lsp-code-lens) :<c-u>call lsp#ui#vim#code_lens()<cr>


### PR DESCRIPTION
(cf. #975)

Sorry this took a while!

I was keeping a tab on the discussion with Bram on focusing in Vim 8 popup windows. It doesn't seem like that will be implemented soon, so in the meantime I guess this might be a workable band-aid. I also added a `:LspPopupScroll` command which exposes the functionality more easily. I did look into `popup_filter()`, but I suspect implementing that would require slightly larger-scale modification of the existing codebase. Of course, if you choose to go down a different route in the future I am willing to help.