### PR TITLE
Include command argument labels in Code Lens item's text (fix #1118)

### DIFF
--- a/autoload/lsp/internal/ui/quickpick.vim
+++ b/autoload/lsp/internal/ui/quickpick.vim
@@ -1,4 +1,4 @@
-" https://github.com/prabirshrestha/quickpick.vim#37e29b28f65d3ae344ec8eaf7ce2d5f87e2f4b90
+" https://github.com/prabirshrestha/quickpick.vim#cf41eecb983c41e5fc45e83291b551a85fe554d3
 "    :QuickpickEmbed path=autoload/lsp/internal/ui/quickpick.vim namespace=lsp#internal#ui#quickpick prefix=lsp-quickpick
 
 let s:has_timer = exists('*timer_start') && exists('*timer_stop')
@@ -268,10 +268,11 @@ endfunction
 function! s:on_accept() abort
   if win_gotoid(s:state['resultswinid'])
     let l:index = line('.') - 1 " line is 1 index, list is 0 index
-    if l:index < 0
+    let l:fitems = s:state['fitems']
+    if l:index < 0 || len(l:fitems) <= l:index
       let l:items = []
     else
-      let l:items = [s:state['fitems'][l:index]]
+      let l:items = [l:fitems[l:index]]
     endif
     call win_gotoid(s:state['winid'])
     call s:notify('accept', { 'items': l:items })

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -74,6 +74,21 @@ function! s:chooseCodeLens(items, bufnr) abort
     return lsp#callbag#create(function('s:quickpick_open', [a:items, a:bufnr]))
 endfunction
 
+function! s:get_codelens_subtitle(item) abort
+    if !has_key(a:item['codelens']['command'], 'arguments')
+        return ''
+    endif
+
+    let l:arguments = a:item['codelens']['command']['arguments']
+    for l:argument in l:arguments
+        if type(l:argument) != type({}) || !has_key(l:argument, 'label')
+            return ''
+        endif
+    endfor
+
+    return ': ' . join(map(copy(l:arguments), 'v:val["label"]'), ' > ')
+endfunction
+
 function! s:quickpick_open(items, bufnr, next, error, complete) abort
     if empty(a:items)
         return lsp#callbag#empty()
@@ -81,9 +96,10 @@ function! s:quickpick_open(items, bufnr, next, error, complete) abort
 
     let l:items = []
     for l:item in a:items
-        let l:title = printf("[%s] %s\t| L%s:%s",
+        let l:title = printf("[%s] %s%s\t| L%s:%s",
             \ l:item['server'],
             \ l:item['codelens']['command']['title'],
+            \ s:get_codelens_subtitle(l:item),
             \ lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['codelens']['range']['start']),
             \ getbufline(a:bufnr, lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['codelens']['range']['start']))[0])
         call add(l:items, { 'title': l:title, 'item': l:item })

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -74,7 +74,11 @@ function! s:chooseCodeLens(items, bufnr) abort
     return lsp#callbag#create(function('s:quickpick_open', [a:items, a:bufnr]))
 endfunction
 
-function! s:get_codelens_subtitle(item) abort
+function! lsp#ui#vim#code_lens#_get_subtitle(item) abort
+    " Since element of arguments property of Command interface is defined as any in LSP spec, it is
+    " up to the language server implementation.
+    " Currently this only impacts rust-analyzer. See #1118 for more details.
+
     if !has_key(a:item['codelens']['command'], 'arguments')
         return ''
     endif
@@ -99,7 +103,7 @@ function! s:quickpick_open(items, bufnr, next, error, complete) abort
         let l:title = printf("[%s] %s%s\t| L%s:%s",
             \ l:item['server'],
             \ l:item['codelens']['command']['title'],
-            \ s:get_codelens_subtitle(l:item),
+            \ lsp#ui#vim#code_lens#_get_subtitle(l:item),
             \ lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['codelens']['range']['start']),
             \ getbufline(a:bufnr, lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['codelens']['range']['start']))[0])
         call add(l:items, { 'title': l:title, 'item': l:item })

--- a/autoload/lsp/ui/vim/code_lens.vim
+++ b/autoload/lsp/ui/vim/code_lens.vim
@@ -105,7 +105,10 @@ endfunction
 
 function! s:quickpick_accept(next, error, complete, data, ...) abort
     call lsp#internal#ui#quickpick#close()
-    call a:next(a:data['items'][0]['item'])
+    let l:items = a:data['items']
+    if len(l:items) > 0
+        call a:next(l:items[0]['item'])
+    endif
     call a:complete()
 endfunction
 

