### PR TITLE
Highlight *.vimspec and .themisrc as Vim script on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto
+*.vimspec linguist-language=vim
+.themisrc linguist-language=vim


### PR DESCRIPTION
This PR adds syntax highlights to `.themisrc` and `*.vimspec` files as Vim script on GitHub. It is better for:

- reviewing code changes on GitHub
- looking at sources on GitHub

Here are examples of highlighted sources:

- https://github.com/rhysd/vim-lsp/blob/highlight-vimspec/test/.themisrc
- https://github.com/rhysd/vim-lsp/blob/highlight-vimspec/test/lsp/omni.vimspec