### PR TITLE
workaround for float position

### DIFF
--- a/autoload/lsp/internal/diagnostics/float.vim
+++ b/autoload/lsp/internal/diagnostics/float.vim
@@ -96,8 +96,7 @@ endfunction
 function! s:compute_position(size) abort
     let l:pos = screenpos(0, line('.'), col('.'))
     if l:pos.row == 0 && l:pos.col == 0
-        " When the specified position is not visible
-        return []
+        let l:pos = {'curscol': screencol(), 'row': screenrow()}
     endif
     let l:pos = [l:pos.row + 1, l:pos.curscol + 1]
     if l:pos[0] + a:size.height > &lines


### PR DESCRIPTION
Vim9 used to return curscol=0, row=0 for screenpos. This caused errors in accessing the pos array. 

![image](https://user-images.githubusercontent.com/10111/202861350-75adc4ba-1bd8-41c6-9ab3-86998b6a1796.png)

This fix falls back to using screencol and screenrow.