### PR TITLE
Enable scrollbar on floating windows.

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
@@ -401,7 +401,7 @@ else
     \   'pos': 'topleft',
     \   'wrap': v:false,
     \   'moved': [0, 0, 0],
-    \   'scrollbar': 0,
+    \   'scrollbar': 1,
     \   'maxwidth': l:style.width,
     \   'maxheight': l:style.height,
     \   'minwidth': l:style.width,


### PR DESCRIPTION
Works with `set mouse=a` and `call lsp#scroll(+4)`/`call lsp#scroll(-4)`.