### PR TITLE
Add sortText for completion items ordering

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -303,7 +303,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
         let l:incomplete = 0
     endif
 
-    let l:sort = has_key(l:server, 'config') && has_key(l:server['config'], 'sort') ? l:server['config']['sort'] : v:none
+    let l:sort = has_key(l:server, 'config') && has_key(l:server['config'], 'sort') ? l:server['config']['sort'] : v:null
 
     if len(l:items) > 0 && type(l:sort) == s:t_dict && len(l:items) <= l:sort['max']
       " If first item contains sortText, maybe we can use sortText

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -273,9 +273,9 @@ function! s:sort_by_sorttext(i1, i2) abort
     let l:text2 = l:text2 ? l:text2 : a:i2['label']
 
     if g:lsp_ignorecase
-        return tolower(l:text1) == tolower(l:text2) ? 0 : tolower(l:text1) > tolower(l:text2) ? 1 : -1
+        return l:text1 ==? l:text2 ? 0 : l:text1 >? l:text2 ? 1 : -1
     else
-        return l:text1 == l:text2 ? 0 : l:text1 > l:text2 ? 1 : -1
+        return l:text1 ==# l:text2 ? 0 : l:text1 ># l:text2 ? 1 : -1
     endif
 endfunction
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -264,6 +264,13 @@ function! s:get_completion_result(server_name, data) abort
     return {'matches': l:completion_result['items'], 'incomplete': l:completion_result['incomplete'] }
 endfunction
 
+function! s:sort_by_sorttext(i1, i2) abort
+  if has_key(a:i1, 'sortText') && has_key(a:i2, 'sortText')
+    return a:i1.sortText == a:i2.sortText ? 0 : a:i1.sortText > a:i2.sortText ? 1 : -1
+  endif
+  return 0
+endfunction
+
 " options = {
 "   server: {}, " needs to be server_info and not server_name
 "   position: lsp#get_position(),
@@ -286,6 +293,11 @@ function! lsp#omni#get_vim_completion_items(options) abort
     else
         let l:items = []
         let l:incomplete = 0
+    endif
+
+    if len(l:items) > 0 && has_key(l:items[0], 'sortText')
+      " If first item contains sortText, maybe we can use sortText
+      call sort(l:items, function('s:sort_by_sorttext'))
     endif
 
     let l:vim_complete_items = []

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -863,8 +863,9 @@ g:lsp_ignorecase                                         *g:lsp_ignorecase*
     Type: |Boolean|
     Default: the value of 'ignorecase'
 
-    Determines whether or not case should be ignored when filtering completion
-    items. See |vim-lsp-completion-filter|. By default, the value of
+    Determines whether or not case should be ignored when filtering or sorting
+    completion items.
+    See |vim-lsp-completion-filter| or |vim-lsp-completion-sort|. By default, the value of
     'ignorecase' is used.
 
 g:lsp_log_file                                           *g:lsp_log_file*
@@ -1202,6 +1203,16 @@ only possible by adding to the already typed prefix (even if you're using the
 `contains` filter). If you'd like to retrigger the filtering, you will have to
 press CTRL-X CTRL-O again.
 
+sort                                              *vim-lsp-completion-sort*
+
+You can sort the completion items returned from the server by using the `sort` key in the server info's `config` |dict|.
+The value of the `sort` key is itself a |dict| containing at least a key
+`max`, which specifies max number of completion items count before ignore sort for performance reason.
+
+The case (in)sensitivity of the matching is determined by |g:lsp_ignorecase|.
+
+    Example: >
+        'config': { 'sort': { 'max': 100 } }
 
 lsp#register_command({command-name}, {callback})     *lsp#register_command()*
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -865,8 +865,8 @@ g:lsp_ignorecase                                         *g:lsp_ignorecase*
 
     Determines whether or not case should be ignored when filtering or sorting
     completion items.
-    See |vim-lsp-completion-filter| or |vim-lsp-completion-sort|. By default, the value of
-    'ignorecase' is used.
+    See |vim-lsp-completion-filter| or |vim-lsp-completion-sort|.
+    By default, the value of 'ignorecase' is used.
 
 g:lsp_log_file                                           *g:lsp_log_file*
     Type: |String|
