### PR TITLE
fix: mapping to escape

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -30,8 +30,6 @@ function! lsp#internal#document_hover#under_cursor#do(options) abort
                 if !hasmapto('<Plug>(lsp-float-close)')
                     imap <silent> <buffer> <C-c> <Plug>(lsp-float-close)
                     nmap  <silent> <buffer> <C-c> <Plug>(lsp-float-close)
-                    imap <silent> <buffer> <Esc> <Plug>(lsp-float-close)
-                    nmap  <silent> <buffer> <Esc> <Plug>(lsp-float-close)
                 endif
             endif
             return
@@ -218,8 +216,6 @@ function! s:on_opened() abort
     if !hasmapto('<Plug>(lsp-float-close)')
         imap <silent> <buffer> <C-c> <Plug>(lsp-float-close)
         nmap  <silent> <buffer> <C-c> <Plug>(lsp-float-close)
-        imap <silent> <buffer> <Esc> <Plug>(lsp-float-close)
-        nmap  <silent> <buffer> <Esc> <Plug>(lsp-float-close)
     endif
 endfunction
 

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -309,7 +309,7 @@ g:lsp_preview_float                         *g:lsp_preview_float*
     If set and nvim_win_open() or popup_create is available, hover information
     are shown in a floating window as |preview-window| at the cursor position.
     The |preview-window| is closed automatically on cursor moves, unless it is
-    focused. While focused it may be closed with <esc>.
+    focused. While focused it may be closed with <C-c>.
 
     This feature requires neovim 0.4.0 (current master) or
     Vim8.1 with has('patch-8.1.1517').
@@ -328,10 +328,10 @@ g:lsp_preview_float                         *g:lsp_preview_float*
     of the window.
 
     Example of custom keybindings: >
-	" Close preview window with <esc>
-	autocmd User lsp_float_opened nmap <buffer> <silent> <esc>
+	" Close preview window with <C-c>
+	autocmd User lsp_float_opened nmap <buffer> <silent> <C-c>
 		      \ <Plug>(lsp-preview-close)
-	autocmd User lsp_float_closed nunmap <buffer> <esc>
+	autocmd User lsp_float_closed nunmap <buffer> <C-c>
 <
 
     Example of customising the highlighting: >
@@ -1575,7 +1575,7 @@ Gets the hover information and displays it in the |preview-window|.
    configure |g:lsp_preview_keep_focus|.
  * If using neovim with nvim_win_open() available, |g:lsp_preview_float| can
    be set to enable a floating preview at the cursor which is closed
-   automatically on cursormove if not focused and can be closed with <esc> if
+   automatically on cursormove if not focused and can be closed with <C-c> if
    focused.
 
     Example: >


### PR DESCRIPTION
Removed only ```<Esc>``` key mappings because it seems to cause problems
in vim8.
Removed only for normal mode, for insert mode ```<Esc>``` works perfectly.
Fix #1263 and  #1267

Since #1269 has been stagnant for some time, I created a PR just by deleting ```esc``` mappings.
Thanks for this plugin.