### PR TITLE
Fix/showsigpreview

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -303,7 +303,6 @@ function! lsp#ui#vim#output#get_size_info(winid) abort
     endif
 
     return [l:bufferlines, l:maxwidth]
-  return [l:bufferlines, l:maxwidth]
 endfunction
 
 function! lsp#ui#vim#output#float_supported() abort

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -284,8 +284,8 @@ function! lsp#ui#vim#output#get_size_info(winid) abort
     " Get size information while still having the buffer active
     let l:buffer = winbufnr(a:winid)
     let l:maxwidth = max(map(getbufline(l:buffer, 1, '$'), 'strdisplaywidth(v:val)'))
+    let l:bufferlines = 0
     if g:lsp_preview_max_width > 0
-      let l:bufferlines = 0
       let l:maxwidth = min([g:lsp_preview_max_width, l:maxwidth])
 
       " Determine, for each line, how many "virtual" lines it spans, and add


### PR DESCRIPTION
Previously, when using the preview window to show signature information, the code failed with an stacktrace like:

     "s:on_stdout client request on_notification() error",
     "Vim(return):E121: Undefined variable: l:bufferlines",
     "function <SNR>118_out_cb[2]..
     <SNR>107_on_stdout[79]..
     <SNR>92_request_on_notification[3]..
     <SNR>93_createNext[1]..
     <SNR>93_subscribeSourceCallback[2]..
     <lambda>738[1]..
     <SNR>94_handle_signature_help[48]..
     lsp#ui#vim#output#preview[39]..
     lsp#ui#vim#output#get_size_info, line 22"

This PR ensures that the required variable is properly defined in all the situations (popup, nvim, preview window)