### PR TITLE
Add Neovim 0.5.0 to CI and allow CI failure with Neovim nightly

### DIFF
--- a/.github/workflows/linux_neovim.yml
+++ b/.github/workflows/linux_neovim.yml
@@ -24,13 +24,17 @@ jobs:
           - name: neovim-v04-x64
             os: ubuntu-latest
             neovim_version: v0.4.4
+            allow_failure: false
           - name: neovim-v05-x64
             os: ubuntu-latest
             neovim_version: v0.5.0
+            allow_failure: false
           - name: neovim-nightly-x64
             os: ubuntu-latest
             neovim_version: nightly
+            allow_failure: true
     runs-on: ${{matrix.os}}
+    continue-on-error: ${{matrix.allow_failure}}
     steps:
       - uses: actions/checkout@v2
       - name: Download neovim
@@ -75,3 +79,4 @@ jobs:
           export THEMIS_VIM=nvim
           nvim --version
           themis
+        continue-on-error: ${{matrix.allow_failure}}

--- a/.github/workflows/mac_neovim.yml
+++ b/.github/workflows/mac_neovim.yml
@@ -24,13 +24,17 @@ jobs:
           - name: neovim-v04-x64
             os: macos-latest
             neovim_version: v0.4.4
+            allow_failure: false
           - name: neovim-v05-x64
             os: macos-latest
             neovim_version: v0.5.0
+            allow_failure: false
           - name: neovim-nightly-x64
             os: macos-latest
             neovim_version: nightly
+            allow_failure: true
     runs-on: ${{matrix.os}}
+    continue-on-error: ${{matrix.allow_failure}}
     steps:
       - uses: actions/checkout@v2
       - name: Download neovim
@@ -75,3 +79,4 @@ jobs:
           export THEMIS_VIM=nvim
           nvim --version
           themis
+        continue-on-error: ${{matrix.allow_failure}}

--- a/.github/workflows/windows_neovim.yml
+++ b/.github/workflows/windows_neovim.yml
@@ -25,15 +25,19 @@ jobs:
             os: windows-latest
             neovim_version: v0.4.4
             neovim_arch: win64
+            allow_failure: false
           - name: neovim-v05-x64
             os: windows-latest
             neovim_version: v0.5.0
             neovim_arch: win64
+            allow_failure: false
           - name: neovim-nightly-x64
             os: windows-latest
             neovim_version: nightly
             neovim_arch: win64
+            allow_failure: true
     runs-on: ${{matrix.os}}
+    continue-on-error: ${{matrix.allow_failure}}
     steps:
       - uses: actions/checkout@v2
       - name: Download neovim
@@ -78,3 +82,4 @@ jobs:
           SET THEMIS_VIM=nvim
           nvim --version
           themis
+        continue-on-error: ${{matrix.allow_failure}}


### PR DESCRIPTION
This PR does:

1. Add [Neovim 0.5.0](https://github.com/neovim/neovim/releases/tag/v0.5.0) to CI target on each platforms
2. Allow CI failure with Neovim nightly package because it sometimes does not work (e.g. SEGV)