### PR TITLE
Add border to completion popups

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
@@ -390,6 +390,7 @@ else
     \   'tabpage': 0,
     \   'firstline': l:style.topline,
     \   'padding': [0, 0, 0, 0],
+    \   'border': [],
     \   'fixed': v:true,
     \ }
   endfunction


### PR DESCRIPTION
Adds a nice border to autocompletion popups:

![image](https://user-images.githubusercontent.com/4622346/117310385-e922ef00-ae8b-11eb-94e3-d96b64f0366f.png)
