### PR TITLE
Add per-file LSP activation rules allowpaths, blockpaths

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -984,6 +984,24 @@ function! lsp#get_allowed_servers(...) abort
             endfor
         endif
 
+        if !l:blocked && !empty(@%)
+            let l:curpath = fnamemodify(@%, ':p')
+            for l:pattern in get(l:server_info, 'blockpaths', [])
+                if match(l:curpath, l:pattern) != -1
+                    let l:blocked = 1
+                    break
+                endif
+            endfor
+            let l:allowed = !has_key(l:server_info, 'allowpaths')
+            for l:pattern in get(l:server_info, 'allowpaths', [])
+                if match(l:curpath, l:pattern) != -1
+                    let l:allowed = 1
+                    break
+                endif
+            endfor
+            let l:blocked = l:blocked || !l:allowed
+        endif
+
         if l:blocked
             continue
         endif

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -987,14 +987,14 @@ function! lsp#get_allowed_servers(...) abort
         if !l:blocked && !empty(@%)
             let l:curpath = fnamemodify(@%, ':p')
             for l:pattern in get(l:server_info, 'blockpaths', [])
-                if match(l:curpath, l:pattern) != -1
+                if l:pattern == '*' || match(l:curpath, l:pattern) != -1
                     let l:blocked = 1
                     break
                 endif
             endfor
             let l:allowed = !has_key(l:server_info, 'allowpaths')
             for l:pattern in get(l:server_info, 'allowpaths', [])
-                if match(l:curpath, l:pattern) != -1
+                if l:pattern == '*' || match(l:curpath, l:pattern) != -1
                     let l:allowed = 1
                     break
                 endif

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1091,6 +1091,8 @@ one parameter which is a vim |dict| and is referred to as |vim-lsp-server_info|
 		\ 'cmd': {server_info->['server-exectuable']},
 		\ 'allowlist': ['filetype to allowlist'],
 		\ 'blocklist': ['filetype to blocklist'],
+		\ 'allowpaths': ['regexp for allowed files'],
+		\ 'blockpaths': ['regexp for blocked files'],
 		\ 'config': {},
 		\ 'workspace_config': {'param': {'enabled': v:true}},
 		\ 'languageId': {server_info->'python'},
@@ -1112,6 +1114,8 @@ The vim |dict| containing information about the server.
 	'cmd': {server_info->['server_executable']},
 	'allowlist': ['filetype'],
 	'blocklist': ['filetype'],
+	'allowpaths': ['regexp'],
+	'blockpaths': ['regexp'],
 	'config': {},
 	'workspace_config': {},
 	'languageId': {server_info->'filetype'},
@@ -1184,6 +1188,28 @@ The vim |dict| containing information about the server.
 	'allowlist': ['*']
 	'blocklist': ['javascript', 'typescript']
 <
+ * allowpaths:
+    optional
+    String array of |regexp| patterns for absolute file paths that should have
+    the language server enabled.  allowpaths are consulted only when file
+    is enabled by the allowlist and blocklist rules for its filetype.
+
+    Example: >
+	'allowpaths': ['^/home/user/Code/']
+<
+    '*' is treated as matching every file.
+
+ * blockpaths:
+    optional
+    String array of |regexp| patterns for absolute file paths that should not
+    run the language server.  The blockpaths rule has priority when both
+    allowpaths and blockpaths match active file.
+
+    Example: >
+	'blockpaths': ['^/home/user/Code/project1/']
+<
+    '*' is treated as matching every file.
+
   * workspace_config:
     optional vim |dict|
     Used to pass workspace configuration to the server after


### PR DESCRIPTION
Add optional items `allowpaths`, `blockpaths` for the `server_info` dictionary.
`allowpaths` and `blockpaths` are lists of regular expressions matched
on the full path of the active file.  LSP is enabled if the current buffer
matches any pattern in the `allowpaths` or when `allowpaths` is not
present in the server_info dictionary.  LSP is disabled if any of the
`blockpaths` patterns matches the current file.  The `blockpaths` rule
has priority when both `allowpaths` and `blockpaths` match.

The `allowpaths` and `blockpaths` are consulted only when LSP is
enabled by the `allowlist`, `blocklist` rules for buffer filetypes.

Fixes #1041