### PR TITLE
Fix when textEdit type was InsertReplaceEdit

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -328,9 +328,10 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'empty': 1,
             \ 'icase': 1,
             \ }
-        if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
+        if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'newText')
+            let l:text_edit_range = lsp#utils#text_edit#_get_range_maybe_replace(l:completion_item['textEdit'])
             let l:vim_complete_item['word'] = l:completion_item['textEdit']['newText']
-            let l:start_character = min([l:completion_item['textEdit']['range']['start']['character'], l:start_character])
+            let l:start_character = min([l:text_edit_range['start']['character'], l:start_character])
         elseif has_key(l:completion_item, 'insertText') && !empty(l:completion_item['insertText'])
             let l:vim_complete_item['word'] = l:completion_item['insertText']
         else

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -106,8 +106,9 @@ function! s:on_complete_done_after() abort
   if l:is_expandable
     " At this timing, the cursor may have been moved by additionalTextEdit, so we use overflow information instead of textEdit itself.
     if type(get(l:completion_item, 'textEdit', v:null)) == type({})
-      let l:overflow_before = max([0, l:complete_start_character - l:completion_item['textEdit']['range']['start']['character']])
-      let l:overflow_after = max([0, l:completion_item['textEdit']['range']['end']['character'] - l:complete_position['character']])
+      let l:text_edit_range = lsp#utils#text_edit#_get_range_maybe_replace(l:completion_item['textEdit'])
+      let l:overflow_before = max([0, l:complete_start_character - l:text_edit_range['start']['character']])
+      let l:overflow_after = max([0, l:text_edit_range['end']['character'] - l:complete_position['character']])
       let l:text = l:completion_item['textEdit']['newText']
     else
       let l:overflow_before = 0
@@ -160,7 +161,8 @@ endfunction
 "
 function! s:is_expandable(done_line, done_position, complete_position, completion_item, completed_item) abort
   if get(a:completion_item, 'textEdit', v:null) isnot# v:null
-    if a:completion_item['textEdit']['range']['start']['line'] != a:completion_item['textEdit']['range']['end']['line']
+    let l:text_edit_range = lsp#utils#text_edit#_get_range_maybe_replace(a:completion_item['textEdit'])
+    if l:text_edit_range['start']['line'] != l:text_edit_range['end']['line']
       return v:true
     endif
 
@@ -168,8 +170,8 @@ function! s:is_expandable(done_line, done_position, complete_position, completio
     let l:completed_before = strcharpart(a:done_line, 0, a:complete_position['character'])
     let l:completed_after = strcharpart(a:done_line, a:done_position['character'], strchars(a:done_line) - a:done_position['character'])
     let l:completed_line = l:completed_before . l:completed_after
-    let l:text_edit_before = strcharpart(l:completed_line, 0, a:completion_item['textEdit']['range']['start']['character'])
-    let l:text_edit_after = strcharpart(l:completed_line, a:completion_item['textEdit']['range']['end']['character'], strchars(l:completed_line) - a:completion_item['textEdit']['range']['end']['character'])
+    let l:text_edit_before = strcharpart(l:completed_line, 0, l:text_edit_range['start']['character'])
+    let l:text_edit_after = strcharpart(l:completed_line, l:text_edit_range['end']['character'], strchars(l:completed_line) - l:text_edit_range['end']['character'])
     return a:done_line !=# l:text_edit_before . s:trim_unmeaning_tabstop(a:completion_item['textEdit']['newText']) . l:text_edit_after
   endif
   return s:get_completion_text(a:completion_item) !=# s:trim_unmeaning_tabstop(a:completed_item['word'])

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -38,6 +38,18 @@ function! lsp#utils#text_edit#_lsp_to_vim_list(uri, text_edit) abort
     return l:result
 endfunction
 
+" @summary Get range from some TextEdit types
+" @note InsertReplaceEdit since Language Server Protocol Specification - 3.16.0
+" @param text_edit = TextEdit | InsertReplaceEdit
+" @returns Range
+function! lsp#utils#text_edit#_get_range_maybe_replace(text_edit) abort
+    if has_key(a:text_edit, 'replace')
+        return a:text_edit['replace']
+    else
+        return a:text_edit['range']
+    endif
+endfunction
+
 " @param uri = DocumentUri
 " @param text_edit = TextEdit
 " @param cache = {} empty dict


### PR DESCRIPTION
When using fuzzy match, when lsp returns InsertReplaceEdit, range was not found error.
(I used volar-server when writing Vue)

1. setup fuzzy match for asyncomplete.vim in vimrc

```vim
" vimrc
function! s:fuzzy_preprocessor(options, matches) abort
  let l:base = a:options["base"]

  " NOTE: There is an lsp with a '.' At the beginning when it is a member candidate.
  "       ex) volar-server
  if len(l:base) >= 2 && l:base[0] == '.'
    let l:base = l:base[1:]
    let a:options["startcol"] += 1
  endif

  let l:items = []
  for l:matches in values(a:matches)
    if len(l:base) > 0
      let l:items += filter(copy(l:matches['items']), '!empty(matchfuzzy([v:val["word"]], l:base))')
    else
      let l:items += l:matches['items']
    endif
  endfor

  call asyncomplete#preprocess_complete(a:options, l:items)
endfunction

let g:asyncomplete_preprocessor = [function('s:fuzzy_preprocessor')]
```

2. try fuzzy match for vue code.

```vue
<script lang="ts" setup>
const a = [];
a.flt|
     ^
  try fuzzy match expand `filter`
</script>
```

3. result completionItem json

```json
{
  "label": "filter",
  "commitCharacters": [
    ".",
    ",",
    ";",
    "("
  ],
  "data": {
    "uri": "file:///e%3A/work/Web/vue/vue-typescript/src/App.vue.ts",
    "fileName": "e:/work/Web/vue/vue-typescript/src/App.vue.ts",
    "offset": 56,
    "originalItem": {
      "name": "filter",
      "kindModifiers": "declare",
      "sortText": "11",
      "kind": "method"
    }
  },
  "textEdit": {
    "replace": {
      "end": {
        "character": 5,
        "line": 2
      },
      "start": {
        "character": 2,
        "line": 2
      }
    },
    "newText": "filter",
    "insert": {
      "end": {
        "character": 5,
        "line": 2
      },
      "start": {
        "character": 2,
        "line": 2
      }
    }
  },
  "sortText": "11",
  "kind": 2,
  "detail": "(method) Array<any>.filter<any>(predicate: (value: any, index: number, array: any[]) => value is any, thisArg?: any): any[] (+1 overload)",
  "documentation": {
    "kind": "markdown",
    "value": "Returns the elements of an array that meet the condition specified in a callback function.\n\n*@param* `predicate` — A function that accepts up to three arguments. The filter method calls the predicate function one time for each element in the array.  \n\n*@param* `thisArg` — An object to which the this keyword can refer in the predicate function. If thisArg is omitted, undefined is used as the this value."
  },
  "insertTextFormat": 1
}
```