### PR TITLE
add new preview window id api

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1216,6 +1216,10 @@ function! lsp#get_progress() abort
     return lsp#internal#work_done_progress#get_progress()
 endfunction
 
+function! lsp#document_hover_preview_winid() abort
+    return lsp#internal#document_hover#under_cursor#getpreviewwinid()
+endfunction
+
 "
 " Scroll vim-lsp related windows.
 "

--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -74,6 +74,13 @@ function! lsp#internal#document_hover#under_cursor#do(options) abort
         \ )
 endfunction
 
+function! lsp#internal#document_hover#under_cursor#getpreviewwinid() abort
+    if exists('s:doc_win')
+        return s:doc_win.get_winid()
+    endif
+    return v:null
+endfunction
+
 function! s:show_hover(ui, server_name, request, response) abort
     if !has_key(a:response, 'result') || empty(a:response['result']) || 
         \ empty(a:response['result']['contents'])

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -324,7 +324,7 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 <
     After opening an autocmd User event lsp_float_opened is issued, as well as
     and lsp_float_closed upon closing. This can be used to alter the preview
-    window (using lsp#ui#vim#output#getpreviewwinid() to get the window id),
+    window (using lsp#internal#document_hover#under_cursor#getpreviewwinid() to get the window id),
     setup custom bindings while a preview is open, or change the highlighting
     of the window.
 
@@ -342,12 +342,12 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 	    autocmd!
 	    if !has('nvim')
 		autocmd User lsp_float_opened
-		    \ call setwinvar(lsp#ui#vim#output#getpreviewwinid(),
+		    \ call setwinvar(lsp#internal#document_hover#under_cursor#getpreviewwinid(),
 		    \		       '&wincolor', 'PopupWindow')
 	    else
 		autocmd User lsp_float_opened
 		    \ call nvim_win_set_option(
-		    \   lsp#ui#vim#output#getpreviewwinid(),
+		    \   lsp#internal#document_hover#under_cursor#getpreviewwinid(),
 		    \   'winhighlight', 'Normal:PopupWindow')
 	    endif
 	augroup end

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -92,6 +92,7 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp#get_buffer_diagnostics_counts() |lsp#get_buffer_diagnostics_counts()|
       lsp#get_buffer_first_error_line()   |lsp#get_buffer_first_error_line()|
       lsp#get_progress()                  |lsp#get_progress()|
+      lsp#document_hover_preview_winid()  |lsp#document_hover_preview_winid()|
     Commands                              |vim-lsp-commands|
       LspAddTreeCallHierarchyIncoming       |:LspAddTreeCallHierarchyIncoming|
       LspCallHierarchyIncoming              |:LspCallHierarchyIncoming|
@@ -324,7 +325,7 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 <
     After opening an autocmd User event lsp_float_opened is issued, as well as
     and lsp_float_closed upon closing. This can be used to alter the preview
-    window (using lsp#internal#document_hover#under_cursor#getpreviewwinid() to get the window id),
+    window (using |lsp#document_hover_preview_winid()| to get the window id),
     setup custom bindings while a preview is open, or change the highlighting
     of the window.
 
@@ -342,12 +343,12 @@ g:lsp_preview_float                         *g:lsp_preview_float*
 	    autocmd!
 	    if !has('nvim')
 		autocmd User lsp_float_opened
-		    \ call setwinvar(lsp#internal#document_hover#under_cursor#getpreviewwinid(),
+		    \ call setwinvar(lsp#document_hover_preview_winid(),
 		    \		       '&wincolor', 'PopupWindow')
 	    else
 		autocmd User lsp_float_opened
 		    \ call nvim_win_set_option(
-		    \   lsp#internal#document_hover#under_cursor#getpreviewwinid(),
+		    \   lsp#document_hover_preview_winid(),
 		    \   'winhighlight', 'Normal:PopupWindow')
 	    endif
 	augroup end
@@ -1450,6 +1451,11 @@ lsp#get_progress()                       *lsp#get_progress()*
     * percentage
 	Type: |Number|
 	0 - 100 or not exist
+
+lsp#document_hover_preview_winid()		    *lsp#document_hover_preview_winid()*
+
+    Returns |windowid| of the current hover preview window or |v:null| if it does not
+    exist.
 
 lsp#scroll(count)                                             *lsp#scroll()*
 


### PR DESCRIPTION
resolves #1281
instead of using `lsp#ui#vim#output#getpreviewwinid()` now use `lsp#internal#document_hover#under_cursor#getpreviewwinid()`