### PR TITLE
Fix typo.

### DIFF
--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1484,8 +1484,8 @@ Format the current document selection.
 
 LspDocumentRangeFormatSync                     *:LspDocumentRangeFormatSync*
 
-Same as |:LspDocumentRangeFormat| but synchronous. Useful when running running
-:autocmd commands. Set |g:lsp_format_sync_timeout| to configure timeouts.
+Same as |:LspDocumentRangeFormat| but synchronous. Useful when running :autocmd
+commands. Set |g:lsp_format_sync_timeout| to configure timeouts.
 
 Note that this may slow down vim.
 


### PR DESCRIPTION
The word "running" appeared twice, so it was removed. The updated line is 79 characters long.