### PR TITLE
Fix flicker on document highlighting with vim 9.0.0993

### DIFF
--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -190,8 +190,9 @@ function! s:init_reference_highlight(buf) abort
             \   'combine': v:true,
             \   'priority': lsp#internal#textprop#priority('document_highlight')
             \ }
-        call prop_type_delete('vim-lsp-reference-highlight', l:props)
-        call prop_type_add('vim-lsp-reference-highlight', l:props)
+        if prop_type_get('vim-lsp-reference-highlight', { 'bufnr': a:buf }) == {}
+            call prop_type_add('vim-lsp-reference-highlight', l:props)
+        endif
     endif
 endfunction
 


### PR DESCRIPTION
Since v9.0.0993 vim performs a full redraw when removing text property types, which causes flickering because vim-lsp currently removes and re-adds the property type every time the highlight is updated. To avoid that, we can just check if the property type already exists on the given buffer, and only add it if it doesn't exist yet.