### PR TITLE
Fix handling textDocument/prepareRename

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -280,7 +280,13 @@ function! s:handle_rename_prepare(server, last_command_id, type, data) abort
         return
     endif
 
-    let l:range = a:data['response']['result']
+    let l:response = a:data['response']['result']
+    if has_key(l:response, 'range')
+        let l:range = l:response['range']
+    else
+        let l:range = l:response
+    endif
+
     let l:lines = getline(1, '$')
     let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim('%', l:range['start'])
     let [l:end_line, l:end_col] = lsp#utils#position#lsp_to_vim('%', l:range['end'])


### PR DESCRIPTION
As discussed in #1384, `textDocument/prepareRename` can return both `Range` and `{ range: Range }` as in [the spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareRename).
So, This PR fixes `s:handle_rename_prepare()` to handle both cases.