### PR TITLE
fix reporting of `typeHierarchy` capability

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -581,7 +581,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'willSave': v:false,
     \           'willSaveWaitUntil': v:false,
     \       },
-    \       'typeHierarchy': v:false,
+    \       'typeHierarchy': {
+    \           'dynamicRegistration': v:false
+    \       },
     \       'typeDefinition': {
     \           'dynamicRegistration': v:false,
     \           'linkSupport' : v:true


### PR DESCRIPTION
Prior to this patch, the LSP request shape basically violates the LSP in that it sends the capability as boolean, as opposed to an object, i.e. 

```json
"typeHierarchy": false,
```

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#typeHierarchyClientCapabilities

```ts
type [TypeHierarchyClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#typeHierarchyClientCapabilities) = {
	/**
	 * Whether implementation supports dynamic registration. If this is set to
	 * `true` the client supports the new `(TextDocumentRegistrationOptions &
	 * StaticRegistrationOptions)` return value for the corresponding server
	 * capability as well.
	 */
	dynamicRegistration?: boolean;
};
```
