### PR TITLE
Fix error on editing empty file

### DIFF
--- a/autoload/lsp/utils/position.vim
+++ b/autoload/lsp/utils/position.vim
@@ -12,6 +12,10 @@ function! s:to_col(expr, lnum, char) abort
         endif
         " a:expr is a file that is not yet loaded as a buffer
         let l:lines = readfile(a:expr, '', a:lnum)
+        if l:lines == []
+            " when the file is empty. a:char should be 0 in the case
+            return a:char + 1
+        endif
     endif
     let l:linestr = l:lines[-1]
     return strlen(strcharpart(l:linestr, 0, a:char)) + 1


### PR DESCRIPTION
This PR fixes following exception.

```
Vim(let):E684: list index out of range: -1 at function lsp#ui#vim#utils#diagnostics_to_loc_list[24]..lsp#utils#position#lsp_to_vim[2]..lsp#utils#position#lsp_character_to_vim[3]..<SNR>193_to_col, line 10
```

Repro:

1. Save empty file `echo > foo.py`
2. Open the file in Vim `vim foo.py`
3. Language server reports some error on the first (empty) line
4. call `lsp#ui#vim#utils#diagnostics_to_loc_list()`