### PR TITLE
Transform cygwin/msys2 paths to windows before encoding them to URIs

### DIFF
--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -117,13 +117,21 @@ else
 endif
 
 let s:uri_to_path_cache = {}
-if has('win32') || has('win64')
+if has('win32') || has('win64') || has('win32unix')
     function! lsp#utils#uri_to_path(uri) abort
         if has_key(s:uri_to_path_cache, a:uri)
             return s:uri_to_path_cache[a:uri]
         endif
 
-        let s:uri_to_path_cache[a:uri] = substitute(s:decode_uri(a:uri[len('file:///'):]), '/', '\\', 'g')
+        let l:path = substitute(s:decode_uri(a:uri[len('file:///'):]), '/', '\\', 'g')
+
+        " Transform windows paths to cygwin paths
+        if has('win32unix')
+            let l:path = substitute(l:path, '\c^\([A-Z]\):\\', '/\l\1/', '')
+            let l:path = substitute(l:path, '\\', '/', 'g')
+        endif
+
+        let s:uri_to_path_cache[a:uri] = l:path
         return s:uri_to_path_cache[a:uri]
     endfunction
 else


### PR DESCRIPTION
Cygwin/MSYS2 paths have the form:
```
/c/Users/SomeUser/path
```
While native Windows paths have the form:
```
C:\Users\SomeUser\path
```

Currently vim-lsp transforms the paths to URIs to the following relevant forms:
Cygwin / MSYS2
```
file:///c/Users/SomeUser/path
```
Native Windows
```
file:///C:/Users/SomeUser/path
```

The Language Servers though that are commonly built and run in windows (e.g. eclipse jdt.ls) do recognize and function only using the second URI form, as this is a valid Windows file URI.

Current PR fixes this, by transforming paths when running vim in cygwin mode before encoding them.

Tested and makes eclipse jdt.ls functional with MSYS2 vim.