### PR TITLE
Add option to disable markdown in preview windows

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -460,6 +460,11 @@ function! s:ensure_start(buf, server_name, cb) abort
 endfunction
 
 function! lsp#default_get_supported_capabilities(server_info) abort
+	let l:formats = ['plaintext']
+	if g:lsp_preview_markdown_enabled
+		let l:formats = ['markdown'] + l:formats
+	endif
+
     " Sorted alphabetically
     return {
     \   'textDocument': {
@@ -477,7 +482,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'completion': {
     \           'dynamicRegistration': v:false,
     \           'completionItem': {
-    \              'documentationFormat': ['markdown', 'plaintext'],
+    \              'documentationFormat': l:formats,
     \              'snippetSupport': v:false,
     \              'resolveSupport': {
     \                  'properties': ['additionalTextEdits']
@@ -516,7 +521,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       },
     \       'hover': {
     \           'dynamicRegistration': v:false,
-    \           'contentFormat': ['markdown', 'plaintext'],
+    \           'contentFormat': l:formats,
     \       },
     \       'implementation': {
     \           'dynamicRegistration': v:false,

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -13,6 +13,7 @@ CONTENTS                                                  *vim-lsp-contents*
       Wiki                                  |vim-lsp-configure-wiki|
     Options                               |vim-lsp-options|
       g:lsp_auto_enable                     |g:lsp_auto_enable|
+      g:lsp_preview_markdown_enabled        |g:lsp_preview_markdown_enabled| 
       g:lsp_preview_keep_focus              |g:lsp_preview_keep_focus|
       g:lsp_preview_float                   |g:lsp_preview_float|
       g:lsp_preview_autoclose               |g:lsp_preview_autoclose|
@@ -378,6 +379,19 @@ g:lsp_preview_doubletap                         *g:lsp_preview_doubletap*
 
 	" Disables double tap feature; refreshes the preview on consecutive taps
 	let g:lsp_preview_doubletap = 0
+
+g:lsp_preview_markdown_enabled                   *g:lsp_preview_markdown_enabled*
+	Type: |Number|
+	Default: `1`
+
+	Indicates whether markdown format must be used in preview windows.
+
+    Example: >
+	" Contents of preview windows are in markdown.
+	let g:lsp_preview_markdown_enabled = 1
+
+	" Contents of preview windows are in plain text.
+	let g:lsp_preview_markdown_enabled = 0
 
 g:lsp_insert_text_enabled                       *g:lsp_insert_text_enabled*
     Type: |Number|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -42,6 +42,7 @@ let g:lsp_document_code_action_signs_hint = get(g:, 'lsp_document_code_action_si
 let g:lsp_document_code_action_signs_priority = get(g:, 'lsp_document_code_action_signs_priority', 10)
 
 let g:lsp_preview_keep_focus = get(g:, 'lsp_preview_keep_focus', 1)
+let g:lsp_preview_markdown_enabled = get(g:, 'lsp_preview_markdown_enabled', 1)
 let g:lsp_use_event_queue = get(g:, 'lsp_use_event_queue', has('nvim') || has('patch-8.1.0889'))
 let g:lsp_insert_text_enabled= get(g:, 'lsp_insert_text_enabled', 1)
 let g:lsp_text_edit_enabled = get(g:, 'lsp_text_edit_enabled', has('patch-8.0.1493'))


### PR DESCRIPTION
Markdown text is not rendered correctly in preview windows. This leads to previews with poor readability, like the one below.

```
╔════════════════════════════════════════════════════════════════════════════════╗
║```go                                                                           ║
║func log.SetFlags(flag int)                                                     ║
║```                                                                             ║
║                                                                                ║
║[`log.SetFlags` on pkg.go.dev](https://pkg.go.dev/log?utm_source=gopls#SetFlags)║
║                                                                                ║
║SetFlags sets the output flags for the standard logger\.                        ║
║The flag bits are Ldate, Ltime, and so on\.                                     ║
║                                                                                ║
╚════════════════════════════════════════════════════════════════════════════════╝
```

This change adds an option to disable markdown in preview windows. This is a workaround for prabirshrestha/vim-lsp#865.

With the option disabled, the above preview looks like this.

```
╔═══════════════════════════════════════════════════════╗
║func log.SetFlags(flag int)                            ║
║SetFlags sets the output flags for the standard logger.║
║The flag bits are Ldate, Ltime, and so on.             ║
║                                                       ║
╚═══════════════════════════════════════════════════════╝
```