### PR TITLE
Added workDoneToken field in initialize request

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -643,9 +643,10 @@ function! s:ensure_init(buf, server_name, cb) abort
     \     'rootUri': l:root_uri,
     \     'rootPath': lsp#utils#uri_to_path(l:root_uri),
     \     'trace': 'off',
+    \     'workDoneToken': '__initialize_token',
     \   },
     \ }
-    
+
     let l:workspace_capabilities = get(l:capabilities, 'workspace', {})
     if get(l:workspace_capabilities, 'workspaceFolders', v:false)
         " TODO: extract folder name for l:root_uri

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -643,7 +643,7 @@ function! s:ensure_init(buf, server_name, cb) abort
     \     'rootUri': l:root_uri,
     \     'rootPath': lsp#utils#uri_to_path(l:root_uri),
     \     'trace': 'off',
-    \     'workDoneToken': '__initialize_token',
+    \     'workDoneToken': lsp#internal#work_done_progress#generate_token(),
     \   },
     \ }
 

--- a/autoload/lsp/internal/work_done_progress.vim
+++ b/autoload/lsp/internal/work_done_progress.vim
@@ -53,6 +53,12 @@ function! s:handle_work_done_progress(server, response) abort
     doautocmd <nomodeline> User lsp_progress_updated
 endfunction
 
+function! lsp#internal#work_done_progress#generate_token() abort
+    let l:random_id = rand(srand()) % 100000
+    let l:work_done_token = '__work_done_token_' . getpid() . '_' . l:random_id
+    return l:work_done_token
+endfunction
+
 function! lsp#internal#work_done_progress#_disable() abort
     if !s:enabled | return | endif
 


### PR DESCRIPTION
I see that vim-lsp sometimes does not show progress with [lightline-lsp-progress](https://github.com/micchy326/lightline-lsp-progress).

It is caused by `initialize` request missing `workDoneToken` field as [its specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize) says it can have. This PR adds it.