### PR TITLE
More secure minimal.vimrc

### DIFF
--- a/minimal.vimrc
+++ b/minimal.vimrc
@@ -6,12 +6,12 @@
 
 set nocompatible hidden laststatus=2
 
-if !filereadable('/tmp/plug.vim')
-  silent !curl --insecure -fLo /tmp/plug.vim
+if !filereadable(expand('~/plug.vim'))
+  silent !curl -fLo ~/plug.vim
     \ https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 endif
 
-source /tmp/plug.vim
+source ~/plug.vim
 
 call plug#begin('/tmp/plugged')
 Plug 'prabirshrestha/asyncomplete.vim'

--- a/minimal.vimrc
+++ b/minimal.vimrc
@@ -13,7 +13,7 @@ endif
 
 source ~/plug.vim
 
-call plug#begin('/tmp/plugged')
+call plug#begin('~/.vim.plugged')
 Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/vim-lsp'
 Plug 'prabirshrestha/asyncomplete-lsp.vim'


### PR DESCRIPTION
Make minimal.vimrc not execute arbitrary code from Internet or local processes.
- Do not skip TLS checks. GitHub should have valid TLS certificate.
- Save plug.vim to home directory. /tmp is writeable by all local processes.