### PR TITLE
Add prefix to completions if start col changes.

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -340,7 +340,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:character = l:completion_item['textEdit']['range']['start']['character']
             let l:vim_complete_item['word'] = l:cur_line[l:start_character : l:character - 1] . l:completion_item['textEdit']['newText']
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
-            let l:with_prefix = l:cur_line[l:start_character:s:completion['startcol'] - 2] . l:completion_item['insertText']
+            let l:with_prefix = l:cur_line[l:start_character : s:completion['startcol'] - 2] . l:completion_item['insertText']
             let l:completion_item['insertText'] = l:with_prefix
             let l:vim_complete_item['word'] = l:with_prefix
         else

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -319,6 +319,13 @@ function! lsp#omni#get_vim_completion_items(options) abort
     endif
 
     let l:start_character = l:complete_position['character']
+
+    for l:completion_item in l:items
+        if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
+            let l:start_character = min([l:completion_item['textEdit']['range']['start']['character'], l:start_character])
+        endif
+    endfor
+
     let l:vim_complete_items = []
     for l:completion_item in l:items
         let l:expandable = get(l:completion_item, 'insertTextFormat', 1) == 2
@@ -329,12 +336,12 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'icase': 1,
             \ }
         if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
-            let l:vim_complete_item['word'] = l:completion_item['textEdit']['newText']
-            let l:start_character = min([l:completion_item['textEdit']['range']['start']['character'], l:start_character])
+            let l:character = l:completion_item['textEdit']['range']['start']['character']
+            let l:vim_complete_item['word'] = getline('.')[l:start_character:l:character - 1] . l:completion_item['textEdit']['newText']
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
-            let l:vim_complete_item['word'] = l:completion_item['insertText']
+            let l:vim_complete_item['word'] = getline('.')[l:start_character:a:options['position']['character']] . l:completion_item['insertText']
         else
-            let l:vim_complete_item['word'] = l:completion_item['label']
+            let l:vim_complete_item['word'] = getline('.')[l:start_character:a:options['position']['character']] . l:completion_item['label']
         endif
 
         if l:expandable

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -327,6 +327,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
     endfor
 
     let l:vim_complete_items = []
+    let l:cur_line = getline('.')
     for l:completion_item in l:items
         let l:expandable = get(l:completion_item, 'insertTextFormat', 1) == 2
         let l:vim_complete_item = {
@@ -335,14 +336,17 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'empty': 1,
             \ 'icase': 1,
             \ }
-        let l:cur_line = getline('.')
         if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
             let l:character = l:completion_item['textEdit']['range']['start']['character']
             let l:vim_complete_item['word'] = l:cur_line[l:start_character:l:character - 1] . l:completion_item['textEdit']['newText']
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
-            let l:vim_complete_item['word'] = l:cur_line[l:start_character:a:options['position']['character']] . l:completion_item['insertText']
+            let l:with_prefix = l:cur_line[l:start_character:s:completion['startcol'] - 2] . l:completion_item['insertText']
+            let l:completion_item['insertText'] = l:with_prefix
+            let l:vim_complete_item['word'] = l:with_prefix
         else
-            let l:vim_complete_item['word'] = l:cur_line[l:start_character:a:options['position']['character']] . l:completion_item['label']
+            let l:with_prefix = l:cur_line[l:start_character:s:completion['startcol'] - 2] . l:completion_item['label']
+            let l:completion_item['label'] = l:with_prefix
+            let l:vim_complete_item['word'] = l:with_prefix
         endif
 
         if l:expandable

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -335,13 +335,14 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'empty': 1,
             \ 'icase': 1,
             \ }
+        let l:cur_line = getline('.')
         if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
             let l:character = l:completion_item['textEdit']['range']['start']['character']
-            let l:vim_complete_item['word'] = getline('.')[l:start_character:l:character - 1] . l:completion_item['textEdit']['newText']
+            let l:vim_complete_item['word'] = l:cur_line[l:start_character:l:character - 1] . l:completion_item['textEdit']['newText']
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
-            let l:vim_complete_item['word'] = getline('.')[l:start_character:a:options['position']['character']] . l:completion_item['insertText']
+            let l:vim_complete_item['word'] = l:cur_line[l:start_character:a:options['position']['character']] . l:completion_item['insertText']
         else
-            let l:vim_complete_item['word'] = getline('.')[l:start_character:a:options['position']['character']] . l:completion_item['label']
+            let l:vim_complete_item['word'] = l:cur_line[l:start_character:a:options['position']['character']] . l:completion_item['label']
         endif
 
         if l:expandable

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -344,7 +344,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:completion_item['insertText'] = l:with_prefix
             let l:vim_complete_item['word'] = l:with_prefix
         else
-            let l:with_prefix = l:cur_line[l:start_character:s:completion['startcol'] - 2] . l:completion_item['label']
+            let l:with_prefix = l:cur_line[l:start_character : s:completion['startcol'] - 2] . l:completion_item['label']
             let l:completion_item['label'] = l:with_prefix
             let l:vim_complete_item['word'] = l:with_prefix
         endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -338,7 +338,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ }
         if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
             let l:character = l:completion_item['textEdit']['range']['start']['character']
-            let l:vim_complete_item['word'] = l:cur_line[l:start_character:l:character - 1] . l:completion_item['textEdit']['newText']
+            let l:vim_complete_item['word'] = l:cur_line[l:start_character : l:character - 1] . l:completion_item['textEdit']['newText']
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
             let l:with_prefix = l:cur_line[l:start_character:s:completion['startcol'] - 2] . l:completion_item['insertText']
             let l:completion_item['insertText'] = l:with_prefix


### PR DESCRIPTION
See issue: https://github.com/prabirshrestha/vim-lsp/issues/1300

`textEdit` completions can cause the column where the completion begins
to change. Current behaviour is to just take the minimum of such start
characters. This breaks autocompletion of edits that don't start at this
earliest position as:

(a) They are filtered out by `prefix` or `contains` autocomplete filters
as they no longer match the `last_typed_word`
(b) They insert at the wrong location even if the above is fixed.

The solution included here is to add any extra characters included by
the moving of the start column as a prefix to any insertion completions.