@@ -1205,9 +1205,11 @@ press CTRL-X CTRL-O again.
 
 sort                                              *vim-lsp-completion-sort*
 
-You can sort the completion items returned from the server by using the `sort` key in the server info's `config` |dict|.
+You can sort the completion items returned from the server by using the `sort`
+key in the server info's `config` |dict|.
 The value of the `sort` key is itself a |dict| containing at least a key
-`max`, which specifies max number of completion items count before giving up sorting for performance reason.
+`max`, which specifies max number of completion items count before giving up
+sorting for performance reason.
 
 The case (in)sensitivity of the matching is determined by |g:lsp_ignorecase|.
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1207,7 +1207,7 @@ sort                                              *vim-lsp-completion-sort*
 
 You can sort the completion items returned from the server by using the `sort` key in the server info's `config` |dict|.
 The value of the `sort` key is itself a |dict| containing at least a key
-`max`, which specifies max number of completion items count before ignore sort for performance reason.
+`max`, which specifies max number of completion items count before giving up sorting for performance reason.
 
 The case (in)sensitivity of the matching is determined by |g:lsp_ignorecase|.
 

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -182,5 +182,62 @@ Describe lsp#omni
                         \   'complete_position': { 'line': 1, 'character': 1 }
                         \ })
         End
+
+        It should sort by sortText
+            let items = [{
+            \ 'label': 'my-label3',
+            \ 'kind': '3',
+            \ 'sortText': '3'
+            \},
+            \{
+            \ 'label': 'my-label1',
+            \ 'kind': '3',
+            \ 'sortText': '1'
+            \},
+            \{
+            \ 'label': 'my-label2',
+            \ 'kind': '3',
+            \ 'sortText': '2'
+            \}]
+
+            let options = {
+            \ 'server': { 'name': 'dummy-server' },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': items },
+            \}
+
+            let want = {
+            \ 'items': [{
+            \   'word': 'my-label1',
+            \   'abbr': 'my-label1',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"0"}',
+            \ },
+            \ {
+            \   'word': 'my-label2',
+            \   'abbr': 'my-label2',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"1"}',
+            \ },
+            \ {
+            \   'word': 'my-label3',
+            \   'abbr': 'my-label3',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"2"}',
+            \ }],
+            \ 'incomplete': 0,
+            \}
+
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
+        End
     End
 End

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -2,9 +2,6 @@ Describe lsp#omni
 
     let g:lsp_get_vim_completion_item_set_kind = 1
 
-    let g:lsp_log_verbose = 1
-    let g:lsp_log_file = expand('~/Downloads/vim-lsp.log')
-
     Before each
         call lsp#omni#_clear_managed_user_data_map()
     End

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -2,6 +2,9 @@ Describe lsp#omni
 
     let g:lsp_get_vim_completion_item_set_kind = 1
 
+    let g:lsp_log_verbose = 1
+    let g:lsp_log_file = expand('~/Downloads/vim-lsp.log')
+
     Before each
         call lsp#omni#_clear_managed_user_data_map()
     End
@@ -201,7 +204,12 @@ Describe lsp#omni
             \}]
 
             let options = {
-            \ 'server': { 'name': 'dummy-server' },
+            \ 'server': {
+            \   'name': 'dummy-server',
+            \   'config': {
+            \     'sort': { 'max': 100 },
+            \   },
+            \  },
             \ 'position': lsp#get_position(),
             \ 'response': { 'result': items },
             \}
