### PR TITLE
Improve completion perf

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -341,6 +341,8 @@ endfunction
 " }
 function! lsp#omni#get_vim_completion_items(options) abort
     let l:server = a:options['server']
+    let l:server_name = l:server['name']
+    let l:kind_text_mappings = s:get_kind_text_mappings(l:server)
     let l:complete_position = a:options['position']
 
     let l:result = a:options['response']['result']
@@ -356,9 +358,6 @@ function! lsp#omni#get_vim_completion_items(options) abort
     endif
 
     let l:vim_complete_items = []
-    let l:server_name = l:server['name']
-    let l:kind_text_mappings = s:get_kind_text_mappings(l:server)
-
     for l:completion_item in l:items
         let l:label = lsp#utils#_trim(l:completion_item.label)
         let l:insert_text = lsp#utils#_trim(get(l:completion_item, 'insertText', l:label))
@@ -367,16 +366,17 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:word = l:label
             let l:abbr = l:label
 
-            let l:expandable = 0
-            if has_key(l:completion_item, 'textEdit') && has_key(l:completion_item.textEdit, 'newText')
-                let l:expandable = l:word !=# l:completion_item.textEdit.newText
-            elseif has_key(l:completion_item, 'insertText')
-                let l:expandable = l:word !=# l:completion_item.insertText
-            endif
+            " always set to 1 for perf for now
+            let l:expandable = 1
+            " if has_key(l:completion_item, 'textEdit') && has_key(l:completion_item.textEdit, 'newText')
+            "     let l:expandable = l:word !=# l:completion_item.textEdit.newText
+            " elseif has_key(l:completion_item, 'insertText')
+            "     let l:expandable = l:word !=# l:completion_item.insertText
+            " endif
 
-            if l:expandable
+            " if l:expandable
                 let l:abbr = l:abbr . '~'
-            endif
+            " endif
         else
             let l:word = l:insert_text
             let l:abbr = l:label
@@ -387,6 +387,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'abbr': l:abbr,
             \ 'dup': 1,
             \ 'icase': 1,
+            \ 'kind': get(l:kind_text_mappings, get(l:completion_item, 'kind', '') , '')
             \ }
 
         if s:is_user_data_support
@@ -459,5 +460,4 @@ endfunction
 function! s:create_user_data_key(base) abort
     return '{"vim-lsp/key":"' . a:base . '"}'
 endfunction
-
 " }}}

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -1,6 +1,7 @@
 " vint: -ProhibitUnusedVariable
 
 " constants {{{
+let s:t_dict = type({})
 
 let s:default_completion_item_kinds = {
             \ '1': 'text',
@@ -356,13 +357,43 @@ function! lsp#omni#get_vim_completion_items(options) abort
 
     let l:vim_complete_items = []
     let l:server_name = l:server['name']
-    let l:item_options = {
-        \ 'server': l:server,
-        \ 'position': l:complete_position,
-        \ 'kind_text_mappings': s:get_kind_text_mappings(l:server),
-        \ }
-    for l:item in l:items
-        call add(l:vim_complete_items, s:get_vim_completion_item(l:item, l:item_options))
+    let l:kind_text_mappings = s:get_kind_text_mappings(l:server)
+
+    for l:completion_item in l:items
+        let l:label = lsp#utils#_trim(l:completion_item.label)
+        let l:insert_text = lsp#utils#_trim(get(l:completion_item, 'insertText', l:label))
+
+        if get(l:completion_item, 'insertTextFormat', 1) == 2
+            let l:word = l:label
+            let l:abbr = l:label
+
+            let l:expandable = 0
+            if has_key(l:completion_item, 'textEdit') && has_key(l:completion_item.textEdit, 'newText')
+                let l:expandable = l:word !=# l:completion_item.textEdit.newText
+            elseif has_key(l:completion_item, 'insertText')
+                let l:expandable = l:word !=# l:completion_item.insertText
+            endif
+
+            if l:expandable
+                let l:abbr = l:abbr . '~'
+            endif
+        else
+            let l:word = l:insert_text
+            let l:abbr = l:label
+        endif
+
+        let l:vim_complete_item = {
+            \ 'word': l:word,
+            \ 'abbr': l:abbr,
+            \ 'dup': 1,
+            \ 'icase': 1,
+            \ }
+
+        if s:is_user_data_support
+            let l:vim_complete_item['user_data'] = s:create_user_data(l:completion_item, l:server_name, l:complete_position)
+        endif
+
+        let l:vim_complete_items += [l:vim_complete_item]
     endfor
 
     return { 'items': l:vim_complete_items, 'incomplete': l:incomplete }

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -233,14 +233,14 @@ function! s:send_completion_request(info) abort
     let l:server_name = a:info['server_names'][0]
     " TODO: support multiple servers
     call lsp#send_request(l:server_name, {
-                \ 'method': 'textDocument/completion',
-                \ 'params': {
-                \   'textDocument': lsp#get_text_document_identifier(),
-                \   'position': lsp#get_position(),
-                \   'context': { 'triggerKind': 1 },
-                \ },
-                \ 'on_notification': function('s:handle_omnicompletion', [l:server_name, s:completion['counter'], a:info]),
-                \ })
+        \ 'method': 'textDocument/completion',
+        \ 'params': {
+        \   'textDocument': lsp#get_text_document_identifier(),
+        \   'position': lsp#get_position(),
+        \   'context': { 'triggerKind': 1 },
+        \ },
+        \ 'on_notification': function('s:handle_omnicompletion', [l:server_name, s:completion['counter'], a:info]),
+        \ })
 endfunction
 
 function! s:get_completion_result(server_name, data) abort
