### PR TITLE
Implemented word correction in cases where startcol was corrected by …

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -95,7 +95,7 @@ function! lsp#get_server_names() abort
 endfunction
 
 function! lsp#get_server_info(server_name) abort
-    return s:servers[a:server_name]['server_info']
+    return get(get(s:servers, a:server_name, {}), 'server_info', {})
 endfunction
 
 function! lsp#get_server_root_uri(server_name) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -358,7 +358,6 @@ function! lsp#omni#get_vim_completion_items(options) abort
             if l:start_character < l:item_start_character
                 let l:item = l:vim_complete_items[l:i]
                 let l:item['word'] = strcharpart(l:current_line, l:start_character, l:item_start_character - l:start_character) .. l:item['word']
-                let l:item['abbr'] = l:item['word']
             endif
         endfor
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -325,7 +325,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:item_start_character = l:completion_item['textEdit']['range']['start']['character']
             if l:item_start_character < l:default_start_character
                 " Add already typed word. The typescript-language-server returns `[Symbol]` item for the line of `Hoo.|`. So we should add `.` (`.[Symbol]`) .
-                let l:vim_complete_item['word'] = strcharpart(l:current_line, l:item_start_character, l:default_start_character - l:item_start_character) .. l:vim_complete_item['word']
+                let l:vim_complete_item['word'] = strcharpart(l:current_line, l:item_start_character, l:default_start_character - l:item_start_character) . l:vim_complete_item['word']
             endif
             let l:start_character = min([l:item_start_character, l:start_character])
             let l:start_characters += [l:item_start_character]
@@ -357,7 +357,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:item_start_character = l:start_characters[l:i]
             if l:start_character < l:item_start_character
                 let l:item = l:vim_complete_items[l:i]
-                let l:item['word'] = strcharpart(l:current_line, l:start_character, l:item_start_character - l:start_character) .. l:item['word']
+                let l:item['word'] = strcharpart(l:current_line, l:start_character, l:item_start_character - l:start_character) . l:item['word']
             endif
         endfor
     endif

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -82,17 +82,6 @@ function! lsp#omni#complete(findstart, base) abort
 endfunction
 
 function! s:get_filter_label(item) abort
-    let l:user_data = lsp#omni#get_managed_user_data_from_completed_item(a:item)
-    if has_key(l:user_data, 'completion_item') && has_key(l:user_data['completion_item'], 'filterText')
-        let l:filter_text = l:user_data['completion_item']['filterText']
-        if empty(l:filter_text) && has_key(l:user_data['completion_item'], 'label')
-            " When filterText is `falsy` the label is used as the filter text
-            let l:filter_text = l:user_data['completion_item']['label']
-        endif
-        if !empty(l:filter_text)
-            return lsp#utils#_trim(l:filter_text)
-        endif
-    endif
     return lsp#utils#_trim(a:item['word'])
 endfunction
 

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -320,9 +320,10 @@ function! lsp#omni#get_vim_completion_items(options) abort
             \ 'empty': 1,
             \ 'icase': 1,
             \ }
-        if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && has_key(l:completion_item['textEdit'], 'range') && has_key(l:completion_item['textEdit'], 'newText')
+        let l:range = lsp#utils#text_edit#get_range(get(l:completion_item, 'textEdit', {}))
+        if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && !empty(l:range) && has_key(l:completion_item['textEdit'], 'newText')
             let l:vim_complete_item['word'] = l:completion_item['textEdit']['newText']
-            let l:item_start_character = l:completion_item['textEdit']['range']['start']['character']
+            let l:item_start_character = l:range['start']['character']
             if l:item_start_character < l:default_start_character
                 " Add already typed word. The typescript-language-server returns `[Symbol]` item for the line of `Hoo.|`. So we should add `.` (`.[Symbol]`) .
                 let l:overlap_text = strcharpart(l:current_line, l:item_start_character, l:default_start_character - l:item_start_character)

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -325,7 +325,10 @@ function! lsp#omni#get_vim_completion_items(options) abort
             let l:item_start_character = l:completion_item['textEdit']['range']['start']['character']
             if l:item_start_character < l:default_start_character
                 " Add already typed word. The typescript-language-server returns `[Symbol]` item for the line of `Hoo.|`. So we should add `.` (`.[Symbol]`) .
