### PR TITLE
Use 'label' value when 'insertText' or 'filterText' is falsy

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -93,8 +93,15 @@ endfunction
 
 function! s:get_filter_label(item) abort
     let l:user_data = lsp#omni#get_managed_user_data_from_completed_item(a:item)
-    if has_key(l:user_data, 'completion_item') && has_key(l:user_data['completion_item'], 'filterText') && !empty(l:user_data['completion_item']['filterText'])
-        return lsp#utils#_trim(l:user_data['completion_item']['filterText'])
+    if has_key(l:user_data, 'completion_item') && has_key(l:user_data['completion_item'], 'filterText')
+        let l:filter_text = l:user_data['completion_item']['filterText']
+        if empty(l:filter_text) && has_key(l:user_data['completion_item'], 'label')
+            " When filterText is `falsy` the label is used as the filter text
+            let l:filter_text = l:user_data['completion_item']['label']
+        endif
+        if !empty(l:filter_text)
+            return lsp#utils#_trim(l:filter_text)
+        endif
     endif
     return lsp#utils#_trim(a:item['word'])
 endfunction

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -107,7 +107,11 @@ function! s:on_complete_done_after() abort
     else
       let l:overflow_before = 0
       let l:overflow_after = 0
-      let l:text = get(l:completion_item, 'insertText', l:completed_item['word'])
+      let l:text = get(l:completion_item, 'insertText', '')
+      if empty(l:text)
+        " When insertText is `falsy` the label is used as the insert text
+        let l:text = get(l:completion_item, 'label', l:completed_item['word'])
+      endif
     endif
 
     " apply snipept or text_edit

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -89,12 +89,7 @@ function! s:_apply(bufnr, text_edit, cursor_position) abort
     let l:after_line = strcharpart(l:end_line, a:text_edit['range']['end']['character'], strchars(l:end_line) - a:text_edit['range']['end']['character'])
 
     " create new lines.
-    let l:new_text = a:text_edit['newText']
-    if empty(l:new_text)
-        " ensure newText is string
-        let l:new_text = ''
-    endif
-    let l:new_lines = lsp#utils#_split_by_eol(l:new_text)
+    let l:new_lines = lsp#utils#_split_by_eol(a:text_edit['newText'])
     let l:new_lines[0] = l:before_line . l:new_lines[0]
     let l:new_lines[-1] = l:new_lines[-1] . l:after_line
 

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -70,29 +70,6 @@ Describe lsp#utils#text_edit
             Assert Equals(l:buffer_text, ['foo', 'bar', ''])
         End
 
-        It insert null newText
-            call s:set_text(['foo', 'bar'])
-
-            call lsp#utils#text_edit#apply_text_edits(
-                    \ expand('%'),
-                    \ [{
-                    \   'range': {
-                    \       'start': {
-                    \           'line': 1,
-                    \           'character': 1
-                    \       },
-                    \       'end': {
-                    \           'line': 1,
-                    \           'character': 1
-                    \       }
-                    \   },
-                    \   'newText': v:null
-                    \ }])
-
-            let l:buffer_text = s:get_text()
-            Assert Equals(l:buffer_text, ['foo', 'bar', ''])
-        End
-
         It replace range string to newText
             call s:set_text(['foo', 'bar'])
 


### PR DESCRIPTION
From [LSP v3.1.6](https://microsoft.github.io/language-server-protocol/specification),

```
	/**
	 * A string that should be used when filtering a set of
	 * completion items. When `falsy` the label is used as the
	 * filter text for this item.
	 */
	filterText?: string;

	/**
	 * A string that should be inserted into a document when selecting
	 * this completion. When `falsy` the label is used as the insert text
	 * for this item.
	 *
	 * The `insertText` is subject to interpretation by the client side.
	 * Some tools might not take the string literally. For example
	 * VS Code when code complete is requested in this example
	 * `con<cursor position>` and a completion item with an `insertText` of
	 * `console` is provided it will only insert `sole`. Therefore it is
	 * recommended to use `textEdit` instead since it avoids additional client
	 * side interpretation.
	 */
	insertText?: string;
```

the label should be used as filter text and insert text when they are falsy value. I noticed that vim-lsp does not consider the case where `insertText` is falsy in `s:on_complete_done_after()` at `completion.vim`. And I found that vim-lsp does not use label when `filterText` is falsy.

This PR fixes the issue. And reverts #1093 and #1094.

zls returns `null` as the falsy value of the `insertText` entry. `s:on_complete_done_after()` did not handle the `null` value correctly and it generated invalid `TextEdit` value with null `newText` entry. This was actually cause of #1093.

I tried to add tests for this. But I could not find test for `filterText` and `s:on_complete_done_after` so I could not add them. Please let me know if I'm missing something about tests.