### PR TITLE
Avoid duplicated syn include

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Syntax/Markdown.vim
+++ b/autoload/vital/_lsp/VS/Vim/Syntax/Markdown.vim
@@ -16,6 +16,7 @@ function! s:apply(...) abort
   let l:text = type(l:text) == v:t_list ? join(l:text, "\n") : l:text
 
   if !exists('b:___VS_Vim_Syntax_Markdown')
+    call s:_execute('syntax sync clear')
     call s:_execute('runtime! syntax/markdown.vim')
 
     " Remove markdownCodeBlock because we support it manually.

--- a/autoload/vital/_lsp/VS/Vim/Window.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window.vim
@@ -106,8 +106,8 @@ function! s:scroll(winid, topline) abort
   function! l:ctx.callback(winid, topline) abort
     let l:wininfo = s:info(a:winid)
     let l:topline = a:topline
-    let l:topline = max([l:topline, 1])
     let l:topline = min([l:topline, line('$') - l:wininfo.height + 1])
+    let l:topline = max([l:topline, 1])
 
     if l:topline == l:wininfo.topline
       return

--- a/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
@@ -339,6 +339,9 @@ else
   endfunction
 endif
 
+"
+" info
+"
 if has('nvim')
   function! s:_info(winid) abort
     let l:info = getwininfo(a:winid)[0]


### PR DESCRIPTION
Avoiding execute `syn include` twice. (Thank you @mattn)
