### PR TITLE
[PoC] Handle jdt:// URIs

### DIFF
--- a/autoload/lsp/utils/location.vim
+++ b/autoload/lsp/utils/location.vim
@@ -68,6 +68,16 @@ function! s:lsp_location_item_to_vim(loc, cache) abort
         let l:use_link = 0
     endif
 
+    if stridx(l:uri, 'jdt://') == 0
+      let l:zip = 'file://' . substitute(substitute(l:uri, 'jdt://.*?=.*/%5c\(/[^=]\+\)\.jar.*', '\1', 'g'), '%5C', '', 'g') . '-sources.jar'
+      let l:source = substitute(substitute(l:uri, 'jdt://.*.jar/\(.*\)\.class?=.*', '\1', 'g'), '\.', '/', 'g') . '.java'
+      return {
+          \ 'filename': "zip" . l:zip . "::" . l:source,
+          \ 'lnum': a:loc["range"]["start"]["line"] + 1,
+          \ 'col': a:loc["range"]["start"]["character"] + 1,
+          \ }
+    endif
+
     if !lsp#utils#is_file_uri(l:uri)
         return v:null
     endif


### PR DESCRIPTION
eclipse.jdt.ls can retrieve definitions for symbols located in jar files.

Example:

```java
import javax.jms.JMSException;
```

In a maven project, when cursor is on `JMSExc|eption`, :LspDefinition would reply with the following, including exact source file name and line/column location:

```json
{
  "uri": "jdt://contents/geronimo-jms_1.1_spec-1.1.1.jar/javax.jms/JMSException.class?=java-engine-main/%5C/Users%5C/MYUSER%5C/.m2%5C/repository%5C/org%5C/apache%5C/geronimo%5C/specs%5C/geronimo-jms_1.1_spec%5C/1.1.1%5C/geronimo-jms_1.1_spec-1.1.1.jar=/maven.pomderived=/true=/=/maven.pomderived=/true=/=/maven.groupId=/org.apache.geronimo.specs=/=/maven.artifactId=/geronimo-jms_1.1_spec=/=/maven.version=/1.1.1=/=/maven.scope=/compile=/%3Cjavax.jms(JMSException.class",
  "range": {
    "end": {
      "character": 25,
      "line": 30
    },
    "start": {
      "character": 13,
      "line": 30
    }
  }
}
```

The `"uri"` string contains the location of the jar file, and within it the full of the `JMSException.java`  file.

This patch converts this `"uri"` string into the following:

```
zipfile:///Users/MYUSER/.m2/repository/org/apache/geronimo/specs/geronimo-jms_1.1_spec/1.1.1/geroni
mo-jms_1.1_spec-1.1.1-sources.jar::javax/jms/JMSException.java
```

The `zipfile://<path>.jar::<path>` format is understood by vim and therefore it can open the definition.

Note that this is tested with a maven project, after `dependency:sources` downloaded the `-sources.jar` files for the otherwise binary dependencies.

* * *

Now this is clearly a proof-of-concept and not something I'd consider to be merged. However it worksforme and would be nice if vim-lsp's `s:lsp_location_item_to_vim` function could handle othe "proprietary" URI specifiers, including `jdt://`.