### PR TITLE
Fix file-marks building up in viminfo (#1337)

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Buffer.vim
+++ b/autoload/vital/_lsp/VS/Vim/Buffer.vim
@@ -47,13 +47,16 @@ endfunction
 " ensure
 "
 function! s:ensure(expr) abort
-  if !bufexists(a:expr)
+  if !exists('g:__VS_Vim_Buffers')
+    let g:__VS_Vim_Buffers = {}
+  endif
+  if !has_key(g:__VS_Vim_Buffers, a:expr)
     if type(a:expr) == type(0)
       throw printf('VS.Vim.Buffer: `%s` is not valid expr.', a:expr)
     endif
-    badd `=a:expr`
+    call extend(g:__VS_Vim_Buffers, {a:expr : bufadd('')})
   endif
-  return bufnr(a:expr)
+  return g:__VS_Vim_Buffers[a:expr]
 endfunction
 
 "


### PR DESCRIPTION
A possible solution to this problem, using global variables.

These will of course not be present after exiting vim and opening same file if you have not enabled [viminfo-!](https://vimhelp.org/options.txt.html#viminfo-%21) like
````vim
  " Prepend "!" to viminfo
  set viminfo^=!
````
If you know if this could arise an issue, I'll adapt.