### PR TITLE
Fix invalid diagnostic prop_add

### DIFF
--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -90,16 +90,10 @@ function! s:clear_all_highlights() abort
                 call nvim_buf_clear_namespace(l:bufnr, s:namespace_id, 0, -1)
             else
                 for l:severity in keys(s:severity_sign_names_mapping)
-                    try
-                        " TODO: need to check for valid range before calling prop_add
-                        " See https://github.com/prabirshrestha/vim-lsp/pull/721
-                        silent! call prop_remove({
-                            \ 'type': s:get_prop_type_name(l:severity),
-                            \ 'bufnr': l:bufnr,
-                            \ 'all': v:true })
-                    catch
-                        call lsp#log('diagnostics', 'clear_all_highlights', 'prop_remove', v:exception, v:throwpoint)
-                    endtry
+                    silent! call prop_remove({
+                        \ 'type': s:get_prop_type_name(l:severity),
+                        \ 'bufnr': l:bufnr,
+                        \ 'all': v:true })
                 endfor
             endif
         endif
@@ -163,18 +157,14 @@ function! s:place_highlights(server, diagnostics_response, bufnr) abort
                    \ l:line - 1, l:highlight_start_col - 1, l:highlight_end_col == -1 ? -1 : l:highlight_end_col)
             endfor
         else
-            try
-                " TODO: need to check for valid range before calling prop_add
-                " See https://github.com/prabirshrestha/vim-lsp/pull/721
+            if lsp#utils#range#is_valid_for_buffer(a:bufnr, l:item['range'])
                 silent! call prop_add(l:start_line, l:start_col, {
                     \ 'end_lnum': l:end_line,
                     \ 'end_col': l:end_col,
                     \ 'bufnr': a:bufnr,
                     \ 'type': s:get_prop_type_name(l:severity),
                     \ })
-            catch
-                call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
-            endtry
+            endif
         endif
     endfor
 endfunction

--- a/autoload/lsp/utils/range.vim
+++ b/autoload/lsp/utils/range.vim
@@ -75,7 +75,7 @@ function! lsp#utils#range#is_valid_for_buffer(bufnr, range)
     let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['start'])
     let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['end'])
 
-    let l:buf_linecount = getbufinfo(a:bufnr)[0].linecount
+    let l:buf_linecount = getbufinfo(a:bufnr)[0]['linecount']
 
     if l:buf_linecount < l:start_line || l:buf_linecount < l:end_line
         return v:false

--- a/autoload/lsp/utils/range.vim
+++ b/autoload/lsp/utils/range.vim
@@ -70,3 +70,23 @@ function! lsp#utils#range#lsp_to_vim(bufnr, range) abort
 
     return l:position
 endfunction
+
+function! lsp#utils#range#is_valid_for_buffer(bufnr, range)
+    let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['start'])
+    let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim(a:bufnr, a:range['end'])
+
+    let l:buf_linecount = getbufinfo(a:bufnr)[0].linecount
+
+    if l:buf_linecount < l:start_line || l:buf_linecount < l:end_line
+        return v:false
+    endif
+
+    let l:first_line_length = len(getbufline(a:bufnr, l:start_line, l:end_line)[0])
+    let l:last_line_length = len(getbufline(a:bufnr, l:start_line, l:end_line)[-1])
+
+    if l:first_line_length < l:start_col || l:last_line_length < l:end_col
+        return v:false
+    endif
+
+    return v:true
+endfunction

--- a/test/lsp/utils/range.vimspec
+++ b/test/lsp/utils/range.vimspec
@@ -76,6 +76,23 @@ Describe lsp#utils#range
       Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:false)
     End
 
+    It should return range is valid with multibyte
+      call setline(1, ['あいうえお', 'かきくけこ', 'さしすせそ'])
+      let l:bufnr = bufnr('%')
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 1, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:true)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 4, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:true)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 1, 'line': 3}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:false)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 5, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:false)
+    End
+
   End
 
 End

--- a/test/lsp/utils/range.vimspec
+++ b/test/lsp/utils/range.vimspec
@@ -57,5 +57,26 @@ Describe lsp#utils#range
 
   End
 
+  Describe lsp#utils#range#is_valid_for_buffer
+
+    It should return range is valid in specific buffer
+      call setline(1, ['line1', 'line2', 'line3'])
+      let l:bufnr = bufnr('%')
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 1, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:true)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 4, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:true)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 1, 'line': 3}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:false)
+
+      let l:range = {'start': {'character': 0, 'line': 0}, 'end': {'character': 5, 'line': 2}}
+      Assert Equals(lsp#utils#range#is_valid_for_buffer(l:bufnr, l:range), v:false)
+    End
+
+  End
+
 End
 


### PR DESCRIPTION
Related: https://github.com/prabirshrestha/vim-lsp/pull/721#issuecomment-753279052
Similar problem occurred solargraph too.
And I fixed in solargraph. But rust still error. I think rust problem reason is #1076

## Solargraph screen shot
### before
![before-ruby](https://user-images.githubusercontent.com/19731661/109312140-08990c80-788a-11eb-9f69-b3be8376937f.gif)

### after
![after-ruby](https://user-images.githubusercontent.com/19731661/109312155-0fc01a80-788a-11eb-8d77-0804c1c8dea6.gif)
