### PR TITLE
Trim trailing whitespace from a hover text

### DIFF
--- a/autoload/vital/_lsp/VS/LSP/MarkupContent.vim
+++ b/autoload/vital/_lsp/VS/LSP/MarkupContent.vim
@@ -51,6 +51,9 @@ function! s:_compact(string) abort
   " normalize eol.
   let l:string = s:Text.normalize_eol(a:string)
 
+  " trim trailing whitespace from each line
+  let l:string = substitute(l:string, '\v\s+\ze%(\n|$)', '', 'g')
+
   " compact fenced code block start.
   let l:string = substitute(l:string, s:_compact_fenced_start . '```\s*\w\+\s*\zs' . s:_compact_fenced_empty, ' ', 'g')
 


### PR DESCRIPTION
Hi.
I have my Vim configured to highlight trailing whitespace. It looks like clangd returns hover data containing spaces at the end of some lines and I get this ugly picture:
![scaled](https://user-images.githubusercontent.com/8867360/128605083-7861aab2-67fc-4d3b-bf18-88483d984e15.png)


This PR removes trailing whitespace from each line of the hover text (I guess it's harmless).
