### PR TITLE
Fix default supported capabilities

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -485,7 +485,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     return {
     \   'textDocument': {
     \       'callHierarchy': {
-    \           'dynamicRegistration': v:true,
+    \           'dynamicRegistration': v:false,
     \       },
     \       'codeAction': {
     \         'dynamicRegistration': v:false,
@@ -561,7 +561,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'dynamicRegistration': v:false,
     \       },
     \       'rename': {
-    \           'dynamicRegistration': v:true,
+    \           'dynamicRegistration': v:false,
     \           'prepareSupport': v:true
     \       },
     \       'semanticTokens': {
@@ -587,10 +587,10 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'serverCancelSupport': v:false
     \       },
     \       'signatureHelp': {
-    \           'relatedInformation': v:true,
+    \           'dynamicRegistration': v:false,
     \       },
     \       'symbol': {
-    \           'relatedInformation': v:true,
+    \           'dynamicRegistration': v:false,
     \       },
     \       'synchronization': {
     \           'didSave': v:true,

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -562,7 +562,8 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       },
     \       'rename': {
     \           'dynamicRegistration': v:false,
-    \           'prepareSupport': v:true
+    \           'prepareSupport': v:true,
+    \           'prepareSupportDefaultBehavior': 1
     \       },
     \       'semanticTokens': {
     \           'dynamicRegistration': v:false,

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -551,6 +551,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'dynamicRegistration': v:false,
     \           'linkSupport' : v:true
     \       },
+    \       'publishDiagnostics': {
+    \           'relatedInformation': v:true,
+    \       },
     \       'rangeFormatting': {
     \           'dynamicRegistration': v:false,
     \       },
@@ -586,9 +589,6 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'signatureHelp': {
     \           'relatedInformation': v:true,
     \       },
-    \       'publishDiagnostics': {
-    \           'relatedInformation': v:true,
-    \       },
     \       'symbol': {
     \           'relatedInformation': v:true,
     \       },
@@ -598,12 +598,12 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'willSave': v:false,
     \           'willSaveWaitUntil': v:false,
     \       },
-    \       'typeHierarchy': {
-    \           'dynamicRegistration': v:false
-    \       },
     \       'typeDefinition': {
     \           'dynamicRegistration': v:false,
     \           'linkSupport' : v:true
+    \       },
+    \       'typeHierarchy': {
+    \           'dynamicRegistration': v:false
     \       },
     \   },
     \   'window': {

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -484,6 +484,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     " Sorted alphabetically
     return {
     \   'textDocument': {
+    \       'callHierarchy': {
+    \           'dynamicRegistration': v:true,
+    \       },
     \       'codeAction': {
     \         'dynamicRegistration': v:false,
     \         'codeActionLiteralSupport': {
@@ -554,6 +557,10 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'references': {
     \           'dynamicRegistration': v:false,
     \       },
+    \       'rename': {
+    \           'dynamicRegistration': v:true,
+    \           'prepareSupport': v:true
+    \       },
     \       'semanticTokens': {
     \           'dynamicRegistration': v:false,
     \           'requests': {
@@ -576,7 +583,13 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \           'multilineTokenSupport': v:false,
     \           'serverCancelSupport': v:false
     \       },
+    \       'signatureHelp': {
+    \           'relatedInformation': v:true,
+    \       },
     \       'publishDiagnostics': {
+    \           'relatedInformation': v:true,
+    \       },
+    \       'symbol': {
     \           'relatedInformation': v:true,
     \       },
     \       'synchronization': {


### PR DESCRIPTION
This PR adds some capabilities which are referred from https://github.com/prabirshrestha/vim-lsp/blob/master/autoload/lsp/capabilities.vim but are not set at `lsp#default_get_supported_capabilities`, then sorts them alphabetically again.

I assume that these capabilities might be expected to be registered dynamically so these are missing in `lsp#default_get_supported_capabilities`. But, some language servers do not support dynamic registration and this means they will not recognize these capabilities are supported by vim-lsp.

So, I'm wondering whether `'dynamicRegistration'` property of these capabilities should be `v:true` or `v:false`. 
It would be appreciate if giving advice here.