### PR TITLE
Improve tag location string

### DIFF
--- a/autoload/lsp/tag.vim
+++ b/autoload/lsp/tag.vim
@@ -21,7 +21,7 @@ function! s:location_to_tag(loc) abort
     let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:range['start'])
     return {
         \ 'filename': l:path,
-        \ 'cmd': printf('/\%%%dl\%%%dc/', l:line, l:col)
+        \ 'cmd': printf('/%dL, %dC/', l:line, l:col)
         \ }
 endfunction
 


### PR DESCRIPTION
Old string: \%10l\%5c
New string: 10L, 5C

In the old string, the escape character is reduntant, the % character is cumbersome, and the lower case "l" looks like "1".