### PR TITLE
Fix invalid mode when to expand completion item

### DIFF
--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -64,6 +64,11 @@ function! s:on_complete_done_after() abort
   " Clear message line. feedkeys above leave garbage on message line.
   echo ''
 
+  " Ignore process if the mode() is not insert-mode after feedkeys.
+  if mode(1)[0] !=# 'i'
+    return ''
+  endif
+
   let l:done_line = s:context['done_line']
   let l:completed_item = s:context['completed_item']
   let l:done_position = s:context['done_position']


### PR DESCRIPTION
This PR fixes the `Not allowed here` error when expanding the completion item that described in the https://github.com/prabirshrestha/vim-lsp/pull/1318