### PR TITLE
Select preferred action by default in quickpick by putting it at top of the results list

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -472,6 +472,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \             'valueSet': ['', 'quickfix', 'refactor', 'refactor.extract', 'refactor.inline', 'refactor.rewrite', 'source', 'source.organizeImports'],
     \           }
     \         },
+    \         'isPreferredSupport': v:true,
     \         'disabledSupport': v:true,
     \       },
     \       'codeLens': {

--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -94,10 +94,15 @@ function! s:handle_code_action(ctx, server_name, command_id, sync, query, bufnr,
         endif
 
         for l:code_action in l:code_actions
-            call add(l:total_code_actions, {
-            \    'server_name': l:server_name,
-            \    'code_action': l:code_action,
-            \})
+            let l:item = {
+            \   'server_name': l:server_name,
+            \   'code_action': l:code_action,
+            \ }
+            if get(l:code_action, 'isPreferred', v:false)
+                let l:total_code_actions = [l:item] + l:total_code_actions
+            else
+                call add(l:total_code_actions, l:item)
+            endif
         endfor
     endfor
 


### PR DESCRIPTION
From [spec](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction):

```typescript
export interface CodeAction {
	...

	/**
	 * Marks this as a preferred action. Preferred actions are used by the
	 * `auto fix` command and can be targeted by keybindings.
	 *
	 * A quick fix should be marked preferred if it properly addresses the
	 * underlying error. A refactoring should be marked preferred if it is the
	 * most reasonable choice of actions to take.
	 *
	 * @since 3.15.0
	 */
	isPreferred?: boolean;

	...
}
```

Since now quickpick is used to select Code Action results, an item at top of the results list can be run only typing `<CR>` quickly.

I thought putting a preferred action at top of the list is useful to run most reasonable action quickly.