### PR TITLE
Add \<esc> to omni for ignore insert `=<SNR>37_on_complete_done_after()`

### DIFF
--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -54,7 +54,7 @@ function! s:on_complete_done() abort
   let s:context['complete_position'] = l:managed_user_data['complete_position']
   let s:context['server_name'] = l:managed_user_data['server_name']
   let s:context['completion_item'] = l:managed_user_data['completion_item']
-  call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
+  call feedkeys(printf("\<esc>\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
 endfunction
 
 "


### PR DESCRIPTION
## Problem

- Show completion items by `<C-x><C-o>`
- type `<C-g>` or `<C-k>` or `<C-v>`
- insert `=<SNR>37_on_complete_done_after()` to buffer
(`<C-v>` inserts `^R=<SNR>37_on_complete_done_after()`)

https://user-images.githubusercontent.com/56591/136400597-e9aa425f-34b8-4c90-8804-5b22d49d8a18.mp4

Reproduced by following vimrc and using vim-lsp-settings and gopls

```vim
autocmd!
set nocompatible
syntax enable
filetype plugin indent on

function! s:on_lsp_buffer_enabled() abort
  setlocal omnifunc=lsp#complete
endfunction

augroup lsp_install
  autocmd!
  autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
augroup END
```

## After

https://user-images.githubusercontent.com/56591/136401160-35a68eb6-1faa-481d-819c-d09787f716a0.mp4

I'm not familier with `feedkey()`, so if anything more better way to fix this, please let me know 🙏 
(type `<C-v>` inserts `^]`)

Thank you!