### PR TITLE
Fix parse arguments

### DIFF
--- a/autoload/lsp/utils/args.vim
+++ b/autoload/lsp/utils/args.vim
@@ -1,10 +1,12 @@
 function! lsp#utils#args#_parse(args, opt) abort
     let l:result = {}
     for l:item in split(a:args, ' ')
-        let l:parts = split(l:item, '=')
-        let l:key = l:parts[0]
-        let l:value = get(l:parts, 1, '')
-        let l:key = l:key[2:]
+        let l:parts = matchlist(l:item, '--\(\w\+\)=\(.*\)')
+        if empty(l:parts)
+          continue
+        endif
+        let l:key = l:parts[1]
+        let l:value = l:parts[2]
         if has_key(a:opt, l:key)
             if has_key(a:opt[l:key], 'type')
                 let l:type = a:opt[l:key]['type']

--- a/autoload/lsp/utils/args.vim
+++ b/autoload/lsp/utils/args.vim
@@ -1,8 +1,10 @@
 function! lsp#utils#args#_parse(args, opt) abort
-    let l:result = {}
+    let l:args = []
+    let l:options = {}
     for l:item in split(a:args, ' ')
         let l:parts = matchlist(l:item, '^--\([a-z][a-z0-9-]*\)\(=\S*\)\?$')
         if empty(l:parts)
+          call add(l:args, l:item)
           continue
         endif
         let l:key = l:parts[1]
@@ -21,7 +23,7 @@ function! lsp#utils#args#_parse(args, opt) abort
                 endif
             endif
         endif
-        let l:result[l:key] = l:value
+        let l:options[l:key] = l:value
     endfor
-    return l:result
+    return {'args': l:args, 'options': l:options}
 endfunction

--- a/autoload/lsp/utils/args.vim
+++ b/autoload/lsp/utils/args.vim
@@ -1,17 +1,17 @@
 function! lsp#utils#args#_parse(args, opt) abort
     let l:result = {}
     for l:item in split(a:args, ' ')
-        let l:parts = matchlist(l:item, '--\(\w\+\)=\(.*\)')
+        let l:parts = matchlist(l:item, '^--\([a-z][a-z0-9-]*\)\(=\S*\)\?$')
         if empty(l:parts)
           continue
         endif
         let l:key = l:parts[1]
-        let l:value = l:parts[2]
+        let l:value = l:parts[2][1:]
         if has_key(a:opt, l:key)
             if has_key(a:opt[l:key], 'type')
                 let l:type = a:opt[l:key]['type']
                 if l:type == type(v:true)
-                    if l:value ==# 'false' || l:value ==# '0' || l:value ==# ''
+                    if l:value ==# 'false' || l:value ==# '0'
                         let l:value = 0
                     else
                         let l:value = 1

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -105,11 +105,11 @@ command! LspDocumentSymbolSearch call lsp#internal#document_symbol#search#do({})
 command! -nargs=? LspDocumentDiagnostics call lsp#internal#diagnostics#document_diagnostics_command#do(
             \ extend({}, lsp#utils#args#_parse(<q-args>, {
             \   'buffers': {'type': type('')},
-            \ })))
+            \ }).options))
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspHover call lsp#internal#document_hover#under_cursor#do(
             \ extend({}, lsp#utils#args#_parse(<q-args>, {
             \   'ui': { 'type': type('') },
-            \ })))
+            \ }).options))
 command! -nargs=* LspNextError call lsp#internal#diagnostics#movement#_next_error(<f-args>)
 command! -nargs=* LspPreviousError call lsp#internal#diagnostics#movement#_previous_error(<f-args>)
 command! -nargs=* LspNextWarning call lsp#internal#diagnostics#movement#_next_warning(<f-args>)