@@ -255,80 +255,6 @@ function! s:get_completion_result(server_name, data) abort
     let l:completion_result = lsp#omni#get_vim_completion_items(l:options)
 
     return {'matches': l:completion_result['items'], 'incomplete': l:completion_result['incomplete'] }
-endfunction
-
-function! s:get_vim_completion_item(item, options) abort
-    let l:server_name = a:options['server']['name']
-    let l:complete_position = a:options['position']
-    let l:kind_text_mappings = a:options['kind_text_mappings']
-
-    let l:word = ''
-    let l:expandable = v:false
-    if get(a:item, 'insertTextFormat', -1) == 2 && !empty(get(a:item, 'insertText', ''))
-        " if candidate is snippet, use insertText. But it may include
-        " placeholder.
-        let l:word = lsp#utils#make_valid_word(a:item['insertText'])
-        let l:expandable = l:word !=# a:item['insertText']
-    elseif !empty(get(a:item, 'insertText', ''))
-        " if plain-text insertText, use it.
-        let l:word = a:item['insertText']
-    elseif has_key(a:item, 'textEdit') && type(a:item['textEdit']) ==# v:t_dict
-        let l:word = lsp#utils#make_valid_word(a:item['label'])
-        let l:expandable = l:word !=# get(a:item['textEdit'], 'newText', '')
-    endif
-    if !empty(l:word)
-        let l:word = split(l:word, '\n')[0]
-    endif
-    if empty(l:word)
-        let l:word = a:item['label']
-    endif
-    let l:abbr = a:item['label']
-
-    if has_key(a:item, 'insertTextFormat') && a:item['insertTextFormat'] == 2
-        let l:word = substitute(l:word, '\$[0-9]\+\|\${\%(\\.\|[^}]\)\+}', '', 'g')
-    endif
-
-    let l:word = lsp#utils#_trim(l:word)
-    let l:kind = has_key(a:item, 'kind') ? get(l:kind_text_mappings, a:item['kind'], '') : ''
-
-    let l:completion = {
-                \ 'word': l:word,
-                \ 'abbr': l:abbr . (l:expandable ? '~' : ''),
-                \ 'icase': 1,
-                \ 'dup': 1,
-                \ 'empty': 1,
-                \ 'kind': l:kind,
-                \ }
-
-    " check support user_data.
-    " if not support but g:lsp_text_edit_enabled enabled,
-    " then print information to user and add information to log file.
-    if !s:is_user_data_support && g:lsp_text_edit_enabled
-        let l:no_support_error_message = 'textEdit support on omni complete requires Vim 8.0 patch 1493 or later(please check g:lsp_text_edit_enabled)'
-        call lsp#utils#error(l:no_support_error_message)
-        call lsp#log(l:no_support_error_message)
-    endif
-
-    " Add user_data.
-    if s:is_user_data_support
-        let l:completion['user_data'] = s:create_user_data(a:item, l:server_name, l:complete_position)
-    endif
-
-    if has_key(a:item, 'detail') && !empty(a:item['detail'])
-        let l:completion['menu'] = substitute(a:item['detail'], '[ \t\n\r]\+', ' ', 'g')
-    endif
-
-    if has_key(a:item, 'documentation')
-        if type(a:item['documentation']) == type('') " field is string
-            let l:completion['info'] .= a:item['documentation']
-        elseif type(a:item['documentation']) == type({}) &&
-                    \ has_key(a:item['documentation'], 'value')
-            " field is MarkupContent (hopefully 'plaintext')
-            let l:completion['info'] .= substitute(a:item['documentation']['value'], '\r', '', 'g')
-        endif
-    endif
-
-    return l:completion
 endfunction
 
 " options = {

--- a/autoload/lsp/ui/vim/documentation.vim
+++ b/autoload/lsp/ui/vim/documentation.vim
@@ -18,17 +18,28 @@ endfunction
 function! s:show_documentation(event) abort
     call s:close_popup()
 
-    if !has_key(a:event['completed_item'], 'info') || empty(a:event['completed_item']['info'])
+    let l:managed_data = lsp#omni#get_managed_user_data_from_completed_item(a:event['completed_item'])
+    if empty(l:managed_data)
         return
     endif
 
