### PR TITLE
[perf] update async.vim to f20569020d65bec3249222606c073c0943045b5e and normalize output to string

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -37,11 +37,7 @@ function! s:on_stdout(id, data, event) abort
         return
     endif
 
-    if empty(l:ctx['buffer'])
-        let l:ctx['buffer'] = join(a:data, "\n")
-    else
-        let l:ctx['buffer'] .= join(a:data, "\n")
-    endif
+    let l:ctx['buffer'] .= a:data
 
     while 1
         if l:ctx['content-length'] < 0
@@ -188,12 +184,14 @@ function! s:lsp_start(opts) abort
             \ 'on_stdout': function('s:on_stdout'),
             \ 'on_stderr': function('s:on_stderr'),
             \ 'on_exit': function('s:on_exit'),
+            \ 'normalize': 'string'
             \ })
     elseif has_key(a:opts, 'tcp')
         let l:client_id = lsp#utils#job#connect(a:opts.tcp, {
             \ 'on_stdout': function('s:on_stdout'),
             \ 'on_stderr': function('s:on_stderr'),
             \ 'on_exit': function('s:on_exit'),
+            \ 'normalize': 'string'
             \ })
     else
         return -1


### PR DESCRIPTION
https://github.com/prabirshrestha/async.vim/pull/47

>One of the big mistakes I did in designing async.vim was to default to neovim output. Most of the time you need to get string and this can be costly for vim, since vim by default returns a string, which means we call split in async.vim then the consumer calls join which should had ideally been a noop. This allocates unnecessary memory due to string and array creation. Luckily we can have 100% backwards compatibility as I still default to 'array' if not passed and one can easily override it to 'string'. For callbag.vim's spawn function I had defaulted to 'raw' and make the user decide if they want compatibility.

There should be no impact for neovim from this PR but should have better memory allocation and perf in vim.

To get perf improvements we still need to fix this https://github.com/prabirshrestha/vim-lsp/pull/1199