@@ -128,13 +128,13 @@ command! -range -nargs=? LspDocumentFormatSync call lsp#internal#document_format
             \ extend({'bufnr': bufnr('%'), 'sync': 1 }, lsp#utils#args#_parse(<q-args>, {
             \   'timeout': {'type': type(0)},
             \   'sleep': {'type': type(0)},
-            \ })))
+            \ }).options))
 command! -range LspDocumentRangeFormat call lsp#internal#document_range_formatting#format({ 'bufnr': bufnr('%') })
 command! -range -nargs=? LspDocumentRangeFormatSync call lsp#internal#document_range_formatting#format(
             \ extend({'bufnr': bufnr('%'), 'sync': 1 }, lsp#utils#args#_parse(<q-args>, {
             \   'timeout': {'type': type(0)},
             \   'sleep': {'type': type(0)},
-            \ })))
+            \ }).options))
 command! LspImplementation call lsp#ui#vim#implementation(0, <q-mods>)
 command! LspPeekImplementation call lsp#ui#vim#implementation(1)
 command! -nargs=0 LspStatus call lsp#print_server_status()

--- a/test/lsp/utils/args.vimspec
+++ b/test/lsp/utils/args.vimspec
@@ -1,0 +1,21 @@
+Describe lsp#utils#args
+
+    Describe lsp#utils#args#_parse
+
+        It should return parsed dictionary from string formed with --key=value
+            let l:tests = [
+            \  ['--server=foo', {}, {'server': 'foo'}],
+            \  ['--server', {'server': {'type': v:t_bool}}, {'server': 1}],
+            \  ['--server=0', {'server': {'type': v:t_bool}}, {'server': 0}],
+            \  ['--server=false', {'server': {'type': v:t_bool}}, {'server': 0}],
+            \  ['--server=', {'server': {'type': v:t_string}}, {'server': ''}],
+            \  ['--server-name=foo', {'server-name': {'type': v:t_string}}, {'server-name': 'foo'}],
+            \]
+            for l:test in l:tests
+              Assert Equals(lsp#utils#args#_parse(l:test[0], l:test[1]), l:test[2])
+            endfor
+        End
+
+    End
+
+End

--- a/test/lsp/utils/args.vimspec
+++ b/test/lsp/utils/args.vimspec
@@ -4,15 +4,16 @@ Describe lsp#utils#args
 
         It should return parsed dictionary from string formed with --key=value
             let l:tests = [
-            \  ['--server=foo', {}, {'server': 'foo'}],
-            \  ['--server', {'server': {'type': v:t_bool}}, {'server': 1}],
-            \  ['--server=0', {'server': {'type': v:t_bool}}, {'server': 0}],
-            \  ['--server=false', {'server': {'type': v:t_bool}}, {'server': 0}],
-            \  ['--server=', {'server': {'type': v:t_string}}, {'server': ''}],
-            \  ['--server-name=foo', {'server-name': {'type': v:t_string}}, {'server-name': 'foo'}],
+            \  ['--server=foo bar', {}, ['bar'], {'server': 'foo'}],
+            \  ['--server bar', {'server': {'type': v:t_bool}}, ['bar'], {'server': 1}],
+            \  ['foo --server=0 bar', {'server': {'type': v:t_bool}}, ['foo', 'bar'], {'server': 0}],
+            \  ['--server=false', {'server': {'type': v:t_bool}}, [], {'server': 0}],
+            \  ['--server=', {'server': {'type': v:t_string}}, [], {'server': ''}],
+            \  ['--server-name=foo', {'server-name': {'type': v:t_string}}, [], {'server-name': 'foo'}],
             \]
             for l:test in l:tests
-              Assert Equals(lsp#utils#args#_parse(l:test[0], l:test[1]), l:test[2])
+              Assert Equals(lsp#utils#args#_parse(l:test[0], l:test[1]).args, l:test[2])
+              Assert Equals(lsp#utils#args#_parse(l:test[0], l:test[1]).options, l:test[3])
             endfor
         End
 


### PR DESCRIPTION
```
:echo lsp#utils#args#_parse('--server=foo XXname=bar', {})
{'name': 'bar', 'server': 'foo'}
```
`XXname` should be ignored.