### PR TITLE
Fix register overwire when a preview window is cleared for lsp-hover

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -113,7 +113,7 @@ function! s:show_preview_window(server_name, request, response) abort
     setlocal nobuflisted
     setlocal buftype=nofile
     setlocal noswapfile
-    %d
+    %d _
     call setline(1, l:lines)
     call s:Window.do(win_getid(), {->s:Markdown.apply()})
     execute "normal \<c-w>p"


### PR DESCRIPTION
This PR uses the black hole register to avoid overwriting a register when a preview window is cleared.