### PR TITLE
ignore errors in s:clear_auto_inserted_text

### DIFF
--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -236,8 +236,11 @@ endfunction
 function! s:clear_auto_inserted_text(done_line, done_position, complete_position) abort
   let l:before = strcharpart(a:done_line, 0, a:complete_position['character'])
   let l:after = strcharpart(a:done_line, a:done_position['character'], (strchars(a:done_line) - a:done_position['character']))
-  call setline('.', l:before . l:after)
-  call cursor([a:done_position['line'] + 1, strlen(l:before) + 1])
+  try
+    call setline('.', l:before . l:after)
+    call cursor([a:done_position['line'] + 1, strlen(l:before) + 1])
+  catch
+  endtry
 endfunction
 
 "


### PR DESCRIPTION
I don't figure this out how to reproduce but.

![image](https://user-images.githubusercontent.com/10111/169721883-b46d1e0e-e22e-4f75-92f0-b43a1de9b038.png)
