### PR TITLE
Fix Neovim CI

### DIFF
--- a/.github/workflows/linux_neovim.yml
+++ b/.github/workflows/linux_neovim.yml
@@ -43,6 +43,7 @@ jobs:
           mkdir -p ~/nvim/bin
           curl -L https://github.com/neovim/neovim/releases/download/${{matrix.neovim_version}}/nvim.appimage -o ~/nvim/bin/nvim
           chmod u+x ~/nvim/bin/nvim
+        continue-on-error: ${{matrix.allow_failure}}
       - name: Cache gopls
         id: cache-gopls
         uses: actions/cache@v2

--- a/.github/workflows/linux_neovim.yml
+++ b/.github/workflows/linux_neovim.yml
@@ -27,7 +27,7 @@ jobs:
             allow_failure: false
           - name: neovim-v05-x64
             os: ubuntu-latest
-            neovim_version: v0.5.0
+            neovim_version: v0.5.1
             allow_failure: false
           - name: neovim-nightly-x64
             os: ubuntu-latest

--- a/.github/workflows/mac_neovim.yml
+++ b/.github/workflows/mac_neovim.yml
@@ -40,9 +40,11 @@ jobs:
       - name: Download neovim
         shell: bash
         run: curl -L https://github.com/neovim/neovim/releases/download/${{matrix.neovim_version}}/nvim-macos.tar.gz -o ~/nvim.tar.gz
+        continue-on-error: ${{matrix.allow_failure}}
       - name: Extract neovim
         shell: bash
         run: tar xzf ~/nvim.tar.gz -C ~/
+        continue-on-error: ${{matrix.allow_failure}}
       - name: Download test runner
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/mac_neovim.yml
+++ b/.github/workflows/mac_neovim.yml
@@ -27,7 +27,7 @@ jobs:
             allow_failure: false
           - name: neovim-v05-x64
             os: macos-latest
-            neovim_version: v0.5.0
+            neovim_version: v0.5.1
             allow_failure: false
           - name: neovim-nightly-x64
             os: macos-latest

--- a/.github/workflows/windows_neovim.yml
+++ b/.github/workflows/windows_neovim.yml
@@ -28,7 +28,7 @@ jobs:
             allow_failure: false
           - name: neovim-v05-x64
             os: windows-latest
-            neovim_version: v0.5.0
+            neovim_version: v0.5.1
             neovim_arch: win64
             allow_failure: false
           - name: neovim-nightly-x64

--- a/.github/workflows/windows_neovim.yml
+++ b/.github/workflows/windows_neovim.yml
@@ -43,9 +43,11 @@ jobs:
       - name: Download neovim
         shell: PowerShell
         run: Invoke-WebRequest -Uri https://github.com/neovim/neovim/releases/download/${{matrix.neovim_version}}/nvim-${{matrix.neovim_arch}}.zip -OutFile neovim.zip
+        continue-on-error: ${{matrix.allow_failure}}
       - name: Extract neovim
         shell: PowerShell
         run: Expand-Archive -Path neovim.zip -DestinationPath $env:USERPROFILE
+        continue-on-error: ${{matrix.allow_failure}}
       - name: Cache gopls
         id: cache-gopls
         uses: actions/cache@v2


### PR DESCRIPTION
Now Neovim nightly packages are missing due to [job error](https://github.com/neovim/neovim/actions/runs/1282732454)