### PR TITLE
Added globals g:lsp_disable_copen and g:lsp_disable_lopen to make quickfix and loclist window openings conditional

### DIFF
--- a/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
+++ b/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
@@ -35,6 +35,10 @@ function! lsp#internal#diagnostics#document_diagnostics_command#do(options) abor
     else
         call setloclist(0, l:result)
         echo 'Retrieved diagnostics results'
-        botright lopen
+        if exists('g:Lsp_lopen_funcref')
+          call g:Lsp_lopen_funcref()
+        else
+          botright lopen
+        endif
     endif
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -216,7 +216,11 @@ function! s:handle_symbol(server, last_command_id, type, data) abort
         call lsp#utils#error('No ' . a:type .' found')
     else
         echo 'Retrieved ' . a:type
-        botright copen
+        if exists('g:Lsp_copen_funcref')
+          call g:Lsp_copen_funcref()
+        else
+          botright copen
+        endif
     endif
 endfunction
 
@@ -249,7 +253,11 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 call setqflist([])
                 call setqflist(a:ctx['list'])
                 echo 'Retrieved ' . a:type
-                botright copen
+                if exists('g:Lsp_copen_funcref')
+                  call g:Lsp_copen_funcref()
+                else
+                  botright copen
+                endif
             else
                 let l:lines = readfile(l:loc['filename'])
                 if has_key(l:loc,'viewstart') " showing a locationLink
@@ -430,7 +438,11 @@ function! s:handle_call_hierarchy(ctx, server, type, data) abort
             call setqflist([])
             call setqflist(a:ctx['list'])
             echo 'Retrieved ' . a:type
-            botright copen
+            if exists('g:Lsp_copen_funcref')
+              call g:Lsp_copen_funcref()
+            else
+              botright copen
+            endif
         endif
     endif
 endfunction

--- a/autoload/lsp/utils/workspace_edit.vim
+++ b/autoload/lsp/utils/workspace_edit.vim
@@ -14,7 +14,11 @@ function! lsp#utils#workspace_edit#apply_workspace_edit(workspace_edit) abort
 
     if g:lsp_show_workspace_edits
         call setloclist(0, l:loclist_items, 'r')
-        execute 'lopen'
+        if exists('g:Lsp_lopen_funcref')
+          call g:Lsp_lopen_funcref()
+        else
+          execute 'lopen'
+        endif
     endif
 endfunction
 


### PR DESCRIPTION
This PR follows the issue I opened a few days ago ([https://github.com/prabirshrestha/vim-lsp/issues/1134](https://github.com/prabirshrestha/vim-lsp/issues/1134)). 
The PR just guards calls to copen/lopen in if conditions, executing callback functions if g:Lsp_copen_funcref or g:Lsp_lopen_funcref are defined, so that the user can control that and do whatever with the info vim-lsp returns (in my case, it's to be able to fuzzyfind symbols with fzf.vim). Feel free to improve it if you got better ideas in this sense.