### PR TITLE
Fix conceallevel=2 to LspHover preview

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -108,6 +108,7 @@ function! s:show_preview_window(server_name, request, response) abort
     sp LspHoverPreview
     execute 'resize '.min([len(l:lines), &previewheight])
     set previewwindow
+    setlocal conceallevel=2
     setlocal bufhidden=hide
     setlocal nobuflisted
     setlocal buftype=nofile


### PR DESCRIPTION
Hi, I'm using `g:lsp_hover_ui = 'preview'`.
When hover with preview window, conceal has been shown.

Before
<img width="731" alt="スクリーンショット 2021-12-29 1 07 33" src="https://user-images.githubusercontent.com/56591/147585242-42348476-96b0-4a9b-85d9-e54c3430d1b7.png">

After
<img width="733" alt="スクリーンショット 2021-12-29 1 08 41" src="https://user-images.githubusercontent.com/56591/147585575-0bb43828-5c27-4a99-ba97-14b0ab685ee9.png">


When using `float`, concellevel set as `2`.
https://github.com/prabirshrestha/vim-lsp/blob/858a5adeaae6283b8a061c8604b875be7048b2e3/autoload/lsp/internal/document_hover/under_cursor.vim#L233

I add same value to preview.
But, should we use `g:lsp_hover_conceal` value instead?