### PR TITLE
Fix completion sort

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -269,8 +269,8 @@ function! s:sort_by_sorttext(i1, i2) abort
     let l:text2 = get(a:i2, 'sortText')
 
     " sortText is possibly empty string
-    let l:text1 = l:text1 ? l:text1 : a:i1['label']
-    let l:text2 = l:text2 ? l:text2 : a:i2['label']
+    let l:text1 = !empty(l:text1) ? l:text1 : a:i1['label']
+    let l:text2 = !empty(l:text2) ? l:text2 : a:i2['label']
 
     if g:lsp_ignorecase
         return l:text1 ==? l:text2 ? 0 : l:text1 >? l:text2 ? 1 : -1

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -424,5 +424,65 @@ Describe lsp#omni
             \}
             Assert Equals(lsp#omni#get_vim_completion_items(options), want)
         End
+
+        Describe g:lsp_ignorecase
+            Before all
+                let saved_ignorecase = get(g:, 'lsp_ignorecase', v:null)
+            End
+
+            After all
+                if saved_ignorecase isnot v:null
+                    let g:lsp_ignorecase = saved_ignorecase
+                endif
+            End
+
+            It should sort completion items case-insensitive when true is set
+                let g:lsp_ignorecase = v:true
+
+                " 'B' < 'a' but 'a' < 'b'
+                let result = [{
+                \ 'label': 'my-label1',
+                \ 'kind': '3',
+                \ 'sortText': 'B'
+                \},
+                \{
+                \ 'label': 'my-label2',
+                \ 'kind': '3',
+                \ 'sortText': 'a'
+                \}]
+
+                let options = {
+                \ 'server': {
+                \   'name': 'dummy-server',
+                \   'config': {
+                \     'sort': { 'max': 10 },
+                \   },
+                \ },
+                \ 'position': lsp#get_position(),
+                \ 'response': { 'result': result },
+                \}
+
+                let want = [{
+                \  'word': 'my-label2',
+                \  'abbr': 'my-label2',
+                \  'icase': 1,
+                \  'dup': 1,
+                \  'empty': 1,
+                \  'kind': 'function',
+                \  'user_data': '{"vim-lsp/key":"0"}',
+                \},
+                \{
+                \  'word': 'my-label1',
+                \  'abbr': 'my-label1',
+                \  'icase': 1,
+                \  'dup': 1,
+                \  'empty': 1,
+                \  'kind': 'function',
+                \  'user_data': '{"vim-lsp/key":"1"}',
+                \}]
+
+                Assert Equals(lsp#omni#get_vim_completion_items(options).items, want)
+            End
+        End
     End
 End

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -185,19 +185,19 @@ Describe lsp#omni
 
         It should sort by sortText
             let items = [{
-            \ 'label': 'my-label3',
-            \ 'kind': '3',
-            \ 'sortText': '3'
-            \},
-            \{
             \ 'label': 'my-label1',
             \ 'kind': '3',
-            \ 'sortText': '1'
+            \ 'sortText': 'c'
             \},
             \{
             \ 'label': 'my-label2',
             \ 'kind': '3',
-            \ 'sortText': '2'
+            \ 'sortText': 'a'
+            \},
+            \{
+            \ 'label': 'my-label3',
+            \ 'kind': '3',
+            \ 'sortText': 'b'
             \}]
 
             let options = {
@@ -213,8 +213,8 @@ Describe lsp#omni
 
             let want = {
             \ 'items': [{
-            \   'word': 'my-label1',
-            \   'abbr': 'my-label1',
+            \   'word': 'my-label2',
+            \   'abbr': 'my-label2',
             \   'icase': 1,
             \   'dup': 1,
             \   'empty': 1,
@@ -222,8 +222,8 @@ Describe lsp#omni
             \   'user_data': '{"vim-lsp/key":"0"}',
             \ },
             \ {
-            \   'word': 'my-label2',
-            \   'abbr': 'my-label2',
+            \   'word': 'my-label3',
+            \   'abbr': 'my-label3',
             \   'icase': 1,
             \   'dup': 1,
             \   'empty': 1,
@@ -231,8 +231,8 @@ Describe lsp#omni
             \   'user_data': '{"vim-lsp/key":"1"}',
             \ },
             \ {
-            \   'word': 'my-label3',
-            \   'abbr': 'my-label3',
+            \   'word': 'my-label1',
+            \   'abbr': 'my-label1',
             \   'icase': 1,
             \   'dup': 1,
             \   'empty': 1,


### PR DESCRIPTION
This fixes implementation by #1223.

Vim script's string is always falsy:

```
:echo !!'foo'
0
```

So, `x ? 1 : 2` is always `1` when `x` is string. `empty()` should be used to check emptiness.

CC: @heavenshell 