--- a/test/lsp/ui/vim/code_lens.vimspec
+++ b/test/lsp/ui/vim/code_lens.vimspec
@@ -1,0 +1,134 @@
+Describe lsp#uivim#code_lens
+    Describe lsp#ui#vim#code_lens#_get_subtitle
+        It should generate subtitle from response of rust-analyzer
+            " Example response of Code Lens extracted from #1118
+            let item = {
+            \     'codelens': {
+            \         'command': {
+            \             'arguments': [
+            \                 {
+            \                      'args': {
+            \                           'cargoArgs': ['test', '--package', 'tmp', '--lib'],
+            \                           'cargoExtraArgs': [],
+            \                           'executableArgs': ['tests::it_works', '--exact', '--nocapture'],
+            \                           'overrideCargo': v:null,
+            \                           'workspaceRoot': '/tmp'
+            \                      },
+            \                      'kind': 'cargo',
+            \                      'label': 'test tests::it_works',
+            \                      'location': {
+            \                           'targetRange': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}},
+            \                           'targetSelectionRange': {'end': {'character': 15, 'line': 12}, 'start': {'character': 7, 'line': 12}},
+            \                           'targetUri': 'file:////tmp/src/lib.rs'
+            \                       }
+            \                 }
+            \             ],
+            \             'command': 'rust-analyzer.runSingle',
+            \             'title': '▶︎ Run Test'
+            \         },
+            \         'range': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}}
+            \     },
+            \     'server': 'rust-analyzer'
+            \ }
+
+            let subtitle = lsp#ui#vim#code_lens#_get_subtitle(item)
+            Assert Equals(subtitle, ': test tests::it_works')
+        End
+
+        It should generate subtitle from multiple labels of command arguments
+            let item = {
+            \     'codelens': {
+            \         'command': {
+            \             'arguments': [
+            \                 {
+            \                      'args': {},
+            \                      'kind': 'kind1',
+            \                      'label': 'do command1',
+            \                      'location': {}
+            \                 },
+            \                 {
+            \                      'args': {},
+            \                      'kind': 'kind2',
+            \                      'label': 'do command2',
+            \                      'location': {}
+            \                 }
+            \             ],
+            \             'command': 'server.someCommand',
+            \             'title': 'lens title'
+            \         },
+            \         'range': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}}
+            \     },
+            \     'server': 'rust-analyzer'
+            \ }
+
+            let subtitle = lsp#ui#vim#code_lens#_get_subtitle(item)
+            Assert Equals(subtitle, ': do command1 > do command2')
+        End
+
+        It should return empty string when 'arguments' field is not found
+            let item = {
+            \     'codelens': {
+            \         'command': {
+            \             'command': 'server.someCommand',
+            \             'title': 'lens title'
+            \         },
+            \         'range': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}}
+            \     },
+            \     'server': 'rust-analyzer'
+            \ }
+
+            let subtitle = lsp#ui#vim#code_lens#_get_subtitle(item)
+            Assert Equals(subtitle, '')
+        End
+
+        It should return empty string when 'arguments' field is not an object
+            let item = {
+            \     'codelens': {
+            \         'command': {
+            \             'arguments': [
+            \                 'command1',
+            \                 'command2',
+            \                 'command3'
+            \             ],
+            \             'command': 'server.someCommand',
+            \             'title': 'lens title'
+            \         },
+            \         'range': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}}
+            \     },
+            \     'server': 'rust-analyzer'
+            \ }
+
+            let subtitle = lsp#ui#vim#code_lens#_get_subtitle(item)
+            Assert Equals(subtitle, '')
+        End
+
+        It should return empty string when at least one of elements in 'arguments' field does not have 'label' field
+            let item = {
+            \     'codelens': {
+            \         'command': {
+            \             'arguments': [
+            \                 {
+            \                      'args': {},
+            \                      'kind': 'kind1',
+            \                      'label': 'do command1',
+            \                      'location': {}
+            \                 },
+            \                 {
+            \                      'args': {},
+            \                      'kind': 'kind2',
+            \                      'location': {}
+            \                 }
+            \             ],
+            \             'command': 'server.someCommand',
+            \             'title': 'lens title'
+            \         },
+            \         'range': {'end': {'character': 5, 'line': 14}, 'start': {'character': 4, 'line': 11}}
+            \     },
+            \     'server': 'rust-analyzer'
+            \ }
+
+            let subtitle = lsp#ui#vim#code_lens#_get_subtitle(item)
+            Assert Equals(subtitle, '')
+        End
+    End
+End


### PR DESCRIPTION
Fix #1118 

This PR changes items in quickpick window by `:LspCodeLens`

**Before:**

```
[rust-analyzer] ▶︎ Run Test	| L5:#[cfg(test)]
[rust-analyzer] Debug	| L5:#[cfg(test)]
[rust-analyzer] ▶︎ Run Test	| L7:    #[test]
[rust-analyzer] Debug	| L7:    #[test]
```

**After:**

```
[rust-analyzer] ▶︎ Run Test: test-mod tests	| L5:#[cfg(test)]
[rust-analyzer] Debug: test-mod tests	| L5:#[cfg(test)]
[rust-analyzer] ▶︎ Run Test: test tests::it_works	| L7:    #[test]
[rust-analyzer] Debug: test tests::it_works	| L7:    #[test]
```

Labels such as `test-mod tests` or `test tests::it_works` are included in items hence I can know what each item does.

Since element of `arguments` property of `Command` interface are not defined in LSP spec, it is up to the language server implementation. So this PR's implementation is depending on implementation of `rust-analyzer`. I know that it is not good to add implementation for specific language server, but #1118 is really critical for me to use Code Lens so I made this PR.

In addition, I also found small index-out-of-range bug in quickpick implementation. c275020 fixed it.