### PR TITLE
Fix calculating last line of text diff in Lua and add new CI for Vim on macOS

### DIFF
--- a/.github/workflows/mac_vim.yml
+++ b/.github/workflows/mac_vim.yml
@@ -1,0 +1,36 @@
+name: mac_vim
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install MacVim
+        shell: bash
+        run: brew install macvim
+      - name: Download test runner
+        shell: bash
+        run: git clone --depth 1 --branch v1.5.5 --single-branch https://github.com/thinca/vim-themis ~/themis
+      - name: Download language servers
+        shell: bash
+        run: |
+          mkdir -p ~/langservers
+          curl -L https://github.com/rust-analyzer/rust-analyzer/releases/download/2020-12-21/rust-analyzer-mac -o ~/langservers/rust-analyzer
+          chmod u+x ~/langservers/rust-analyzer
+          ~/langservers/rust-analyzer --version
+      - name: Run tests
+        shell: bash
+        run: |
+          export PATH=~/themis/bin:$PATH
+          export PATH=~/langservers:$PATH
+          export THEMIS_VIM=vim
+          vim --version
+          themis

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -97,7 +97,7 @@ function! s:LastDifference(old, new, start_char) abort
   if g:lsp_use_lua && s:has_lua
     let l:eval = has('nvim') ? 'vim.api.nvim_eval' : 'vim.eval'
     let l:i = luaeval('vimlsp_last_difference('
-        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.l:eval.'("has(\"nvim\")"),'.l:line_count.')')
+        \.l:eval.'("a:old"),'.l:eval.'("a:new"),'.s:lua_array_start_index.','.l:line_count.')')
   else
 	for l:i in range(-1, -1 * l:line_count, -1)
 	  if a:old[l:i] !=# a:new[l:i] | break | endif


### PR DESCRIPTION
Hi,

This PR

- adds CI workflow for Vim on macOS. I used [MacVim](https://github.com/macvim-dev/macvim) which is most popular Vim distribution for macOS
- fixes calculating text diff in Lua

I confirmed all tests pass with the new workflow on my forked repository: https://github.com/rhysd/vim-lsp/runs/2107026701?check_suite_focus=true