### PR TITLE
Handle error case where cursor is outside screen

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -240,6 +240,10 @@ endfunction
 
 function! s:compute_position(size) abort
     let l:pos = screenpos(0, line('.'), col('.'))
+    if l:pos.row == 0 && l:pos.col == 0
+        " When the specified position is not visible
+        return []
+    endif
     let l:pos = [l:pos.row + 1, l:pos.curscol + 1]
     if l:pos[0] + a:size.height > &lines
         let l:pos[0] = l:pos[0] - a:size.height - 3


### PR DESCRIPTION
This is small followup of #1253. `screenpos()` returns `{'col': 0, 'row': 0, 'endcol': 0, 'curscol': 0}` when the position is outside screen. This patch adds error handling for the case.