### PR TITLE
add LspDocumentSymbolSearch using quickpick

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ function! s:on_lsp_buffer_enabled() abort
     setlocal signcolumn=yes
     if exists('+tagfunc') | setlocal tagfunc=lsp#tagfunc | endif
     nmap <buffer> gd <plug>(lsp-definition)
+    nmap <buffer> gs <plug>(lsp-document-symbol-search)
     nmap <buffer> gr <plug>(lsp-references)
     nmap <buffer> gi <plug>(lsp-implementation)
     nmap <buffer> gt <plug>(lsp-type-definition)

--- a/autoload/lsp/internal/document_symbol/search.vim
+++ b/autoload/lsp/internal/document_symbol/search.vim
@@ -1,0 +1,60 @@
+" https://microsoft.github.io/language-server-protocol/specification#textDocument_documentSymbol
+" options - {
+"   bufnr: bufnr('%')       " optional
+"   server - 'server_name'  " optional
+" }
+function! lsp#internal#document_symbol#search#do(options) abort
+    let l:bufnr = get(a:options, 'bufnr', bufnr('%'))
+    if has_key(a:options, 'server')
+        let l:servers = [a:options['server']]
+    else
+        let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
+    endif
+
+    if len(l:servers) == 0
+        let l:filetype = getbufvar(l:bufnr, '&filetype')
+        call lsp#utils#error('textDocument/documentSymbol not supported for ' . l:filetype)
+        return
+    endif
+
+    redraw | echo 'Retrieving document symbols ...'
+
+    let s:items = []
+    call lsp#internal#ui#quickpick#open({
+        \ 'items': [],
+        \ 'busy': 1,
+        \ 'input': '',
+        \ 'key': 'text',
+        \ 'on_accept': function('s:on_accept'),
+        \ })
+
+    call lsp#callbag#pipe(
+        \ lsp#callbag#fromList(l:servers),
+        \ lsp#callbag#flatMap({server->
+        \   lsp#callbag#pipe(
+        \       lsp#request(server, {
+        \           'method': 'textDocument/documentSymbol',
+        \           'params': {
+        \               'textDocument': lsp#get_text_document_identifier(l:bufnr),
+        \           },
+        \       }),
+        \       lsp#callbag#map({x->{'server': server, 'response': x['response']}}),
+        \   )
+        \ }),
+        \ lsp#callbag#flatMap({x->s:show_ui(x['server'], x['response'])}),
+        \ lsp#callbag#subscribe(),
+        \ )
+endfunction
+
+function! s:show_ui(server, response) abort
+    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:server, { 'response': a:response })
+    let s:items += l:list
+    call lsp#internal#ui#quickpick#items(s:items)
+    call lsp#internal#ui#quickpick#busy(0)
+    return lsp#callbag#empty()
+endfunction
+
+function! s:on_accept(data, ...) abort
+    call lsp#internal#ui#quickpick#close()
+    call lsp#utils#location#_open_vim_list_item(a:data['items'][0], '')
+endfunction

--- a/autoload/lsp/internal/document_symbol/search.vim
+++ b/autoload/lsp/internal/document_symbol/search.vim
@@ -19,16 +19,16 @@ function! lsp#internal#document_symbol#search#do(options) abort
 
     redraw | echo 'Retrieving document symbols ...'
 
-    let s:items = []
     call lsp#internal#ui#quickpick#open({
         \ 'items': [],
         \ 'busy': 1,
         \ 'input': '',
         \ 'key': 'text',
         \ 'on_accept': function('s:on_accept'),
+        \ 'on_close': function('s:on_close'),
         \ })
 
-    call lsp#callbag#pipe(
+    let s:Dispose = lsp#callbag#pipe(
         \ lsp#callbag#fromList(l:servers),
         \ lsp#callbag#flatMap({server->
         \   lsp#callbag#pipe(
@@ -38,23 +38,39 @@ function! lsp#internal#document_symbol#search#do(options) abort
         \               'textDocument': lsp#get_text_document_identifier(l:bufnr),
         \           },
         \       }),
-        \       lsp#callbag#map({x->{'server': server, 'response': x['response']}}),
+        \       lsp#callbag#map({x->{'server': server, 'request': x['request'], 'response': x['response']}}),
         \   )
         \ }),
-        \ lsp#callbag#flatMap({x->s:show_ui(x['server'], x['response'])}),
-        \ lsp#callbag#subscribe(),
+        \ lsp#callbag#scan({acc, curr->add(acc, curr)}, []),
+        \ lsp#callbag#tap({x->s:update_ui_items(x)}),
+        \ lsp#callbag#subscribe({
+        \   'complete':{->lsp#internal#ui#quickpick#busy(0)},
+        \   'error':{e->s:on_error(e)},
+        \ }),
         \ )
 endfunction
 
