### PR TITLE
Fix signs for diagnostics that are reported one line past the end

### DIFF
--- a/autoload/lsp/internal/diagnostics/signs.vim
+++ b/autoload/lsp/internal/diagnostics/signs.vim
@@ -129,6 +129,12 @@ endfunction
 function! s:place_signs(server, diagnostics_response, bufnr) abort
     for l:item in lsp#utils#iteratable(a:diagnostics_response['params']['diagnostics'])
         let l:line = lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['range']['start'])
+
+        " Some language servers report an unexpected EOF one line past the end
+        if l:line == getbufinfo(a:bufnr)[0].linecount + 1
+            let l:line = l:line - 1
+        endif
+
         if has_key(l:item, 'severity') && !empty(l:item['severity'])
             let l:sign_name = get(s:severity_sign_names_mapping, l:item['severity'], 'LspError')
             let l:sign_priority = get(g:lsp_diagnostics_signs_priority_map, l:sign_name, g:lsp_diagnostics_signs_priority)


### PR DESCRIPTION
Some language servers report unexpected EOF errors on the line that's actually one past the last line of the file. Be a bit more accomodating and just show them on the last line of the buffer instead.