### PR TITLE
highlight change: NonText -> Comment

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -141,7 +141,7 @@ let s:color_map = {
 \ 'starting': 'MoreMsg',
 \ 'failed': 'WarningMsg',
 \ 'running': 'Keyword',
-\ 'not running': 'NonText'
+\ 'not running': 'Comment'
 \}
 
 " Print the current status of all servers (if called with no arguments)


### PR DESCRIPTION
Problem: Some vimmers use the NonText highlight group as a poor-man's conceal. Use Comment instead for LspStatus.