-function! s:show_ui(server, response) abort
-    let l:list = lsp#ui#vim#utils#symbols_to_loc_list(a:server, { 'response': a:response })
-    let s:items += l:list
-    call lsp#internal#ui#quickpick#items(s:items)
-    call lsp#internal#ui#quickpick#busy(0)
-    return lsp#callbag#empty()
+function! s:update_ui_items(x) abort
+    let l:items = []
+    for l:i in a:x
+        let l:items += lsp#ui#vim#utils#symbols_to_loc_list(l:i['server'], l:i)
+    endfor
+    call lsp#internal#ui#quickpick#items(l:items)
 endfunction
 
 function! s:on_accept(data, ...) abort
     call lsp#internal#ui#quickpick#close()
     call lsp#utils#location#_open_vim_list_item(a:data['items'][0], '')
+endfunction
+
+function! s:on_close(...) abort
+    if exists('s:Dispose')
+        call s:Dispose()
+        unlet s:Dispose
+    endif
+endfunction
+
+function! s:on_error(e) abort
+    call lsp#internal#ui#quickpick#close()
+    call lsp#log('LspDocumentSymbolSearch error', a:e)
 endfunction

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -98,6 +98,7 @@ CONTENTS                                                  *vim-lsp-contents*
       LspDocumentRangeFormat                |:LspDocumentRangeFormat|
       LspDocumentRangeFormatSync            |:LspDocumentRangeFormatSync|
       LspDocumentSymbol                     |:LspDocumentSymbol|
+      LspDocumentSymbolSearch               |:LspDocumentSymbolSearch|
       LspHover                              |:LspHover|
       LspNextDiagnostic                     |:LspNextDiagnostic|
       LspNextError                          |:LspNextError|
@@ -1417,6 +1418,10 @@ Note that this may slow down vim.
 LspDocumentSymbol                                       *:LspDocumentSymbol*
 
 Gets the symbols for the current document.
+
+LspDocumentSymbolSearch                             *:LspDocumentSymbolSearch*
+
+Search the symbols for the current document and navigate.
 
 LspHover                                                         *:LspHover*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -136,6 +136,7 @@ nnoremap <plug>(lsp-peek-declaration) :<c-u>call lsp#ui#vim#declaration(1)<cr>
 nnoremap <plug>(lsp-definition) :<c-u>call lsp#ui#vim#definition(0)<cr>
 nnoremap <plug>(lsp-peek-definition) :<c-u>call lsp#ui#vim#definition(1)<cr>
 nnoremap <plug>(lsp-document-symbol) :<c-u>call lsp#ui#vim#document_symbol()<cr>
+nnoremap <plug>(lsp-document-symbol-search) :<c-u>call lsp#internal#document_symbol#search#do({})<cr>
 nnoremap <plug>(lsp-document-diagnostics) :<c-u>call lsp#internal#diagnostics#document_diagnostics_command#do({})<cr>
 nnoremap <plug>(lsp-hover) :<c-u>call lsp#ui#vim#hover#get_hover_under_cursor()<cr>
 nnoremap <plug>(lsp-preview-close) :<c-u>call lsp#ui#vim#output#closepreview()<cr>

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -88,6 +88,7 @@ command! LspPeekDeclaration call lsp#ui#vim#declaration(1)
 command! LspDefinition call lsp#ui#vim#definition(0, <q-mods>)
 command! LspPeekDefinition call lsp#ui#vim#definition(1)
 command! LspDocumentSymbol call lsp#ui#vim#document_symbol()
+command! LspDocumentSymbolSearch call lsp#internal#document_symbol#search#do({})
 command! -nargs=? LspDocumentDiagnostics call lsp#internal#diagnostics#document_diagnostics_command#do(
             \ extend({}, lsp#utils#args#_parse(<q-args>, {
             \   'buffers': {'type': type('')},


### PR DESCRIPTION
Demo:
![LspDocumentSymbolSearch](https://user-images.githubusercontent.com/287744/104086048-2abaca80-5209-11eb-9953-cd070be0c886.gif)

I prefer this experience better which is similar to vscode than using quickfix/loclist. Makes navigation lot faster.
I did think about using `LspDocumentSymbol --ui=search` but I think having an explict search is better since in the future we can have tree/hierarchy view for document symbols.

//cc @mattn another use case of quickpick.
