### PR TITLE
Always show the kind and name in CallHierarchy

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -443,10 +443,9 @@ function! s:hierarchy_item_to_vim(item, server) abort
 
     let l:path = lsp#utils#uri_to_path(l:uri)
     let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, a:item['range']['start'])
+    let l:text = '[' . lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, a:item['kind']) . '] ' . a:item['name']
     if has_key(a:item, 'detail')
-        let l:text = a:item['detail']
-    else
-        let l:text = '[' . lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, a:item['kind']) . '] ' . a:item['name']
+        let l:text .= ": " . a:item['detail']
     endif
 
     return {


### PR DESCRIPTION
#1113 improved the quickfix.
But the output of `gopls` looks like this due to the current implementation([v0.6.9](https://github.com/golang/tools/blob/gopls/v0.6.9/internal/lsp/source/call_hierarchy.go#L291)).

```
internal/lsp/source/identifier.go|57 col 6| golang.org/x/tools/internal/lsp/source • identifier.go
```

So, fix to show the kind and name as follow.

```
internal/lsp/source/identifier.go|57 col 6| [function] Identifier: golang.org/x/tools/internal/lsp/source • identifier.go
```

After(rust):

```
src/lib.rs|1 col 1| [function] get_two: fn get_two() -> i32
```
