### PR TITLE
Handle disabled code action

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -469,7 +469,8 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'codeActionKind': {
     \             'valueSet': ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source', 'source.organizeImports'],
     \           }
-    \         }
+    \         },
+    \         'disabledSupport': v:true,
     \       },
     \       'codeLens': {
     \           'dynamicRegistration': v:false,

--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -116,6 +116,13 @@ function! s:handle_code_action(ctx, server_name, command_id, sync, query, bufnr,
     " Execute code action.
     if 0 < l:index && l:index <= len(l:total_code_actions)
         let l:selected = l:total_code_actions[l:index - 1]
+        if has_key(l:selected, 'disabled')
+            let l:reason = l:selected['disabled']['reason']
+            " Avoid the message is overwritten by inputlist() call
+            redraw
+            echo 'This action is disabled: ' . l:reason
+            return
+        endif
         call s:handle_one_code_action(l:selected['server_name'], a:sync, a:bufnr, l:selected['code_action'])
     endif
 endfunction


### PR DESCRIPTION
[LSP v3.16](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction) defines `disabled` optional property to response of CodeAction request.

```
	/**
	 * Marks that the code action cannot currently be applied.
	 *
	 * Clients should follow the following guidelines regarding disabled code
	 * actions:
	 *
	 * - Disabled code actions are not shown in automatic lightbulbs code
	 *   action menus.
	 *
	 * - Disabled actions are shown as faded out in the code action menu when
	 *   the user request a more specific type of code action, such as
	 *   refactorings.
	 *
	 * - If the user has a keybinding that auto applies a code action and only
	 *   a disabled code actions are returned, the client should show the user
	 *   an error message with `reason` in the editor.
	 *
	 * @since 3.16.0
	 */
	disabled?: {

		/**
		 * Human readable description of why the code action is currently
		 * disabled.
		 *
		 * This is displayed in the code actions UI.
		 */
		reason: string;
	};
```

This PR shows the reason of the disabled action and stops the command execution.