### PR TITLE
ignore place_signs error

### DIFF
--- a/autoload/lsp/internal/diagnostics/signs.vim
+++ b/autoload/lsp/internal/diagnostics/signs.vim
@@ -135,8 +135,11 @@ function! s:place_signs(server, diagnostics_response, bufnr) abort
             let l:sign_priority = get(g:lsp_diagnostics_signs_priority_map,
                 \ a:server . '_' . l:sign_name, l:sign_priority)
             " pass 0 and let vim generate sign id
-            let l:sign_id = sign_place(0, s:sign_group, l:sign_name, a:bufnr,
-                \{ 'lnum': l:line, 'priority': l:sign_priority })
+            try
+                let l:sign_id = sign_place(0, s:sign_group, l:sign_name, a:bufnr,
+                    \{ 'lnum': l:line, 'priority': l:sign_priority })
+            catch
+            endtry
         endif
     endfor
 endfunction


### PR DESCRIPTION
For efm-langserver, some linter command return 0 for line number. This is wrong value for Language Server Protocol. But this is useful to know that there are errors in the whole lines. So I suggest to ignore error of sign_add.

![image](https://user-images.githubusercontent.com/10111/185301863-31c2b763-8c5c-491e-b51a-5d403a11b633.png)
