### PR TITLE
Add missing return on empty hover contents

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -46,6 +46,7 @@ function! s:show_hover(server_name, request, response) abort
     if !has_key(a:response, 'result') || empty(a:response['result']) || 
         \ empty(a:response['result']['contents'])
         call lsp#utils#error('No hover information found in server - ' . a:server_name)
+        return
     endif
 
     call lsp#ui#vim#output#preview(a:server_name, a:response['result']['contents'], {'statusline': ' LSP Hover'})


### PR DESCRIPTION
Fix #1141 

It shows error message on empty hover contents but it continues to open preview window then it shows empty preview window.