### PR TITLE
Fix floating window on neovim

### DIFF
--- a/autoload/lsp/internal/completion/documentation.vim
+++ b/autoload/lsp/internal/completion/documentation.vim
@@ -109,8 +109,8 @@ function! s:show_floating_window(event, managed_user_data) abort
     \     'maxwidth': float2nr(&columns * 0.4),
     \     'maxheight': float2nr(&lines * 0.4),
     \ })
-    let l:margin_right = &columns - 1 - (a:event.col + a:event.width + 1 + (a:event.scrollbar ? 1 : 0))
-    let l:margin_left = a:event.col - 3
+    let l:margin_right = &columns - 1 - (float2nr(a:event.col) + float2nr(a:event.width) + 1 + (a:event.scrollbar ? 1 : 0))
+    let l:margin_left = float2nr(a:event.col) - 3
     if l:size.width < l:margin_right
       " do nothing
     elseif l:margin_left <= l:margin_right


### PR DESCRIPTION
Fixed https://github.com/prabirshrestha/vim-lsp/pull/1334#issuecomment-1202811697.
The problem is that `l:margin_left` and `l:margin_right` are not Integer but Float on neovim.