### PR TITLE
Keep existing window sizes when quickpick opens and closes

### DIFF
--- a/autoload/lsp/internal/ui/quickpick.vim
+++ b/autoload/lsp/internal/ui/quickpick.vim
@@ -1,4 +1,4 @@
-" https://github.com/prabirshrestha/quickpick.vim#3d4d574d16d2a6629f32e11e9d33b0134aa1e2d9
+" https://github.com/prabirshrestha/quickpick.vim#d9d18841b03b633eca411f69dc7997cca4203194
 "    :QuickpickEmbed path=autoload/lsp/internal/ui/quickpick.vim namespace=lsp#internal#ui#quickpick prefix=lsp-quickpick
 
 let s:has_timer = exists('*timer_start') && exists('*timer_stop')
@@ -24,6 +24,7 @@ function! lsp#internal#ui#quickpick#open(opt) abort
       \ 'maxheight': 10,
       \ 'debounce': 250,
       \ 'filter': 1,
+      \ 'winrestcmd': '',
       \ }, a:opt)
 
   let s:inputecharpre = 0
@@ -31,9 +32,10 @@ function! lsp#internal#ui#quickpick#open(opt) abort
 
   let s:state['bufnr'] = bufnr('%')
   let s:state['winid'] = win_getid()
+  let s:state['winrestcmd'] = winrestcmd()
 
   " create result buffer
-  exe printf('keepalt botright 1new %s', s:state['filetype'])
+  exe printf('keepalt botright 3new %s', s:state['filetype'])
   let s:state['resultsbufnr'] = bufnr('%')
   let s:state['resultswinid'] = win_getid()
   if s:has_proptype
@@ -159,6 +161,7 @@ function! lsp#internal#ui#quickpick#close() abort
 
   exe 'silent! bunload! ' . s:state['promptbufnr']
   exe 'silent! bunload! ' . s:state['resultsbufnr']
+  exe 'silent! ' . s:state['winrestcmd']
 
   let s:inputecharpre = 0
 


### PR DESCRIPTION
quickpick resizes existing windows when quickpick opens and closes as follows:

https://user-images.githubusercontent.com/9126033/131221051-eba4a83e-4adf-430c-a8f7-5dc0839e1459.mp4


(This video sets `equalalways` for the reproduction, but the windows are also resized when `noequalalways` is set) 

This PR prevents quickpick from resizing existing windows.
