### PR TITLE
Add argument to preview function to clear statusbar (#1173)

### DIFF
--- a/autoload/lsp/internal/diagnostics.vim
+++ b/autoload/lsp/internal/diagnostics.vim
@@ -3,9 +3,9 @@ function! lsp#internal#diagnostics#_enable() abort
     if !g:lsp_diagnostics_enabled | return | endif
 
     call lsp#internal#diagnostics#state#_enable() " Needs to be the first one to register
+    call lsp#internal#diagnostics#float#_enable() " Needs to be registered before echo to avoid visual glitches in nvim
     call lsp#internal#diagnostics#echo#_enable()
     call lsp#internal#diagnostics#highlights#_enable()
-    call lsp#internal#diagnostics#float#_enable()
     call lsp#internal#diagnostics#signs#_enable()
     call lsp#internal#diagnostics#virtual_text#_enable()
 endfunction

--- a/autoload/lsp/internal/diagnostics/float.vim
+++ b/autoload/lsp/internal/diagnostics/float.vim
@@ -36,7 +36,7 @@ function! s:show_float(diagnostic) abort
         let l:lines = split(a:diagnostic['message'], '\n', 1)
         call lsp#ui#vim#output#preview('', l:lines, {
             \   'statusline': ' LSP Diagnostics'
-            \})
+            \}, 0)
         let s:displaying_message = 1
     elseif get(s:, 'displaying_message', 0)
         call lsp#ui#vim#output#closepreview()

--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -49,5 +49,5 @@ function! s:show_hover(server_name, request, response) abort
         return
     endif
 
-    call lsp#ui#vim#output#preview(a:server_name, a:response['result']['contents'], {'statusline': ' LSP Hover'})
+    call lsp#ui#vim#output#preview(a:server_name, a:response['result']['contents'], {'statusline': ' LSP Hover'}, 1)
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -257,7 +257,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                     call lsp#ui#vim#output#preview(a:server, l:view, {
                         \   'statusline': ' LSP Peek ' . a:type,
                         \   'filetype': &filetype
-                        \ })
+                        \ }, 1)
                 else " showing a location
                     call lsp#ui#vim#output#preview(a:server, l:lines, {
                         \   'statusline': ' LSP Peek ' . a:type,

--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -326,7 +326,7 @@ function! lsp#ui#vim#output#float_supported() abort
     return s:use_vim_popup || s:use_nvim_float
 endfunction
 
-function! lsp#ui#vim#output#preview(server, data, options) abort
+function! lsp#ui#vim#output#preview(server, data, options, clear_commandbar) abort
     if s:is_cmdwin()
         return
     endif
@@ -337,7 +337,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
         \ && len(g:lsp_preview_doubletap) >= 1
         \ && type(g:lsp_preview_doubletap[0]) ==# 2
         \ && index(['i', 's'], mode()[0]) ==# -1
-        echo ''
+        if a:clear_commandbar | echo '' | endif
         return call(g:lsp_preview_doubletap[0], [])
     endif
     " Close any previously opened preview window
@@ -379,7 +379,7 @@ function! lsp#ui#vim#output#preview(server, data, options) abort
     " Go to the previous window to adjust positioning
     call win_gotoid(l:current_window_id)
 
-    echo ''
+    if a:clear_commandbar | echo '' | endif
 
     if s:winid && (s:use_vim_popup || s:use_nvim_float)
       if s:use_nvim_float

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -77,7 +77,7 @@ function! s:handle_signature_help(server, data) abort
             call add(l:contents, l:signature['documentation'])
         endif
 
-        call lsp#ui#vim#output#preview(a:server, l:contents, {'statusline': ' LSP SignatureHelp'})
+        call lsp#ui#vim#output#preview(a:server, l:contents, {'statusline': ' LSP SignatureHelp'}, 1)
         return
     else
         " signature help is used while inserting. So this must be graceful.


### PR DESCRIPTION
- The 'preview' function cleared commandbar unconditionally, which
caused loss of info provided by previous functions, new argument helps
to avoid that

- Register float diagnostic before echo to avoid preview window
positioning problems in nvim