### PR TITLE
Show completion item detail when there is no documentation

### DIFF
--- a/autoload/lsp/internal/completion/documentation.vim
+++ b/autoload/lsp/internal/completion/documentation.vim
@@ -64,7 +64,7 @@ function! s:resolve_completion(event) abort
             \ }})
             \ )
     else
-        return lsp#callbag#of({})
+        return lsp#callbag#of(l:managed_user_data)
     endif
 endfunction
 


### PR DESCRIPTION
Currently we prepend `CompletionItem.detail` to popup when `documentation` exists, but when there's no `documentation` we show nothing even when `detail` exists. This PR fixes this.