### PR TITLE
Update vital-vs

### DIFF
--- a/autoload/vital/_lsp/VS/LSP/MarkupContent.vim
+++ b/autoload/vital/_lsp/VS/LSP/MarkupContent.vim
@@ -24,25 +24,28 @@ endfunction
 "
 " normalize
 "
-function! s:normalize(markup_content) abort
+function! s:normalize(markup_content, ...) abort
+  let l:option = get(a:000, 0, {})
+  let l:option.compact = get(l:option, 'compact', v:true)
+
+  let l:normalized = ''
   if type(a:markup_content) == type('')
-    return s:_compact(a:markup_content)
+    let l:normalized = a:markup_content
   elseif type(a:markup_content) == type([])
-    return s:_compact(join(a:markup_content, "\n"))
+    let l:normalized = join(a:markup_content, "\n")
   elseif type(a:markup_content) == type({})
-    let l:string = a:markup_content.value
+    let l:normalized = a:markup_content.value
     if has_key(a:markup_content, 'language')
-      let l:string = '```' . a:markup_content.language . ' ' . l:string . ' ```'
+      let l:normalized = '```' . a:markup_content.language . ' ' . l:normalized . ' ```'
     elseif get(a:markup_content, 'kind', 'plaintext') ==# 'plaintext'
       let l:string = '```plaintext ' . l:string . ' ```'
     endif
-    return s:_compact(l:string)
   endif
+  if l:option.compact
+    return s:_compact(l:normalized)
+  endif
+  return l:normalized
 endfunction
-
-let s:_compact_fenced_start = '\%(^\|' . "\n" . '\)\s*'
-let s:_compact_fenced_end = '\s*\%($\|' . "\n" . '\)'
-let s:_compact_fenced_empty = '\s*\%(\s\|' . "\n" . '\)\s*'
 
 "
 " _compact
@@ -51,14 +54,10 @@ function! s:_compact(string) abort
   " normalize eol.
   let l:string = s:Text.normalize_eol(a:string)
 
-  " compact fenced code block start.
-  let l:string = substitute(l:string, s:_compact_fenced_start . '```\s*\w\+\s*\zs' . s:_compact_fenced_empty, ' ', 'g')
-
-  " compact fenced code block end.
-  let l:string = substitute(l:string, s:_compact_fenced_empty . '\ze```' . s:_compact_fenced_end, ' ', 'g')
-
-  " trim first/last whitespace.
-  let l:string = substitute(l:string, '^' . s:_compact_fenced_empty . '\|' . s:_compact_fenced_empty . '$', '', 'g')
+  let l:string = substitute(l:string, "\\%(\\s\\|\n\\)*```\\s*\\(\\w\\+\\)\\%(\\s\\|\n\\)\\+", "\n\n```\\1 ", 'g')
+  let l:string = substitute(l:string, "\\%(\\s\\|\n\\)\\+```\\%(\\s*\\%(\\%$\\|\n\\)\\)\\+", " ```\n\n", 'g')
+  let l:string = substitute(l:string, "\\%^\\%(\\s\\|\n\\)*", '', 'g')
+  let l:string = substitute(l:string, "\\%(\\s\\|\n\\)*\\%$", '', 'g')
 
   return l:string
 endfunction

--- a/autoload/vital/_lsp/VS/Vim/Buffer.vim
+++ b/autoload/vital/_lsp/VS/Vim/Buffer.vim
@@ -50,9 +50,8 @@ function! s:ensure(expr) abort
   if !bufexists(a:expr)
     if type(a:expr) == type(0)
       throw printf('VS.Vim.Buffer: `%s` is not valid expr.', l:bufnr)
-    else
-      badd `=a:expr`
     endif
+    badd `=a:expr`
   endif
   return bufnr(a:expr)
 endfunction

--- a/autoload/vital/_lsp/VS/Vim/Window.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window.vim
@@ -19,7 +19,7 @@ function! s:do(winid, func) abort
     return
   endif
 
-  if exists('*win_execute')
+  if !has('nvim') && exists('*win_execute')
     let s:Do = a:func
     try
       noautocmd keepalt keepjumps call win_execute(a:winid, 'call s:Do()')

--- a/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
@@ -304,7 +304,9 @@ else
       let a:self._on_closed = l:On_closed
       return s:_open(a:bufnr, a:style, { -> a:self._on_closed() })
     endif
-    call popup_move(a:winid, s:_style(a:style))
+    let l:style = s:_style(a:style)
+    call popup_move(a:winid, l:style)
+    call popup_setoptions(a:winid, l:style)
     return a:winid
   endfunction
 endif
@@ -478,12 +480,13 @@ endif
 " init
 "
 let s:has_init = v:false
+let s:filepath = expand('<sfile>:p')
 function! s:_init() abort
   if s:has_init || !has('nvim')
     return
   endif
   let s:has_init = v:true
-  augroup printf('VS_Vim_Window_FloatingWindow:%s', expand('<sfile>'))
+  execute printf('augroup VS_Vim_Window_FloatingWindow:%s', s:filepath)
     autocmd!
     autocmd WinEnter * call <SID>_notify_closed()
   augroup END


### PR DESCRIPTION
This PR aims to solve the wrong augroup creation.

The older implementation wouldn't create correct augroup (it will be `printf('VS_Vim_Window_FloatingWindow:...)`.
The newer implementation will create expected augroup that will be filepath instead.