### PR TITLE
Include kind in code action list item

### DIFF
--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -110,9 +110,7 @@ function! s:handle_code_action(ctx, server_name, command_id, sync, query, bufnr,
     " Prompt to choose code actions when empty query provided.
     let l:index = 1
     if len(l:total_code_actions) > 1 || empty(a:query)
-        let l:index = inputlist(map(copy(l:total_code_actions), { i, action ->
-                    \   printf('%s - [%s] %s', i + 1, action['server_name'], action['code_action']['title'])
-                    \ }))
+        let l:index = inputlist(map(copy(l:total_code_actions), funcref('s:get_action_list_item_text')))
     endif
 
     " Execute code action.
@@ -150,3 +148,10 @@ function! s:handle_one_code_action(server_name, sync, bufnr, command_or_code_act
     endif
 endfunction
 
+function! s:get_action_list_item_text(index, action) abort
+    let l:text = printf('%s - [%s] %s', a:index + 1, a:action['server_name'], a:action['code_action']['title'])
+    if has_key(a:action['code_action'], 'kind') && a:action['code_action']['kind'] !=# ''
+        let l:text .= ' (' . a:action['code_action']['kind'] . ')'
+    endif
+    return l:text
+endfunction


### PR DESCRIPTION
### Problem

vim-lsp allow to filter code actions by kind value.

```
LspCodeAction [{CodeActionKind}]                            *:LspCodeAction*

Gets a list of possible commands that can be applied to a file so it can be
fixed (quick fix).

If the optional {CodeActionKind} specified, will invoke code action
immediately when matched code action is one only.
```

However there is no way to know the kind name.

### Solution

This PR adds kind in list item when running the command. Here is an example screenshot:

<img width="619" alt="スクリーンショット 2021-03-20 21 45 33" src="https://user-images.githubusercontent.com/823277/111870085-f6604900-89c5-11eb-962e-0f71ab92c77f.png">

Or should we make another command to check kinds of code actions like `:LspListCodeActionKinds`?