### PR TITLE
Fix CodeAction sign

### DIFF
--- a/autoload/lsp/internal/document_code_action/signs.vim
+++ b/autoload/lsp/internal/document_code_action/signs.vim
@@ -79,7 +79,7 @@ function! s:send_request() abort
         \           'range': l:range,
         \           'context': {
         \               'diagnostics': [],
-        \               'only': ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source', 'source.organizeImports'],
+        \               'only': ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite'],
         \           }
         \       }
         \   })


### PR DESCRIPTION
This PR aims to avoid always showing CodeAction signs if the server returns `source.organizeImports` as CodeAction response.

