### PR TITLE
Include maintainers information in document

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,11 @@ let g:asyncomplete_log_file = expand('~/asyncomplete.log')
 [vim-themis](https://github.com/thinca/vim-themis) is used for testing. To run
 integration tests [gopls](https://github.com/golang/tools/tree/master/gopls)
 executable must be in path.
+
+## Maintainers
+
+- [Prabir Shrestha](https://github.com/prabirshrestha) (author, maintainer)
+- [mattn](https://github.com/mattn) (maintainer)
+- [hrsh7th](https://github.com/hrsh7th) (maintainer)
+- [Thomas Faingnaert](https://github.com/thomasfaingnaert) (maintainer)
+- [rhysd](https://github.com/rhysd) (maintainer)

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -143,7 +143,6 @@ CONTENTS                                                  *vim-lsp-contents*
     Mappings                              |vim-lsp-mappings|
        <plug>(lsp-preview-close)            |<plug>(lsp-preview-close)|
        <plug>(lsp-preview-focus)            |<plug>(lsp-preview-focus)|
-
     Autocomplete                          |vim-lsp-autocomplete|
       omnifunc                              |vim-lsp-omnifunc|
       asyncomplete.vim                      |vim-lsp-asyncomplete|
@@ -152,6 +151,7 @@ CONTENTS                                                  *vim-lsp-contents*
     Folding                               |vim-lsp-folding|
     Semantic highlighting                 |vim-lsp-semantic|
     License                               |vim-lsp-license|
+    Maintainers                           |vim-lsp-maintainers|
 
 
 ==============================================================================
@@ -1937,5 +1937,14 @@ License                                                    *vim-lsp-license*
 The MIT License (MIT)
 
 Full license text: https://github.com/prabirshrestha/vim-lsp/blob/master/LICENSE
+
+==============================================================================
+Maintainers                                             *vim-lsp-maintainers*
+
+* Prabir Shrestha (author, maintainer): https://github.com/prabirshrestha
+* mattn (maintainer): https://github.com/mattn
+* hrsh7th (maintainer): https://github.com/hrsh7th
+* Thomas Faingnaert (maintainer): https://github.com/thomasfaingnaert
+* rhysd (maintainer): https://github.com/rhysd
 
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
so that users can easily contact to maintainers without making issues on repository (for example, on SNS).