-                let l:vim_complete_item['word'] = strcharpart(l:current_line, l:item_start_character, l:default_start_character - l:item_start_character) . l:vim_complete_item['word']
+                let l:overlap_text = strcharpart(l:current_line, l:item_start_character, l:default_start_character - l:item_start_character)
+                if stridx(l:vim_complete_item['word'], l:overlap_text) != 0
+                    let l:vim_complete_item['word'] = l:overlap_text . l:vim_complete_item['word']
+                endif
             endif
             let l:start_character = min([l:item_start_character, l:start_character])
             let l:start_characters += [l:item_start_character]

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -348,7 +348,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
         endif
 
         if s:is_user_data_support
-            let l:vim_complete_item['user_data'] = s:create_user_data(l:completion_item, l:server_name, l:complete_position)
+            let l:vim_complete_item['user_data'] = s:create_user_data(l:completion_item, l:server_name, l:complete_position, l:start_characters[len(l:start_characters) - 1])
         endif
 
         let l:vim_complete_items += [l:vim_complete_item]
@@ -382,12 +382,13 @@ endfunction
 "
 " create item's user_data.
 "
-function! s:create_user_data(completion_item, server_name, complete_position) abort
+function! s:create_user_data(completion_item, server_name, complete_position, start_character) abort
     let l:user_data_key = s:create_user_data_key(s:managed_user_data_key_base)
     let s:managed_user_data_map[l:user_data_key] = {
     \   'complete_position': a:complete_position,
     \   'server_name': a:server_name,
-    \   'completion_item': a:completion_item
+    \   'completion_item': a:completion_item,
+    \   'start_character': a:start_character,
     \ }
     let s:managed_user_data_key_base += 1
     return l:user_data_key

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -107,8 +107,9 @@ function! s:on_complete_done_after() abort
   if l:is_expandable
     " At this timing, the cursor may have been moved by additionalTextEdit, so we use overflow information instead of textEdit itself.
     if type(get(l:completion_item, 'textEdit', v:null)) == type({})
-      let l:overflow_before = max([0, l:start_character - l:completion_item['textEdit']['range']['start']['character']])
-      let l:overflow_after = max([0, l:completion_item['textEdit']['range']['end']['character'] - l:complete_position['character']])
+      let l:range = lsp#utils#text_edit#get_range(l:completion_item['textEdit'])
+      let l:overflow_before = max([0, l:start_character - l:range['start']['character']])
+      let l:overflow_after = max([0, l:range['end']['character'] - l:complete_position['character']])
       let l:text = l:completion_item['textEdit']['newText']
     else
       let l:overflow_before = 0
@@ -161,7 +162,8 @@ endfunction
 "
 function! s:is_expandable(done_line, done_position, complete_position, completion_item, completed_item) abort
   if get(a:completion_item, 'textEdit', v:null) isnot# v:null
-    if a:completion_item['textEdit']['range']['start']['line'] != a:completion_item['textEdit']['range']['end']['line']
+    let l:range = lsp#utils#text_edit#get_range(a:completion_item['textEdit'])
+    if l:range['start']['line'] != l:range['end']['line']
       return v:true
     endif
 