+    let l:completion_item = l:managed_data['completion_item']
+    if !has_key(l:completion_item, 'documentation')
+        return
+    endif
+
+    if type(l:completion_item['documentation']) == type('')
+        let l:documentation = l:completion_item['documentation']
+    elseif type(l:completion_item['documentation']) == type({}) && has_key(l:completion_item['documentation'], 'value')
+        " field is MarkupContent (hopefully plaintext)
+        let l:documentation = substitute(l:completion_item['documentation']['value'], '\r', '', 'g')
+    endif
 
     " TODO: Support markdown
-    let l:data = split(a:event['completed_item']['info'], '\n')
+    let l:data = split(l:documentation, '\n')
     let l:lines = []
     let l:syntax_lines = []
     let l:ft = lsp#ui#vim#output#append(l:data, l:lines, l:syntax_lines)
-
 
    " Neovim
     if s:use_nvim_float

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -1,3 +1,8 @@
+let s:has_lua = has('nvim-0.4.0') || (has('lua') && has('patch-8.2.0775'))
+function! lsp#utils#has_lua() abort
+    return s:has_lua
+endfunction
+
 let s:has_virtual_text = exists('*nvim_buf_set_virtual_text') && exists('*nvim_create_namespace')
 function! lsp#utils#_has_virtual_text() abort
     return s:has_virtual_text

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -25,12 +25,10 @@ Describe lsp#omni
             \ 'items': [{
             \   'word': 'my-label',
             \   'abbr': 'my-label',
-            \   'info': 'my documentation.',
             \   'icase': 1,
             \   'dup': 1,
             \   'empty': 1,
             \   'kind': 'function',
-            \   'menu': 'my-detail',
             \   'user_data': '{"vim-lsp/key":"0"}',
             \ }],
             \ 'incomplete': 0,
@@ -67,13 +65,11 @@ Describe lsp#omni
             let want = {
             \ 'items': [{
             \  'word': 'my-label',
-            \  'abbr': 'my-label~',
-            \  'info': 'my documentation.',
+            \  'abbr': 'my-label',
             \  'icase': 1,
             \  'dup': 1,
             \  'empty': 1,
             \  'kind': 'function',
-            \  'menu': 'my-detail',
             \  'user_data': '{"vim-lsp/key":"0"}',
             \  }],
             \  'incomplete': 0,
@@ -86,38 +82,6 @@ Describe lsp#omni
                         \   'completion_item': item,
                         \   'complete_position': { 'line': 1, 'character': 1 }
                         \ })
-        End
-
-        It should return item with newlines in 'menu' replaced
-            let item = {
-            \ 'label': 'my-label',
-            \ 'documentation': 'my documentation.',
-            \ 'detail': "my-detail\nmore-detail",
-            \ 'kind': '3'
-            \}
-
-            let options = {
-            \ 'server': { 'name': 'dummy-server' },
-            \ 'position': lsp#get_position(),
-            \ 'response': { 'result': [item] },
-            \}
-
-            let want = {
-            \ 'items': [{
-            \  'word': 'my-label',
-            \  'abbr': 'my-label',
-            \  'info': 'my documentation.',
-            \  'icase': 1,
-            \  'dup': 1,
-            \  'empty': 1,
-            \  'kind': 'function',
-            \  'menu': 'my-detail more-detail',
-            \  'user_data': '{"vim-lsp/key":"0"}',
-            \  }],
-            \  'incomplete': 0,
-            \}
-
-            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
         End
 
         It should not raise errors
@@ -136,12 +100,10 @@ Describe lsp#omni
             \ 'items': [{
             \  'word': 'my-label',
             \  'abbr': 'my-label',
-            \  'info': '',
             \  'icase': 1,
             \  'dup': 1,
             \  'empty': 1,
             \  'kind': '',
-            \  'menu': '',
             \  'user_data': '{"vim-lsp/key":"0"}',
             \  }],
             \  'incomplete': 0,
@@ -166,12 +128,10 @@ Describe lsp#omni
             \ 'items': [{
             \  'word': 'my-label',
             \  'abbr': 'my-label',
-            \  'info': '',
             \  'icase': 1,
             \  'dup': 1,
             \  'empty': 1,
             \  'kind': '',
-            \  'menu': '',
             \  'user_data': '{"vim-lsp/key":"1"}',
             \  }],
             \  'incomplete': 0,


### PR DESCRIPTION
This is work in progress to improve completion. Need to test with different language servers could be breaking some.

- [x] optimize `lsp#omni#get_vim_completion_items`  ref: https://github.com/prabirshrestha/vim-lsp/pull/835, https://github.com/prabirshrestha/vim-lsp/pull/834
- [x] add/fix tests
- [x] do not compute documentation for all items in `get_vim_completion_items` and instead compute doc when popup is shown for that particular item
- [x] add support for lazy preview doc computation
- [x] cleanup unnecessary code and methods
- [x] profile
- [ ] use lua for `get_vim_completion_items` when available for even faster perf
- [ ] function overload experience?
- [x] update docs