### PR TITLE
Avoid BufEnter autocmd when opening floating window

### DIFF
--- a/autoload/lsp/internal/completion/documentation.vim
+++ b/autoload/lsp/internal/completion/documentation.vim
@@ -169,7 +169,7 @@ function! s:get_doc_win() abort
     \ })
     call s:doc_win.set_var('&wrap', 1)
     call s:doc_win.set_var('&conceallevel', 2)
-    silent let l:bufnr = s:Buffer.create()
+    noautocmd silent let l:bufnr = s:Buffer.create()
     call s:doc_win.set_bufnr(l:bufnr)
     call setbufvar(s:doc_win.get_bufnr(), '&buftype', 'nofile')
     call setbufvar(s:doc_win.get_bufnr(), '&bufhidden', 'hide')


### PR DESCRIPTION
The `s:Buffer.create()` will fire some of the autocmd like `FileType` `BufEnter` etc... due to `bufload` calls.

1. The `bufload` is needed to call `setbufline` before showing the buffer.
2. Basically, `FileType` autocmd is needs for syntax highlighting.

So in `vsim-vital-vs` context, `s:Buffer.create()` should fire autocmd but in this case we don't need `FileType` autocmd because syntax highlighting will be applied by calling `s:Markdown.apply`.

So we can avoid autocmd here.
