### PR TITLE
respect g:lsp_signature_help_enabled when cursor moved

### DIFF
--- a/autoload/lsp/ui/vim/signature_help.vim
+++ b/autoload/lsp/ui/vim/signature_help.vim
@@ -115,7 +115,9 @@ endfunction
 function! s:on_cursor_moved() abort
     let l:bufnr = bufnr('%')
     call timer_stop(s:debounce_timer_id)
-    let s:debounce_timer_id = timer_start(g:lsp_signature_help_delay, function('s:on_text_changed_after', [l:bufnr]), { 'repeat': 1 })
+    if g:lsp_signature_help_enabled
+        let s:debounce_timer_id = timer_start(g:lsp_signature_help_delay, function('s:on_text_changed_after', [l:bufnr]), { 'repeat': 1 })
+    endif
 endfunction
 
 function! s:on_text_changed_after(bufnr, timer) abort


### PR DESCRIPTION
fixes https://github.com/prabirshrestha/vim-lsp/issues/820.

For perf reasons it is still expected to set it to false before lsp has been setup.