### PR TITLE
Set type of location list items for diagnostics

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -110,13 +110,16 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
     if !empty(l:diagnostics) && lsp#utils#is_file_uri(l:uri)
         let l:path = lsp#utils#uri_to_path(l:uri)
         for l:item in l:diagnostics
-            let l:has_severity = has_key(l:item, 'severity') && !empty(l:item['severity'])
+            let l:severity_text = ''
+            if has_key(l:item, 'severity') && !empty(l:item['severity'])
+                let l:severity_text = s:get_diagnostic_severity_text(l:item['severity'])
+            endif
             let l:text = ''
             if has_key(l:item, 'source') && !empty(l:item['source'])
                 let l:text .= l:item['source'] . ':'
             endif
-            if l:has_severity
-                let l:text .= s:get_diagnostic_severity_text(l:item['severity']) . ':'
+            if l:severity_text !=# ''
+                let l:text .= l:severity_text . ':'
             endif
             if has_key(l:item, 'code') && !empty(l:item['code'])
                 let l:text .= l:item['code'] . ':'
@@ -129,9 +132,9 @@ function! lsp#ui#vim#utils#diagnostics_to_loc_list(result) abort
                 \ 'col': l:col,
                 \ 'text': l:text,
                 \ }
-            if l:has_severity
+            if l:severity_text !=# ''
                 " 'E' for error, 'W' for warning, 'I' for information, 'H' for hint
-                let l:location_item['type'] = s:diagnostic_severity[l:item['severity']][0]
+                let l:location_item['type'] = l:severity_text[0]
             endif
             call add(l:list, l:location_item)
         endfor

--- a/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
+++ b/test/lsp/internal/diagnostics/document_diagnostics_command.vimspec
@@ -35,8 +35,8 @@ Describe lsp#internal#diagnostics#document_diagnostics_command
             \ ]}}
 
         let l:server1_response2 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri2, 'diagnostics': [
-            \ {'severity': 1, 'message': 'm3', 'range': { 'start': { 'line': 2, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
-            \ {'severity': 1, 'message': 'm4', 'range': { 'start': { 'line': 3, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
+            \ {'severity': 2, 'message': 'm3', 'range': { 'start': { 'line': 2, 'character': 1, 'end': { 'line': 1, 'character': 1 } } }},
+            \ {'severity': 2, 'message': 'm4', 'range': { 'start': { 'line': 3, 'character': 2, 'end': { 'line': 1, 'character': 3 } } }},
             \ ]}}
 
         call lsp#stream(1, { 'server': 'server1', 'response': l:server1_response1 })
@@ -50,8 +50,8 @@ Describe lsp#internal#diagnostics#document_diagnostics_command
         call map(l:result, {_, v -> extend(v, {'module': ''})})
 
         Assert Equals(l:result, [
-            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
-            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'module': '', 'text': 'Error:m2'},
             \ ])
         execute ':lclose'
 
@@ -64,10 +64,10 @@ Describe lsp#internal#diagnostics#document_diagnostics_command
 
         " +2 for bufnr because original bufnr + loclist + new unopened file
         Assert Equals(l:result, [
-            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m1'},
-            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m2'},
-            \ {'lnum': 3, 'bufnr': l:bufnr + 2, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m3'},
-            \ {'lnum': 4, 'bufnr': l:bufnr + 2, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'module': '', 'text': 'Error:m4'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'module': '', 'text': 'Error:m1'},
+            \ {'lnum': 2, 'bufnr': l:bufnr, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'E', 'module': '', 'text': 'Error:m2'},
+            \ {'lnum': 3, 'bufnr': l:bufnr + 2, 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'W', 'module': '', 'text': 'Warning:m3'},
+            \ {'lnum': 4, 'bufnr': l:bufnr + 2, 'col': 3, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': 0, 'type': 'W', 'module': '', 'text': 'Warning:m4'},
             \ ])
         execute ':lclose'
     End


### PR DESCRIPTION
Item of location list can have key `"type"`, which represents single-character error type, 'E', 'W', etc. This can be calculated from severity of diagnostics results but currently it is not set.

This PR sets the key as follows:

- `"E"` for error
- `"W"` for warning
- `"I"` for information
- `"H"` for hint
- does not set `"type"` when no severity is specified in the diagnostics results

With this PR, location list now shows the type of item:

- before:

<img width="664" alt="スクリーンショット 2021-04-12 17 45 49" src="https://user-images.githubusercontent.com/823277/114367554-835a8480-9bb7-11eb-84c7-8e05ed2e4d43.png">

- after:

<img width="689" alt="スクリーンショット 2021-04-12 17 46 42" src="https://user-images.githubusercontent.com/823277/114367595-8ce3ec80-9bb7-11eb-863e-c456c5d252ad.png">
