### PR TITLE
Make g:lsp_auto_enable work when lazily loaded

### DIFF
--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -69,13 +69,6 @@ let g:lsp_work_done_progress_enabled = get(g:, 'lsp_work_done_progress_enabled',
 
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 
-if g:lsp_auto_enable
-    augroup lsp_auto_enable
-        autocmd!
-        autocmd VimEnter * call lsp#enable()
-    augroup END
-endif
-
 command! LspCallHierarchyIncoming call lsp#ui#vim#call_hierarchy_incoming()
 command! LspCallHierarchyOutgoing call lsp#ui#vim#call_hierarchy_outgoing()
 command! -range -nargs=* -complete=customlist,lsp#ui#vim#code_action#complete LspCodeAction call lsp#ui#vim#code_action#do({
@@ -179,3 +172,14 @@ nnoremap <silent> <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
 nnoremap <silent> <plug>(lsp-next-reference) :<c-u>call lsp#internal#document_highlight#jump(+1)<cr>
 nnoremap <silent> <plug>(lsp-previous-reference) :<c-u>call lsp#internal#document_highlight#jump(-1)<cr>
 nnoremap <silent> <plug>(lsp-signature-help) :<c-u>call lsp#ui#vim#signature_help#get_signature_help_under_cursor()<cr>
+
+if g:lsp_auto_enable
+    if has('vim_starting')
+        augroup lsp_auto_enable
+            autocmd!
+            autocmd VimEnter * call lsp#enable()
+        augroup END
+    else
+        call lsp#enable()
+    endif
+endif

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -5,6 +5,7 @@ call themis#helper('command').with(themis#helper('assert'))
 
 set runtimepath+=./test/utils
 
+let g:lsp_auto_enable = 0
 " let g:lsp_log_verbose = 1
 " let g:lsp_log_file = expand("~/.config/nvim/data/lsp.log")
 autocmd BufNewFile,BufRead *.rs setfiletype rust


### PR DESCRIPTION
When vim-lsp is loaded after vim's starting (e.g. with `:packadd`), it is not enabled regardless of the value of `g:lsp_auto_enable`. So if you want to *lazily* load vim-lsp, you need to call `lsp#enable()` manually although the variable exists.
This PR makes vim-lsp to call `lsp#enable()` if `g:lsp_auto_enable` is TRUE in such condition. I think this behavior is what users expect from the variable's name.

This PR have a side effect to change the default behavior written above, because `g:lsp_auto_enable` is TRUE by default. You can disable its auto-enabling by setting `g:lsp_auto_enable = 0`.
I think most users who want to load vim-lsp on demand also want to enable vim-lsp at the same time, so this will not be a big problem.