@@ -237,6 +245,186 @@ Describe lsp#omni
             \ 'incomplete': 0,
             \}
 
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
+        End
+
+        It should not sort over max
+            let items = [{
+            \ 'label': 'my-label3',
+            \ 'kind': '3',
+            \ 'sortText': '3'
+            \},
+            \{
+            \ 'label': 'my-label1',
+            \ 'kind': '3',
+            \ 'sortText': '1'
+            \},
+            \{
+            \ 'label': 'my-label2',
+            \ 'kind': '3',
+            \ 'sortText': '2'
+            \}]
+
+            let options = {
+            \ 'server': {
+            \   'name': 'dummy-server',
+            \   'config': {
+            \     'sort': { 'max': 2 },
+            \   },
+            \  },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': items },
+            \}
+
+            let want = {
+            \ 'items': [{
+            \   'word': 'my-label3',
+            \   'abbr': 'my-label3',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"0"}',
+            \ },
+            \ {
+            \   'word': 'my-label1',
+            \   'abbr': 'my-label1',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"1"}',
+            \ },
+            \ {
+            \   'word': 'my-label2',
+            \   'abbr': 'my-label2',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"2"}',
+            \ }],
+            \ 'incomplete': 0,
+            \}
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
+        End
+
+        It should sort by label(sortText not exists)
+            let items = [{
+            \ 'label': 'my-label3',
+            \ 'kind': '3',
+            \},
+            \{
+            \ 'label': 'my-label1',
+            \ 'kind': '3',
+            \},
+            \{
+            \ 'label': 'my-label2',
+            \ 'kind': '3',
+            \}]
+
+            let options = {
+            \ 'server': {
+            \   'name': 'dummy-server',
+            \   'config': {
+            \     'sort': { 'max': 10 },
+            \   },
+            \  },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': items },
+            \}
+
+            let want = {
+            \ 'items': [{
+            \   'word': 'my-label1',
+            \   'abbr': 'my-label1',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"0"}',
+            \ },
+            \ {
+            \   'word': 'my-label2',
+            \   'abbr': 'my-label2',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"1"}',
+            \ },
+            \ {
+            \   'word': 'my-label3',
+            \   'abbr': 'my-label3',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"2"}',
+            \ }],
+            \ 'incomplete': 0,
+            \}
+            Assert Equals(lsp#omni#get_vim_completion_items(options), want)
+        End
+
+        It should sort by label(empty sortText)
+            let items = [{
+            \ 'label': 'my-label3',
+            \ 'kind': '3',
+            \ 'sortText': ''
+            \},
+            \{
+            \ 'label': 'my-label1',
+            \ 'kind': '3',
+            \ 'sortText': '',
+            \},
+            \{
+            \ 'label': 'my-label2',
+            \ 'kind': '3',
+            \ 'sortText': '',
+            \}]
+
+            let options = {
+            \ 'server': {
+            \   'name': 'dummy-server',
+            \   'config': {
+            \     'sort': { 'max': 10 },
+            \   },
+            \  },
+            \ 'position': lsp#get_position(),
+            \ 'response': { 'result': items },
+            \}
+
+            let want = {
+            \ 'items': [{
+            \   'word': 'my-label1',
+            \   'abbr': 'my-label1',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"0"}',
+            \ },
+            \ {
+            \   'word': 'my-label2',
+            \   'abbr': 'my-label2',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"1"}',
+            \ },
+            \ {
+            \   'word': 'my-label3',
+            \   'abbr': 'my-label3',
+            \   'icase': 1,
+            \   'dup': 1,
+            \   'empty': 1,
+            \   'kind': 'function',
+            \   'user_data': '{"vim-lsp/key":"2"}',
+            \ }],
+            \ 'incomplete': 0,
+            \}
             Assert Equals(lsp#omni#get_vim_completion_items(options), want)
         End
     End


### PR DESCRIPTION
## Summary

Support sortText for ordering.

## Detail

In `deno lsp`, some completion items(folder, file paths) would be convenient by sorted completion items.

Before
<img width="762" alt="スクリーンショット 2021-09-20 1 35 02" src="https://user-images.githubusercontent.com/56591/133935634-751bb6dc-0bb7-4ced-8733-6d023364599a.png">

After
<img width="762" alt="スクリーンショット 2021-09-20 1 33 42" src="https://user-images.githubusercontent.com/56591/133935642-d9db7cba-9cda-4976-85e2-ea6a9efd4c80.png">

Thank you!

