### PR TITLE
Semantic tokens performance improvements

### DIFF
--- a/autoload/lsp/internal/semantic.vim
+++ b/autoload/lsp/internal/semantic.vim
@@ -342,16 +342,18 @@ let s:default_highlight_groups = {
     \ s:hl_group_prefix . 'Variable': 'Identifier',
     \ s:hl_group_prefix . 'Property': 'Identifier',
     \ s:hl_group_prefix . 'EnumMember': 'Constant',
-    \ s:hl_group_prefix . 'Events': 'Identifier',
+    \ s:hl_group_prefix . 'Event': 'Identifier',
     \ s:hl_group_prefix . 'Function': 'Function',
     \ s:hl_group_prefix . 'Method': 'Function',
+    \ s:hl_group_prefix . 'Macro': 'Macro',
     \ s:hl_group_prefix . 'Keyword': 'Keyword',
     \ s:hl_group_prefix . 'Modifier': 'Type',
     \ s:hl_group_prefix . 'Comment': 'Comment',
     \ s:hl_group_prefix . 'String': 'String',
     \ s:hl_group_prefix . 'Number': 'Number',
     \ s:hl_group_prefix . 'Regexp': 'String',
-    \ s:hl_group_prefix . 'Operator': 'Operator'
+    \ s:hl_group_prefix . 'Operator': 'Operator',
+    \ s:hl_group_prefix . 'Decorator': 'Macro'
 \ }
 
 function! s:get_hl_group(server, legend, token_idx, token_modifiers) abort

--- a/autoload/lsp/internal/semantic.vim
+++ b/autoload/lsp/internal/semantic.vim
@@ -275,11 +275,12 @@ endfunction
 
 function! s:clear_highlights(server, buf) abort
     if s:use_vim_textprops
-        let l:IsSemanticTextprop = {textprop -> textprop['type'] =~ '^' . s:textprop_type_prefix . '.*'}
-        let l:textprop_types = prop_list(1, {'bufnr': a:buf, 'end_lnum': -1})
+        let l:BeginsWith = {str, prefix -> str[0:len(prefix) - 1] ==# prefix}
+        let l:IsSemanticTextprop = {_, textprop -> l:BeginsWith(textprop, s:textprop_type_prefix)}
+        let l:textprop_types = prop_type_list()
         call filter(l:textprop_types, l:IsSemanticTextprop)
         for l:textprop_type in l:textprop_types
-            silent! call prop_remove({'type': l:textprop_type, 'bufnr': a:buf, 'all': v:true}, 1, line('$'))
+            silent! call prop_remove({'type': l:textprop_type, 'bufnr': a:buf, 'all': v:true})
         endfor
     elseif s:use_nvim_highlight
         call nvim_buf_clear_namespace(a:buf, s:namespace_id, 0, line('$'))

--- a/autoload/lsp/internal/semantic.vim
+++ b/autoload/lsp/internal/semantic.vim
@@ -27,7 +27,7 @@ function! lsp#internal#semantic#_enable() abort
         \     lsp#callbag#fromEvent(l:events),
         \     lsp#callbag#filter({_->lsp#internal#semantic#is_enabled()}),
         \     lsp#callbag#debounceTime(g:lsp_semantic_delay),
-        \     lsp#callbag#filter({_->getbufvar(bufnr('%'), '&buftype') !~# '^(help\|terminal\|prompt\|popup)$'}),
+        \     lsp#callbag#filter({_->index(['help', 'terminal', 'prompt', 'popup'], getbufvar(bufnr('%'), '&buftype')) ==# -1}),
         \     lsp#callbag#filter({_->!lsp#utils#is_large_window(win_getid())}),
         \     lsp#callbag#switchMap({_->
         \         lsp#callbag#pipe(


### PR DESCRIPTION
The initial implementation of semantic tokens was quite slow. This PR contains some tweaks to improve its performance.

Not currently addressed by this commit is this: at present the function to apply the highlights to the file removes _all_ the highlights from the file and then re-adds them, not those which have just been modified. This is because, according to the vim profiler, the majority of the time is spent decoding the tokens rather than applying them. A "smarter" algorithm which only removes the highlights which change in some way may have to decode the tokens twice, and so even be slower. That being said, I'm not all that confident in vim's profiler so it may be worth verifying this.

A lua rewrite of at least part of this code is probably the most sensible way to get any further performance out if it, but in the meantime these little changes seem to make a noticeable difference.