@@ -169,8 +171,8 @@ function! s:is_expandable(done_line, done_position, complete_position, completio
     let l:completed_before = strcharpart(a:done_line, 0, a:complete_position['character'])
     let l:completed_after = strcharpart(a:done_line, a:done_position['character'], strchars(a:done_line) - a:done_position['character'])
     let l:completed_line = l:completed_before . l:completed_after
-    let l:text_edit_before = strcharpart(l:completed_line, 0, a:completion_item['textEdit']['range']['start']['character'])
-    let l:text_edit_after = strcharpart(l:completed_line, a:completion_item['textEdit']['range']['end']['character'], strchars(l:completed_line) - a:completion_item['textEdit']['range']['end']['character'])
+    let l:text_edit_before = strcharpart(l:completed_line, 0, l:range['start']['character'])
+    let l:text_edit_after = strcharpart(l:completed_line, l:range['end']['character'], strchars(l:completed_line) - l:range['end']['character'])
     return a:done_line !=# l:text_edit_before . s:trim_unmeaning_tabstop(a:completion_item['textEdit']['newText']) . l:text_edit_after
   endif
   return s:get_completion_text(a:completion_item) !=# s:trim_unmeaning_tabstop(a:completed_item['word'])

--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -54,6 +54,7 @@ function! s:on_complete_done() abort
   let s:context['complete_position'] = l:managed_user_data['complete_position']
   let s:context['server_name'] = l:managed_user_data['server_name']
   let s:context['completion_item'] = l:managed_user_data['completion_item']
+  let s:context['start_character'] = l:managed_user_data['start_character']
   call feedkeys(printf("\<C-r>=<SNR>%d_on_complete_done_after()\<CR>", s:SID()), 'n')
 endfunction
 
@@ -75,7 +76,7 @@ function! s:on_complete_done_after() abort
   let l:complete_position = s:context['complete_position']
   let l:server_name = s:context['server_name']
   let l:completion_item = s:context['completion_item']
-  let l:complete_start_character = l:done_position['character'] - strchars(l:completed_item['word'])
+  let l:start_character = s:context['start_character']
 
   " check the commit characters are <BS> or <C-w>.
   if strlen(getline('.')) < strlen(l:done_line)
@@ -106,7 +107,7 @@ function! s:on_complete_done_after() abort
   if l:is_expandable
     " At this timing, the cursor may have been moved by additionalTextEdit, so we use overflow information instead of textEdit itself.
     if type(get(l:completion_item, 'textEdit', v:null)) == type({})
-      let l:overflow_before = max([0, l:complete_start_character - l:completion_item['textEdit']['range']['start']['character']])
+      let l:overflow_before = max([0, l:start_character - l:completion_item['textEdit']['range']['start']['character']])
       let l:overflow_after = max([0, l:completion_item['textEdit']['range']['end']['character'] - l:complete_position['character']])
       let l:text = l:completion_item['textEdit']['newText']
     else
@@ -120,7 +121,7 @@ function! s:on_complete_done_after() abort
     let l:range = {
     \   'start': {
     \     'line': l:position['line'],
-    \     'character': l:position['character'] - (l:complete_position['character'] - l:complete_start_character) - l:overflow_before,
+    \     'character': l:position['character'] - (l:complete_position['character'] - l:start_character) - l:overflow_before,
     \   },
     \   'end': {
     \     'line': l:position['line'],

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -1,3 +1,11 @@
+function! lsp#utils#text_edit#get_range(text_edit) abort
+  let l:insert = get(a:text_edit, 'insert', v:null)
+  if type(l:insert) == v:t_dict
+    return l:insert
+  endif
+  return get(a:text_edit, 'range', v:null)
+endfunction
+
 function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
     let l:current_bufname = bufname('%')
     let l:target_bufname = lsp#utils#uri_to_path(a:uri)

--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -1,4 +1,7 @@
 function! lsp#utils#text_edit#get_range(text_edit) abort
+  if type(a:text_edit) != v:t_dict
+    return v:null
+  endif
   let l:insert = get(a:text_edit, 'insert', v:null)
   if type(l:insert) == v:t_dict
     return l:insert

--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -82,7 +82,8 @@ Describe lsp#omni
             Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got['items'][0]), {
                         \   'server_name': 'dummy-server',
                         \   'completion_item': item,
-                        \   'complete_position': { 'line': 1, 'character': 1 }
+                        \   'complete_position': { 'line': 1, 'character': 1 },
+                        \   'start_character': 0,
                         \ })
         End
 
@@ -184,7 +185,8 @@ Describe lsp#omni
             Assert Equals(lsp#omni#get_managed_user_data_from_completed_item(got['items'][0]), {
                         \   'server_name': 'dummy-server',
                         \   'completion_item': item,
-                        \   'complete_position': { 'line': 1, 'character': 1 }
+                        \   'complete_position': { 'line': 1, 'character': 1 },
+                        \   'start_character': 0,
                         \ })
         End
 


### PR DESCRIPTION
…TextEdit.range.start.character

# Problem

In typescript-language-server, the vim-lsp's completion mechanism can't handle the class static property completion.

# Solution

Implement `complete_item.word` fixing.

# Background

Currently, vim-lsp is fixing the `startcol` by `TextEdit.range.start.character`.
But it is not enough. We should fix `complete_item.word` too.

For example, in the following cases, word correction processing is required.

1. The line is `Class.|`
2. The `CompletionItem`
    - `{ label: 'PROP' }
    - `{ label: 'Symbol', textEdit: { newText: '[Symbol]' ... } }`

In such case, the `startcol` should be the `Class|.`.
This is because the `[Symbol]` item expects a `Class[Symbol]`.

 So we should add `.` for all item in this case.