### PR TITLE
Fix inserting "v:null" when newText in textEdit is null

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -89,7 +89,12 @@ function! s:_apply(bufnr, text_edit, cursor_position) abort
     let l:after_line = strcharpart(l:end_line, a:text_edit['range']['end']['character'], strchars(l:end_line) - a:text_edit['range']['end']['character'])
 
     " create new lines.
-    let l:new_lines = lsp#utils#_split_by_eol(a:text_edit['newText'])
+    let l:new_text = a:text_edit['newText']
+    if empty(l:new_text)
+        " ensure newText is string
+        let l:new_text = ''
+    endif
+    let l:new_lines = lsp#utils#_split_by_eol(l:new_text)
     let l:new_lines[0] = l:before_line . l:new_lines[0]
     let l:new_lines[-1] = l:new_lines[-1] . l:after_line
 


### PR DESCRIPTION
## Problem

When I'm trying [zls](https://github.com/zigtools/zls) (language server for Zig) with this plugin, I found that text `"v:null"` is inserted after selecting completion item on omnicompletion.

Screenshot:

![tmp](https://user-images.githubusercontent.com/823277/111033082-d8896600-8452-11eb-8434-e6aef65133b5.gif)

Repro:

1. Save below code `foo.zig`
2. Move cursor at end of line 5 and enter insert mode
3. Trigger omni completion with `<C-x><C-o>`
4. Select `print`
5. Type `a` key
6. `    std.debug.printa` is expected but got `    std.debug.v:null`

## Fix

After some investigation, I found that zls returned `null` as `newText` entry of `textEdit` in the case. I don't know this conforms LSP spec, but vim-lsp does not consider `null` is put in the entry.

This PR adds check if `newText` has value `null` and when it is `null`, fallbacks to empty string `""`.