### PR TITLE
Improve foldexpr perf

### DIFF
--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -1,4 +1,4 @@
-let s:has_lua = has('nvim-0.4.0') || (has('lua') && has('patch-8.2.0775'))
+let s:has_lua = has('nvim-0.4.0') || (has('lua') && has('patch-8.2.1066'))
 function! lsp#utils#has_lua() abort
     return s:has_lua
 endfunction

--- a/lua/lsp/ui/vim/folding.lua
+++ b/lua/lsp/ui/vim/folding.lua
@@ -1,0 +1,61 @@
+local M = {}
+local utils = require('lsp/utils')
+
+local function valid_range(a)
+  return utils.is_dict(a) and a['startLine'] ~= nil and a['endLine'] ~= nil
+end
+
+function M.sort(folding_ranges)
+  table.sort(folding_ranges, function(a, b)
+    if a['startLine'] ~= b['startLine'] then
+      return a['startLine'] < b['startLine']
+    end
+    return a['endLine'] < b['endLine']
+  end)
+  return folding_ranges
+end
+
+local function in_range(linenr, range)
+  return linenr < range['startLine'] and -1 or range['endLine'] < linenr and 1 or 0
+end
+
+function M.prepare(folding_ranges)
+  return M.sort(utils.filter(folding_ranges, valid_range))
+end
+
+function M.foldexpr_sorted(folding_ranges, linenr)
+  local linenr = linenr - 1
+  local in_ranges = utils.binary_filter(folding_ranges, linenr, in_range)
+  local foldlevel = #in_ranges
+  if utils.binary_search(in_ranges, linenr, function (a, r) return a - r['startLine'] end) > 0 then
+    return '>' .. tostring(foldlevel)
+  elseif utils.binary_search(in_ranges, linenr, function (a, r) return a - r['endLine'] end) > 0 then
+    return '<' .. tostring(foldlevel)
+  else
+    return '='
+  end
+end
+
+function M.foldexpr(folding_ranges, linenr)
+  local foldlevel = 0
+  local prefix = ''
+  for folding_range in utils.list_wrapper(folding_ranges)() do
+    if utils.is_dict(folding_range) and folding_range['startLine'] ~= nil and folding_range['endLine'] ~= nil then
+      startline = folding_range['startLine'] + 1
+      endline = folding_range['endLine'] + 1
+
+      if startline <= linenr and linenr <= endline then
+        foldlevel = foldlevel + 1
+      end
+
+      if startline == linenr then
+        prefix = '>'
+      elseif endline == linenr then
+        prefix = '<'
+      end
+    end
+  end
+  return (prefix == '') and '=' or (prefix .. tostring(foldlevel))
+end
+
+return M

--- a/lua/lsp/utils.lua
+++ b/lua/lsp/utils.lua
@@ -1,0 +1,124 @@
+local M = {}
+
+local DictM = {}
+function DictM.__call(tbl)
+  -- TODO: deal with `lua-special-tbl` in nvim
+  return pairs(tbl)
+end
+
+function M.dict_wrapper(dict)
+  if type(dict) == 'table' then
+    return setmetatable(dict, DictM)
+  else
+    return dict
+  end
+end
+
+local ListM = {}
+function ListM.__call(lst)
+  local i = 0
+  local cnt = #lst
+  return function()
+    i = i + 1
+    if i <= cnt then
+      return lst[i]
+    end
+  end
+end
+
+function M.list_wrapper(lst)
+  if type(lst) == 'table' then
+    return setmetatable(lst, ListM)
+  else
+    return lst
+  end
+end
+
+function M.list()
+  if vim.list then
+    return vim.list()
+  else
+    return {[vim.type_idx]=vim.types.array}
+  end
+end
+
+function M.is_dict(v)
+  if vim.type then
+    return vim.type(v) == 'dict'
+  elseif type(v) == 'table' then
+    if v[vim.type_idx] ~= nil then
+      return v[vim.type_idx] == vim.types.dictionary
+    else
+      return true
+    end
+  else
+    return false
+  end
+end
+
+function M.binary_search(a, value, comparator)
+  local lo = 1
+  local hi = #a
+  while lo <= hi do
+    local mid = lo + math.floor((hi - lo) / 2)
+    local cmp = comparator(value, a[mid])
+    if cmp < 0 then
+      hi = mid - 1
+    elseif cmp > 0 then
+      lo = mid + 1
+    else
+      return mid
+    end
+  end
+  return -1
+end
+
+function M.filter(lst, cond)
+  local new_lst = {}
+  for item in M.list_wrapper(lst)() do
+    if cond(item) then
+      table.insert(new_lst, item)
+    end
+  end
+  return new_lst
+end
+
+function M.binary_filter(a, value, comparator)
+  local lo = 1
+  local hi = #a
+  while lo <= hi do
+    local mid = lo + math.floor((hi - lo) / 2)
+    local cmp = comparator(value, a[mid])
+    if cmp < 0 then
+      hi = mid - 1
+    elseif cmp > 0 then
+      lo = mid + 1
+    else
+      local result = {a[mid]}
+      local left = mid - 1
+      local right = mid + 1
+      while right <= #a do
+        local cmp = comparator(value, a[right])
+        if cmp > 0 then
+          break
+        elseif cmp == 0 then
+          result[#result + 1] = a[right]
+        end
+        right = right + 1
+      end
+      while left >= 1 do
+        local cmp = comparator(value, a[left])
+        if cmp < 0 then
+          break
+        elseif cmp == 0 then
+          table.insert(result, 1, a[left])
+        end
+        left = left - 1
+      end
+      return result
+    end
+  end
+  return {}
+end
+
+return M

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -3,7 +3,7 @@ if exists('g:lsp_loaded') || !exists('*json_encode') || !has('timers') || !has('
 endif
 let g:lsp_loaded = 1
 
-let g:lsp_use_lua = get(g:, 'lsp_use_lua', has('nvim-0.4.0') || (has('lua') && has('patch-8.2.0775')))
+let g:lsp_use_lua = get(g:, 'lsp_use_lua', lsp#utils#has_lua())
 let g:lsp_auto_enable = get(g:, 'lsp_auto_enable', 1)
 let g:lsp_async_completion = get(g:, 'lsp_async_completion', 0)
 let g:lsp_log_file = get(g:, 'lsp_log_file', '')


### PR DESCRIPTION
#1088 

profiles for lua and vim version

> 7656 1.612083 let l:ret = luaeval('require("lsp/ui/vim/folding").foldexpr(_A.fr, _A.l)', {'fr': s:folding_ranges[a:server][a:buf], 'l': a:linenr})
> 7656 40.998533 0.058340 let l:ret = s:foldexpr_old(a:server, a:buf, a:linenr)
> 7656 14.077531 0.056954 let l:ret = s:foldexpr_new(a:server, a:buf, a:linenr)

profiles for foldexpr_sorted

> 4414 0.530323 return luaeval('require("lsp/ui/vim/folding").foldexpr(_A.fr, _A.l)', {'fr': s:folding_ranges[a:server][a:buf], 'l': a:linenr})
> 4414 0.274744 return luaeval('require("lsp/ui/vim/folding").foldexpr_sorted(_A.fr, _A.l)', {'fr': s:folding_ranges[a:server][a:buf], 'l': a:linenr})