### PR TITLE
Add pure-JSON logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,9 @@ let g:lsp_log_verbose = 1
 let g:asyncomplete_log_file = expand('~/asyncomplete.log')
 ```
 
-Alternatively, if you prefer pure-JSON logs, you can enable that like so:
+The log file will contain JSON messages. You can use tools such as `jq` to
+pretty-print the log and filter it down to just the messages you care about.
 
-```vim
-let g:lsp_json_log_file = expand('~/vim-lsp.json')
-
-" only if you want diagnostic wire traces
-let g:lsp_log_verbose = 1
-```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,22 @@ highlight lspReference ctermfg=red guifg=red ctermbg=green guibg=green
 In order to enable file logging set `g:lsp_log_file`.
 
 ```vim
-let g:lsp_log_verbose = 1
 let g:lsp_log_file = expand('~/vim-lsp.log')
+
+" only if you want diagnostic wire traces
+let g:lsp_log_verbose = 1
 
 " for asyncomplete.vim log
 let g:asyncomplete_log_file = expand('~/asyncomplete.log')
+```
+
+Alternatively, if you prefer pure-JSON logs, you can enable that like so:
+
+```vim
+let g:lsp_json_log_file = expand('~/vim-lsp.json')
+
+" only if you want diagnostic wire traces
+let g:lsp_log_verbose = 1
 ```
 
 ## Tests

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -46,6 +46,23 @@ function! lsp#log(...) abort
     endif
 endfunction
 
+function! lsp#log_json_verbose(obj) abort
+    if g:lsp_log_verbose
+        call lsp#log_json(a:obj)
+    end
+endfunction
+
+function! lsp#log_json(obj) abort
+    if !empty(g:lsp_json_log_file)
+        " Since the objects passed to this function are almost always
+        " going to be literals at the callsite, this copy() is prudent but
+        " likely unnecessary.
+        let l:logrec = copy(a:obj)
+        let l:logrec['timestamp'] = strftime('%c')
+        call writefile([json_encode(l:logrec)], g:lsp_json_log_file, 'a')
+    endif
+endfunction
+
 function! lsp#enable() abort
     if s:enabled
         return
@@ -164,6 +181,7 @@ endfunction
 function! lsp#register_server(server_info) abort
     let l:server_name = a:server_info['name']
     if has_key(s:servers, l:server_name)
+        call lsp#log_json({'event': 'lsp#register_server', 'msg': 'server already registered', 'server_name': l:server_name})
         call lsp#log('lsp#register_server', 'server already registered', l:server_name)
     endif
     let s:servers[l:server_name] = {
@@ -171,6 +189,7 @@ function! lsp#register_server(server_info) abort
         \ 'lsp_id': 0,
         \ 'buffers': {},
         \ }
+    call lsp#log_json({'event': 'lsp#register_server', 'msg': 'server registered', 'server_name': l:server_name})
     call lsp#log('lsp#register_server', 'server registered', l:server_name)
     doautocmd <nomodeline> User lsp_register_server
 endfunction
@@ -232,6 +251,7 @@ function! s:on_text_document_did_open(...) abort
     let l:buf = a:0 > 0 ? a:1 : bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
     if getcmdwintype() !=# '' | return | endif
+    call lsp#log_json({'event': 's:on_text_document_did_open()', 'bufnr': l:buf, 'filetype': &filetype, 'cwd': getcwd(), 'bufuri': lsp#utils#get_buffer_uri(l:buf)})
     call lsp#log('s:on_text_document_did_open()', l:buf, &filetype, getcwd(), lsp#utils#get_buffer_uri(l:buf))
 
     " Some language server notify diagnostics to the buffer that has not been loaded yet.
@@ -251,7 +271,9 @@ endfunction
 function! s:on_text_document_did_save() abort
     let l:buf = bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
+    call lsp#log_json({'event': 's:on_text_document_did_save()', 'bufnr': l:buf})
     call lsp#log('s:on_text_document_did_save()', l:buf)
+
     for l:server_name in lsp#get_allowed_servers(l:buf)
         if g:lsp_text_document_did_save_delay >= 0
             " We delay the callback by one loop iteration as calls to ensure_flush
@@ -267,6 +289,7 @@ endfunction
 function! s:on_text_document_did_change() abort
     let l:buf = bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
+    call lsp#log_json({'event': 's:on_text_document_did_change()', 'bufnr': l:buf})
     call lsp#log('s:on_text_document_did_change()', l:buf)
     call s:add_didchange_queue(l:buf)
 endfunction
@@ -282,6 +305,7 @@ function! s:call_did_save(buf, server_name, result, cb) abort
     let [l:supports_did_save, l:did_save_options] = lsp#capabilities#get_text_document_save_registration_options(a:server_name)
     if !l:supports_did_save
         let l:msg = s:new_rpc_success('---> ignoring textDocument/didSave. not supported by server', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_json({'event': 'call_did_save()', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -305,6 +329,7 @@ function! s:call_did_save(buf, server_name, result, cb) abort
         \ })
 
     let l:msg = s:new_rpc_success('textDocument/didSave sent', { 'server_name': a:server_name, 'path': l:path })
+    call lsp#log_json({'event': 'call_did_save()', 'msg': l:msg})
     call lsp#log(l:msg)
     call a:cb(l:msg)
 endfunction
@@ -312,6 +337,7 @@ endfunction
 function! s:on_text_document_did_close() abort
     let l:buf = bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
+    call lsp#log_json({'event': 's:on_text_document_did_close()', 'bufnr': l:buf})
     call lsp#log('s:on_text_document_did_close()', l:buf)
 endfunction
 
@@ -326,6 +352,7 @@ function! s:update_file_content(buf, server_name, new) abort
     if !has_key(s:file_content, a:buf)
         let s:file_content[a:buf] = {}
     endif
+    call lsp#log_json({'event': 's:update_file_content()', 'bufnr': a:buf})
     call lsp#log('s:update_file_content()', a:buf)
     let s:file_content[a:buf][a:server_name] = a:new
 endfunction
@@ -400,6 +427,7 @@ function! s:ensure_start(buf, server_name, cb) abort
 
     if lsp#utils#is_remote_uri(l:path)
         let l:msg = s:new_rpc_error('ignoring start server due to remote uri', { 'server_name': a:server_name, 'uri': l:path})
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -409,6 +437,7 @@ function! s:ensure_start(buf, server_name, cb) abort
     let l:server_info = l:server['server_info']
     if l:server['lsp_id'] > 0
         let l:msg = s:new_rpc_success('server already started', { 'server_name': a:server_name })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -433,11 +462,13 @@ function! s:ensure_start(buf, server_name, cb) abort
 
         if empty(l:cmd)
             let l:msg = s:new_rpc_error('ignore server start since cmd is empty', { 'server_name': a:server_name })
+            call lsp#log_json({'event': 'rpc', 'msg': l:msg})
             call lsp#log(l:msg)
             call a:cb(l:msg)
             return
         endif
 
+        call lsp#log_json({'event': 'ensure_start()', 'msg': 'Starting server', 'server_name': a:server_name, 'cmd': l:cmd})
         call lsp#log('Starting server', a:server_name, l:cmd)
 
         let l:lsp_id = lsp#client#start({
@@ -452,10 +483,12 @@ function! s:ensure_start(buf, server_name, cb) abort
     if l:lsp_id > 0
         let l:server['lsp_id'] = l:lsp_id
         let l:msg = s:new_rpc_success('started lsp server successfully', { 'server_name': a:server_name, 'lsp_id': l:lsp_id })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
     else
         let l:msg = s:new_rpc_error('failed to start server', { 'server_name': a:server_name, 'cmd': l:cmd })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
     endif
@@ -565,6 +598,7 @@ function! s:ensure_init(buf, server_name, cb) abort
 
     if has_key(l:server, 'init_result')
         let l:msg = s:new_rpc_success('lsp server already initialized', { 'server_name': a:server_name, 'init_result': l:server['init_result'] })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -574,6 +608,7 @@ function! s:ensure_init(buf, server_name, cb) abort
         " waiting for initialize response
         call add(l:server['init_callbacks'], a:cb)
         let l:msg = s:new_rpc_success('waiting for lsp server to initialize', { 'server_name': a:server_name })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         return
     endif
@@ -584,6 +619,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     let l:root_uri = has_key(l:server_info, 'root_uri') ?  l:server_info['root_uri'](l:server_info) : ''
     if empty(l:root_uri)
         let l:msg = s:new_rpc_error('ignore initialization lsp server due to empty root_uri', { 'server_name': a:server_name, 'lsp_id': l:server['lsp_id'] })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         let l:root_uri = lsp#utils#get_default_root_uri()
     endif
@@ -629,6 +665,7 @@ function! s:ensure_conf(buf, server_name, cb) abort
             \ })
     endif
     let l:msg = s:new_rpc_success('configuration sent', { 'server_name': a:server_name })
+    call lsp#log_json({'event': 'rpc', 'msg': l:msg})
     call lsp#log(l:msg)
     call a:cb(l:msg)
 endfunction
@@ -667,6 +704,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
     let l:buffers = l:server['buffers']
     if !has_key(l:buffers, l:path)
         let l:msg = s:new_rpc_success('file is not managed', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -677,6 +715,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
 
     if l:buffer_info['changed_tick'] == l:changed_tick
         let l:msg = s:new_rpc_success('not dirty', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -695,6 +734,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/didChange sent', { 'server_name': a:server_name, 'path': l:path })
+    call lsp#log_json({'event': 'rpc', 'msg': l:msg})
     call lsp#log(l:msg)
     call a:cb(l:msg)
 endfunction
@@ -705,6 +745,7 @@ function! s:ensure_open(buf, server_name, cb) abort
 
     if empty(l:path)
         let l:msg = s:new_rpc_success('ignore open since not a valid uri', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -714,6 +755,7 @@ function! s:ensure_open(buf, server_name, cb) abort
 
     if has_key(l:buffers, l:path)
         let l:msg = s:new_rpc_success('already opened', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_json({'event': 'rpc', 'msg': l:msg})
         call lsp#log(l:msg)
         call a:cb(l:msg)
         return
@@ -734,6 +776,7 @@ function! s:ensure_open(buf, server_name, cb) abort
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/open sent', { 'server_name': a:server_name, 'path': l:path, 'filetype': getbufvar(a:buf, '&filetype') })
+    call lsp#log_json({'event': 'rpc', 'msg': l:msg})
     call lsp#log(l:msg)
     call a:cb(l:msg)
 endfunction
@@ -744,6 +787,7 @@ function! s:send_request(server_name, data) abort
     if has_key(l:data, 'on_notification')
         let l:data['on_notification'] = '---funcref---'
     endif
+    call lsp#log_json_verbose({'event': 'send_request', 'lsp_id': l:lsp_id, 'server_name': a:server_name, 'data': l:data})
     call lsp#log_verbose('--->', l:lsp_id, a:server_name, l:data)
     return lsp#client#send_request(l:lsp_id, a:data)
 endfunction
@@ -754,6 +798,7 @@ function! s:send_notification(server_name, data) abort
     if has_key(l:data, 'on_notification')
         let l:data['on_notification'] = '---funcref---'
     endif
+    call lsp#log_json_verbose({'event': 'send_notification', 'lsp_id': l:lsp_id, 'server_name': a:server_name, 'data': l:data})
     call lsp#log_verbose('--->', l:lsp_id, a:server_name, l:data)
     call lsp#client#send_notification(l:lsp_id, a:data)
 endfunction
@@ -761,15 +806,18 @@ endfunction
 function! s:send_response(server_name, data) abort
     let l:lsp_id = s:servers[a:server_name]['lsp_id']
     let l:data = copy(a:data)
+    call lsp#log_json_verbose({'event': 'send_response', 'lsp_id': l:lsp_id, 'server_name': a:server_name, 'data': l:data})
     call lsp#log_verbose('--->', l:lsp_id, a:server_name, l:data)
     call lsp#client#send_response(l:lsp_id, a:data)
 endfunction
 
 function! s:on_stderr(server_name, id, data, event) abort
+    call lsp#log_json_verbose({'event': 'on_stderr', 'lsp_id': a:id, 'server_name': a:server_name, 'data': a:data})
     call lsp#log_verbose('<---(stderr)', a:id, a:server_name, a:data)
 endfunction
 
 function! s:on_exit(server_name, id, data, event) abort
+    call lsp#log_json({'event': 's:on_exit', 'id': a:id, 'server_name': a:server_name, 'exited': a:data})
     call lsp#log('s:on_exit', a:id, a:server_name, 'exited', a:data)
     if has_key(s:servers, a:server_name)
         let l:server = s:servers[a:server_name]
@@ -786,6 +834,7 @@ function! s:on_exit(server_name, id, data, event) abort
 endfunction
 
 function! s:on_notification(server_name, id, data, event) abort
+    call lsp#log_json_verbose({'event': 'on_notification', 'lsp_id': a:id, 'server_name': a:server_name, 'data': a:data})
     call lsp#log_verbose('<---', a:id, a:server_name, a:data)
     let l:response = a:data['response']
     let l:server = s:servers[a:server_name]
@@ -818,6 +867,7 @@ function! s:on_notification(server_name, id, data, event) abort
 endfunction
 
 function! s:on_request(server_name, id, request) abort
+    call lsp#log_json_verbose({'event': 'on_request', 'lsp_id': a:id, 'server_name': a:server_name, 'request': a:request})
     call lsp#log_verbose('<---', 's:on_request', a:id, a:request)
 
     let l:stream_data = { 'server': a:server_name, 'request': a:request }
@@ -1114,6 +1164,7 @@ function! s:add_didchange_queue(buf) abort
         return
     endif
     call add(s:didchange_queue, a:buf)
+    call lsp#log_json({'event': 'generic', 'msg': 's:send_didchange_queue() will be triggered'})
     call lsp#log('s:send_didchange_queue() will be triggered')
     call timer_stop(s:didchange_timer)
     let l:lazy = &updatetime > 1000 ? &updatetime : 1000
@@ -1121,6 +1172,7 @@ function! s:add_didchange_queue(buf) abort
 endfunction
 
 function! s:send_didchange_queue(...) abort
+    call lsp#log_json({'event': 's:send_event_queue()'})
     call lsp#log('s:send_event_queue()')
     for l:buf in s:didchange_queue
         if !bufexists(l:buf)

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -55,8 +55,7 @@ function! s:on_stdout(id, data, event) abort
             let l:ctx['content-length'] = s:get_content_length(l:headers)
             if l:ctx['content-length'] < 0
                 " invalid content-length
-                call lsp#log_json({'event': 'on_stdout', 'client_id': a:id, 'error': 'invalid content-length'})
-                call lsp#log('on_stdout', a:id, 'invalid content-length')
+                call lsp#log({'event': 'on_stdout', 'client_id': a:id, 'error': 'invalid content-length'})
                 call s:lsp_stop(a:id)
                 return
             endif
@@ -75,8 +74,7 @@ function! s:on_stdout(id, data, event) abort
         try
             let l:response = json_decode(l:response_str)
         catch
-            call lsp#log_json({'event': 's:on_stdout', 'error': 'json_decode failed', 'exception': v:exception})
-            call lsp#log('s:on_stdout json_decode failed', v:exception)
+            call lsp#log({'event': 's:on_stdout', 'error': 'json_decode failed', 'exception': v:exception})
         endtry
 
         let l:ctx['buffer'] = l:ctx['buffer'][len(l:response_str):]
@@ -94,8 +92,7 @@ function! s:on_stdout(id, data, event) abort
                 " it is a request->response
                 if !(type(l:response['id']) == type(0) || type(l:response['id']) == type(''))
                     " response['id'] can be number | string | null based on the spec
-                    call lsp#log_json({'event': 'invalid response id. ignoring message', 'response': l:response})
-                    call lsp#log('invalid response id. ignoring message', l:response)
+                    call lsp#log({'event': 'internal error', 'msg': 'invalid response id. ignoring message', 'response': l:response})
                     continue
                 endif
                 if has_key(l:ctx['requests'], l:response['id'])
@@ -106,8 +103,7 @@ function! s:on_stdout(id, data, event) abort
                     try
                         call l:ctx['opts']['on_notification'](a:id, l:on_notification_data, 'on_notification')
                     catch
-                        call lsp#log_json({'event': 's:on_stdout', 'error': 'client option on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
-                        call lsp#log('s:on_stdout client option on_notification() error', v:exception, v:throwpoint)
+                        call lsp#log({'event': 's:on_stdout', 'error': 'client option on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
                     endtry
                 endif
                 if has_key(l:ctx['on_notifications'], l:response['id'])
@@ -115,16 +111,14 @@ function! s:on_stdout(id, data, event) abort
                     try
                         call l:ctx['on_notifications'][l:response['id']](a:id, l:on_notification_data, 'on_notification')
                     catch
-                        call lsp#log_json({'event': 's:on_stdout', 'error': 'client request on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
-                        call lsp#log('s:on_stdout client request on_notification() error', v:exception, v:throwpoint)
+                        call lsp#log({'event': 's:on_stdout', 'error': 'client request on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
                     endtry
                     unlet l:ctx['on_notifications'][l:response['id']]
                 endif
                 if has_key(l:ctx['requests'], l:response['id'])
                     unlet l:ctx['requests'][l:response['id']]
                 else
-                    call lsp#log_json({'event': 'error', 'error': 'cannot find the request corresponding to response: ', 'response': l:response})
-                    call lsp#log('cannot find the request corresponding to response: ', l:response)
+                    call lsp#log({'event': 'internal error', 'error': 'cannot find the request corresponding to response: ', 'response': l:response})
                 endif
             else
                 " it is a notification
@@ -132,8 +126,7 @@ function! s:on_stdout(id, data, event) abort
                     try
                         call l:ctx['opts']['on_notification'](a:id, l:on_notification_data, 'on_notification')
                     catch
-                        call lsp#log_json({'event': 's:on_stdout', 'error': 'on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
-                        call lsp#log('s:on_stdout on_notification() error', v:exception, v:throwpoint)
+                        call lsp#log({'event': 's:on_stdout', 'error': 'on_notification() error', 'exception': v:exception, 'throwpoint': v:throwpoint})
                     endtry
                 endif
             endif
@@ -167,8 +160,7 @@ function! s:on_stderr(id, data, event) abort
         try
             call l:ctx['opts']['on_stderr'](a:id, a:data, a:event)
         catch
-            call lsp#log_json({'event': 'error', 'error': 's:on_stderr exception', 'exception': v:exception, 'throwpoint': v:throwpoint})
-            call lsp#log('s:on_stderr exception', v:exception, v:throwpoint)
+            call lsp#log({'event': 'internal error', 'error': 's:on_stderr exception', 'exception': v:exception, 'throwpoint': v:throwpoint})
             echom v:exception
         endtry
     endif
@@ -183,8 +175,7 @@ function! s:on_exit(id, status, event) abort
         try
             call l:ctx['opts']['on_exit'](a:id, a:status, a:event)
         catch
-            call lsp#log_json({'event': 's:on_exit', 'exception': v:exception, 'throwpoint': v:throwpoint})
-            call lsp#log('s:on_exit exception', v:exception, v:throwpoint)
+            call lsp#log({'event': 'internal error', 'error': 's:on_exit exception', 'exception': v:exception, 'throwpoint': v:throwpoint})
             echom v:exception
         endtry
     endif

--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -98,6 +98,7 @@ function! s:clear_all_highlights() abort
                             \ 'bufnr': l:bufnr,
                             \ 'all': v:true })
                     catch
+                        call lsp#log_json({'event': 'diagnostics', 'func': 'clear_all_highlights', 'call': 'prop_remove', 'exception': v:exception, 'throwpoint': v:throwpoint})
                         call lsp#log('diagnostics', 'clear_all_highlights', 'prop_remove', v:exception, v:throwpoint)
                     endtry
                 endfor

--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -98,8 +98,7 @@ function! s:clear_all_highlights() abort
                             \ 'bufnr': l:bufnr,
                             \ 'all': v:true })
                     catch
-                        call lsp#log_json({'event': 'diagnostics', 'func': 'clear_all_highlights', 'call': 'prop_remove', 'exception': v:exception, 'throwpoint': v:throwpoint})
-                        call lsp#log('diagnostics', 'clear_all_highlights', 'prop_remove', v:exception, v:throwpoint)
+                        call lsp#log({'event': 'internal error', 'request': 'diagnostics', 'func': 'clear_all_highlights', 'call': 'prop_remove', 'exception': v:exception, 'throwpoint': v:throwpoint})
                     endtry
                 endfor
             endif

--- a/autoload/lsp/internal/document_formatting.vim
+++ b/autoload/lsp/internal/document_formatting.vim
@@ -76,8 +76,7 @@ function! s:format_next(x) abort
 endfunction
 
 function! s:format_error(e) abort
-    call lsp#log_json({'event': 'debug', 'msg': 'Formatting Document Failed', 'error': a:e})
-    call lsp#log('Formatting Document Failed', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'Formatting Document Failed', 'error': a:e})
     call lsp#utils#error('Formatting Document Failed.' . (type(a:e) == type('') ? a:e : ''))
 endfunction
 

--- a/autoload/lsp/internal/document_formatting.vim
+++ b/autoload/lsp/internal/document_formatting.vim
@@ -76,6 +76,7 @@ function! s:format_next(x) abort
 endfunction
 
 function! s:format_error(e) abort
+    call lsp#log_json({'event': 'debug', 'msg': 'Formatting Document Failed', 'error': a:e})
     call lsp#log('Formatting Document Failed', a:e)
     call lsp#utils#error('Formatting Document Failed.' . (type(a:e) == type('') ? a:e : ''))
 endfunction

--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -118,8 +118,7 @@ function! s:set_highlights(data) abort
                     \ 'type': 'vim-lsp-reference-highlight'})
                 call add(b:lsp_reference_matches, l:position[0])
             catch
-                call lsp#log_json({'event': 'document_highlight', 'func': 'set_highlights', 'exception': v:exception, 'throwpoint': v:throwpoint})
-                call lsp#log('document_highlight', 'set_highlights', v:exception, v:throwpoint)
+                call lsp#log({'event': 'internal error', 'request': 'document_highlight', 'func': 'set_highlights', 'exception': v:exception, 'throwpoint': v:throwpoint})
             endtry
         endfor
     else

--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -118,6 +118,7 @@ function! s:set_highlights(data) abort
                     \ 'type': 'vim-lsp-reference-highlight'})
                 call add(b:lsp_reference_matches, l:position[0])
             catch
+                call lsp#log_json({'event': 'document_highlight', 'func': 'set_highlights', 'exception': v:exception, 'throwpoint': v:throwpoint})
                 call lsp#log('document_highlight', 'set_highlights', v:exception, v:throwpoint)
             endtry
         endfor

--- a/autoload/lsp/internal/document_range_formatting.vim
+++ b/autoload/lsp/internal/document_range_formatting.vim
@@ -80,6 +80,7 @@ function! s:format_next(x) abort
 endfunction
 
 function! s:format_error(e) abort
+    call lsp#log_json({'event': 'Formatting Document Range Failed', 'error': a:e})
     call lsp#log('Formatting Document Range Failed', a:e)
     call lsp#utils#error('Formatting Document Range Failed.' . (type(a:e) == type('') ? a:e : ''))
 endfunction

--- a/autoload/lsp/internal/document_range_formatting.vim
+++ b/autoload/lsp/internal/document_range_formatting.vim
@@ -80,8 +80,7 @@ function! s:format_next(x) abort
 endfunction
 
 function! s:format_error(e) abort
-    call lsp#log_json({'event': 'Formatting Document Range Failed', 'error': a:e})
-    call lsp#log('Formatting Document Range Failed', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'Formatting Document Range Failed', 'error': a:e})
     call lsp#utils#error('Formatting Document Range Failed.' . (type(a:e) == type('') ? a:e : ''))
 endfunction
 

--- a/autoload/lsp/internal/document_symbol/search.vim
+++ b/autoload/lsp/internal/document_symbol/search.vim
@@ -72,6 +72,5 @@ endfunction
 
 function! s:on_error(e) abort
     call lsp#internal#ui#quickpick#close()
-    call lsp#log_json({'event': 'LspDocumentSymbolSearch error', 'error': a:e})
-    call lsp#log('LspDocumentSymbolSearch error', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'LspDocumentSymbolSearch error', 'error': a:e})
 endfunction

--- a/autoload/lsp/internal/document_symbol/search.vim
+++ b/autoload/lsp/internal/document_symbol/search.vim
@@ -72,5 +72,6 @@ endfunction
 
 function! s:on_error(e) abort
     call lsp#internal#ui#quickpick#close()
+    call lsp#log_json({'event': 'LspDocumentSymbolSearch error', 'error': a:e})
     call lsp#log('LspDocumentSymbolSearch error', a:e)
 endfunction

--- a/autoload/lsp/internal/show_message.vim
+++ b/autoload/lsp/internal/show_message.vim
@@ -25,8 +25,7 @@ function! lsp#internal#show_message#_disable() abort
 endfunction
 
 function! s:on_error(e) abort
-    call lsp#log_json({'event': 'lsp#internal#show_message error', 'error': a:e})
-    call lsp#log('lsp#internal#show_message error', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'lsp#internal#show_message error', 'error': a:e})
     if exists('s:Dispose')
         call s:Dispose()
         unlet s:Dispose

--- a/autoload/lsp/internal/show_message.vim
+++ b/autoload/lsp/internal/show_message.vim
@@ -25,6 +25,7 @@ function! lsp#internal#show_message#_disable() abort
 endfunction
 
 function! s:on_error(e) abort
+    call lsp#log_json({'event': 'lsp#internal#show_message error', 'error': a:e})
     call lsp#log('lsp#internal#show_message error', a:e)
     if exists('s:Dispose')
         call s:Dispose()

--- a/autoload/lsp/internal/show_message_request.vim
+++ b/autoload/lsp/internal/show_message_request.vim
@@ -23,6 +23,7 @@ function! lsp#internal#show_message_request#_disable() abort
 endfunction
 
 function! s:on_error(e) abort
+    call lsp#log_json({'event':'lsp#internal#show_message_request error', 'error': a:e})
     call lsp#log('lsp#internal#show_message_request error', a:e)
     if exists('s:Dispose')
         call s:Dispose()

--- a/autoload/lsp/internal/show_message_request.vim
+++ b/autoload/lsp/internal/show_message_request.vim
@@ -23,8 +23,7 @@ function! lsp#internal#show_message_request#_disable() abort
 endfunction
 
 function! s:on_error(e) abort
-    call lsp#log_json({'event':'lsp#internal#show_message_request error', 'error': a:e})
-    call lsp#log('lsp#internal#show_message_request error', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'lsp#internal#show_message_request error', 'error': a:e})
     if exists('s:Dispose')
         call s:Dispose()
         unlet s:Dispose

--- a/autoload/lsp/internal/workspace_symbol/search.vim
+++ b/autoload/lsp/internal/workspace_symbol/search.vim
@@ -90,5 +90,6 @@ endfunction
 
 function! s:on_error(e) abort
     call lsp#internal#ui#quickpick#close()
+    call lsp#log_json({'event': 'LspWorkspaceSymbolSearch error', 'error': a:e})
     call lsp#log('LspWorkspaceSymbolSearch error', a:e)
 endfunction

--- a/autoload/lsp/internal/workspace_symbol/search.vim
+++ b/autoload/lsp/internal/workspace_symbol/search.vim
@@ -90,6 +90,5 @@ endfunction
 
 function! s:on_error(e) abort
     call lsp#internal#ui#quickpick#close()
-    call lsp#log_json({'event': 'LspWorkspaceSymbolSearch error', 'error': a:e})
-    call lsp#log('LspWorkspaceSymbolSearch error', a:e)
+    call lsp#log({'event': 'request error', 'msg': 'LspWorkspaceSymbolSearch error', 'error': a:e})
 endfunction

--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -1,8 +1,7 @@
 let s:tag_kind_priority = ['definition', 'declaration', 'implementation', 'type definition']
 
 function! s:not_supported(what) abort
-    call lsp#log_json({'event': 'not_supported', 'what': a:what, 'filetype': &filetype})
-    call lsp#log(a:what . ' not supported for ' . &filetype)
+    call lsp#log({'event': 'request rejected', 'error': 'not supported', 'what': a:what, 'filetype': &filetype})
 endfunction
 
 function! s:location_to_tag(loc) abort

--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -1,6 +1,7 @@
 let s:tag_kind_priority = ['definition', 'declaration', 'implementation', 'type definition']
 
 function! s:not_supported(what) abort
+    call lsp#log_json({'event': 'not_supported', 'what': a:what, 'filetype': &filetype})
     call lsp#log(a:what . ' not supported for ' . &filetype)
 endfunction
 

--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -110,6 +110,7 @@ function! s:handle_code_action(ctx, server_name, command_id, sync, query, bufnr,
         echo 'No code actions found'
         return
     endif
+    call lsp#log_json({'event': 's:handle_code_action', 'total_code_actions': l:total_code_actions})
     call lsp#log('s:handle_code_action', l:total_code_actions)
 
     if len(l:total_code_actions) == 1 && !empty(a:query)

--- a/autoload/lsp/ui/vim/code_action.vim
+++ b/autoload/lsp/ui/vim/code_action.vim
@@ -110,8 +110,7 @@ function! s:handle_code_action(ctx, server_name, command_id, sync, query, bufnr,
         echo 'No code actions found'
         return
     endif
-    call lsp#log_json({'event': 's:handle_code_action', 'total_code_actions': l:total_code_actions})
-    call lsp#log('s:handle_code_action', l:total_code_actions)
+    call lsp#log({'event': 'request complete', 'location': 's:handle_code_action', 'total_code_actions': l:total_code_actions})
 
     if len(l:total_code_actions) == 1 && !empty(a:query)
         let l:action = l:total_code_actions[0]

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -210,6 +210,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
           \   'on_notification': function(l:ctx['callback'], [], l:ctx)
           \ })
   catch /.*/
+    call lsp#log_json({'event': 's:resolve_completion_item', 'msg': 'request timeout.'})
     call lsp#log('s:resolve_completion_item', 'request timeout.')
   endtry
 

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -210,8 +210,7 @@ function! s:resolve_completion_item(completion_item, server_name) abort
           \   'on_notification': function(l:ctx['callback'], [], l:ctx)
           \ })
   catch /.*/
-    call lsp#log_json({'event': 's:resolve_completion_item', 'msg': 'request timeout.'})
-    call lsp#log('s:resolve_completion_item', 'request timeout.')
+    call lsp#log({'event': 'request timeout', 'location': 's:resolve_completion_item'})
   endtry
 
   if empty(l:ctx['response'])

--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -57,8 +57,7 @@ function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort
     endif
 
     if !g:lsp_fold_enabled
-        call lsp#log_json({'event': 'debug', 'msg': 'Skip sending fold request: folding was disabled explicitly'})
-        call lsp#log('Skip sending fold request: folding was disabled explicitly')
+        call lsp#log({'event': 'debug', 'msg': 'Skip sending fold request: folding was disabled explicitly'})
         return
     endif
 

--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -57,6 +57,7 @@ function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort
     endif
 
     if !g:lsp_fold_enabled
+        call lsp#log_json({'event': 'debug', 'msg': 'Skip sending fold request: folding was disabled explicitly'})
         call lsp#log('Skip sending fold request: folding was disabled explicitly')
         return
     endif

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -28,8 +28,7 @@ function! lsp#ui#vim#semantic#handle_semantic(server, data) abort
     if !g:lsp_semantic_enabled | return | endif
 
     if lsp#client#is_error(a:data['response'])
-        call lsp#log_json({'event': 'debug', 'msg': 'Skipping semantic highlight: response is invalid'})
-        call lsp#log('Skipping semantic highlight: response is invalid')
+        call lsp#log({'event': 'debug', 'msg': 'Skipping semantic highlight: response is invalid'})
         return
     endif
 

--- a/autoload/lsp/ui/vim/semantic.vim
+++ b/autoload/lsp/ui/vim/semantic.vim
@@ -28,6 +28,7 @@ function! lsp#ui#vim#semantic#handle_semantic(server, data) abort
     if !g:lsp_semantic_enabled | return | endif
 
     if lsp#client#is_error(a:data['response'])
+        call lsp#log_json({'event': 'debug', 'msg': 'Skipping semantic highlight: response is invalid'})
         call lsp#log('Skipping semantic highlight: response is invalid')
         return
     endif

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -25,6 +25,7 @@ function! lsp#ui#vim#signature_help#get_signature_help_under_cursor() abort
             \ })
     endfor
 
+    call lsp#log_json({'event': 'debug', 'msg': 'Retrieving signature help'})
     call lsp#log('Retrieving signature help')
     return
 endfunction

--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -25,8 +25,7 @@ function! lsp#ui#vim#signature_help#get_signature_help_under_cursor() abort
             \ })
     endfor
 
-    call lsp#log_json({'event': 'debug', 'msg': 'Retrieving signature help'})
-    call lsp#log('Retrieving signature help')
+    call lsp#log({'event': 'debug', 'msg': 'Retrieving signature help'})
     return
 endfunction
 

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -172,6 +172,7 @@ function! s:_check(text_edits) abort
       \   l:range.end.line == l:text_edit.range.start.line &&
       \   l:range.end.character > l:text_edit.range.start.character
       \ )
+        call lsp#log_json({'event': 'text_edit', 'msg': 'range overlapped.'})
         call lsp#log('text_edit: range overlapped.')
       endif
       let l:range = l:text_edit.range

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -172,8 +172,7 @@ function! s:_check(text_edits) abort
       \   l:range.end.line == l:text_edit.range.start.line &&
       \   l:range.end.character > l:text_edit.range.start.character
       \ )
-        call lsp#log_json({'event': 'text_edit', 'msg': 'range overlapped.'})
-        call lsp#log('text_edit: range overlapped.')
+        call lsp#log({'event': 'debug', 'msg': 'text_edit range overlapped.'})
       endif
       let l:range = l:text_edit.range
     endfor

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -7,6 +7,7 @@ let g:lsp_use_lua = get(g:, 'lsp_use_lua', has('nvim-0.4.0') || (has('lua') && h
 let g:lsp_auto_enable = get(g:, 'lsp_auto_enable', 1)
 let g:lsp_async_completion = get(g:, 'lsp_async_completion', 0)
 let g:lsp_log_file = get(g:, 'lsp_log_file', '')
+let g:lsp_json_log_file = get(g:, 'lsp_json_log_file', '')
 let g:lsp_log_verbose = get(g:, 'lsp_log_verbose', 1)
 let g:lsp_debug_servers = get(g:, 'lsp_debug_servers', [])
 let g:lsp_format_sync_timeout = get(g:, 'lsp_format_sync_timeout', -1)


### PR DESCRIPTION
This introduces a secondary log file that contains pure JSON. This enables a few niceties while debugging language servers. For example, if you have a JSON-native log database you can have it ingest the vim-lsp logs for easier tracing. You can also simply pretty-print the log with `tail -f ~/my/vim-lsp.json | jq .` in order to give your eyes a break.

This is a draft PR because I intend for this to show the value of this JSON logging. I'm very open to changing this to suit the project's development goals. The reason I added an additional log file, with additional logging function calls throughout the code, is because I didn't know whether the existing log format needs to be retained. If we can change the log file format without regard for backward compatibility, we could simply change each logging call to use the new approach.

I guessed at some of the `event` field values. I'm sure some of those could be improved.