### PR TITLE
Fix loss of reference highlights on buffer change

### DIFF
--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -183,20 +183,16 @@ function! s:in_reference(reference_list) abort
 endfunction
 
 function! s:init_reference_highlight(buf) abort
-    if !empty(getbufvar(a:buf, 'lsp_did_reference_setup'))
-        return
-    endif
-
     if s:use_vim_textprops
-        call prop_type_add('vim-lsp-reference-highlight', {
+        let l:props = {
             \   'bufnr': a:buf,
             \   'highlight': 'lspReference',
             \   'combine': v:true,
             \   'priority': lsp#internal#textprop#priority('document_highlight')
-            \ })
+            \ }
+        call prop_type_delete('vim-lsp-reference-highlight', l:props)
+        call prop_type_add('vim-lsp-reference-highlight', l:props)
     endif
-
-    call setbufvar(a:buf, 'lsp_did_reference_setup', 1)
 endfunction
 
 " Cyclically move between references by `offset` occurrences.


### PR DESCRIPTION
This PR fixes an issue where document highlighting of references will stop working on buffers that have switched to a different buffer within the same window.

Instead of returning after checking if a buffer already has a text property type added, this commit will remove the existing property type and add it back each time a buffer changes.

To reproduce the issue:

- enable `g:lsp_document_highlight_enabled`
- open a file supported by a language server
- highlight a reference
- switch to another buffer (e.g., `:bn`, `:e new`, `:LspDefinition`)
- switch back to previous buffer (e.g., `:bp`, <kbd>CTRL</kbd>+<kbd>6</kbd>, <kbd>CTRL</kbd>+<kbd>O</kbd>)
- try to highlight a reference

Before fix:

![before](https://user-images.githubusercontent.com/40370954/190067982-7927866d-4236-441d-823a-114e03fc1a7a.gif)


After fix:

![after](https://user-images.githubusercontent.com/40370954/190068015-88ae63c9-6321-4105-973f-44ff4a4f4a37.gif)