### PR TITLE
Format Hover Pop-up Window

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -167,7 +167,7 @@ function! s:show_floating_window(server_name, request, response) abort
     call s:Window.do(l:doc_win.get_winid(), { -> s:format_window() })
 endfunction
 
-function! s:format_window()
+function! s:format_window() abort
     global/^/normal! gqgq
 endfunction
 

--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -89,7 +89,7 @@ function! s:show_hover(ui, server_name, request, response) abort
         call s:show_floating_window(a:server_name, a:request, a:response)
     else
         call s:show_preview_window(a:server_name, a:request, a:response)
-	endif
+    endif
 endfunction
 
 function! s:show_preview_window(server_name, request, response) abort
@@ -161,6 +161,14 @@ function! s:show_floating_window(server_name, request, response) abort
         \   'border': v:true,
         \ })
     call s:Window.do(l:doc_win.get_winid(), { -> s:Markdown.apply() })
+
+    " Format contents to fit window
+    call setbufvar(l:doc_win.get_bufnr(), '&textwidth', l:size.width)
+    call s:Window.do(l:doc_win.get_winid(), { -> s:format_window() })
+endfunction
+
+function! s:format_window()
+    global/^/normal! gqgq
 endfunction
 
 function! s:get_contents(contents) abort

--- a/autoload/vital/_lsp/VS/Vim/Window.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window.vim
@@ -106,7 +106,7 @@ function! s:scroll(winid, topline) abort
   function! l:ctx.callback(winid, topline) abort
     let l:wininfo = s:info(a:winid)
     let l:topline = a:topline
-    let l:topline = min([l:topline, line('$') - l:wininfo.height + 1])
+    let l:topline = min([l:topline, line('$') - l:wininfo.height + 3])
     let l:topline = max([l:topline, 1])
 
     if l:topline == l:wininfo.topline

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -155,6 +155,7 @@ CONTENTS                                                  *vim-lsp-contents*
     Snippets                              |vim-lsp-snippets|
     Folding                               |vim-lsp-folding|
     Semantic highlighting                 |vim-lsp-semantic|
+    Popup Formatting                      |vim-lsp-popup-format|
     License                               |vim-lsp-license|
     Maintainers                           |vim-lsp-maintainers|
 
@@ -1998,6 +1999,14 @@ want function calls to still use the |Label| group, but use |Identifier| for
         \ }
         \ })
 <
+==============================================================================
+Popup Formatting                                      *vim-lsp-popup-format*
+
+Popup windows use the |gq| operator for formatting content to the window.
+
+For customization, see 
+|formatprg|.
+
 ==============================================================================
 License                                                    *vim-lsp-license*
 


### PR DESCRIPTION
Addresses issue #1249 where wrapped lines overflow in the pop-up window. Additionally fixes an issue that prevented scrolling to the last two lines of a popup window.

1) Applies Vim's `gq` command to each individual line of content returned by language server. User configurable through `formatprg` builtin.

2) Allows scrolling to the last lines of a popup window. An offset did not take into consideration the window's border size.