### PR TITLE
Fix #1059

### DIFF
--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -126,6 +126,7 @@ function! s:on_complete_done_after() abort
     if get(l:completion_item, 'insertTextFormat', 1) == 2
       " insert Snippet.
       call lsp#utils#text_edit#apply_text_edits('%', [{ 'range': l:range, 'newText': '' }])
+      call cursor(lsp#utils#position#lsp_to_vim('%', l:range['start']))
       if exists('g:lsp_snippet_expand') && len(g:lsp_snippet_expand) > 0
         call g:lsp_snippet_expand[0]({ 'snippet': l:text })
       else


### PR DESCRIPTION
Sorry. It's my bad.

This change has no side-effect.

I'm organizing completion confirmation implementation as a separate package.
I've added a test for this problem then it passed and also existing tests are all passed.

https://github.com/hrsh7th/vim-vital-vs/blob/master/autoload/vital/__vital__/VS/LSP/CompletionItem.vimspec#L258