### PR TITLE
Allow to scroll floating window content to the end.

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Window.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window.vim
@@ -106,7 +106,6 @@ function! s:scroll(winid, topline) abort
   function! l:ctx.callback(winid, topline) abort
     let l:wininfo = s:info(a:winid)
     let l:topline = a:topline
-    let l:topline = min([l:topline, line('$') - l:wininfo.height + 1])
     let l:topline = max([l:topline, 1])
 
     if l:topline == l:wininfo.topline


### PR DESCRIPTION
While working on #1406, mouse worked fine but keyboard missed some lines at the end of the floating window.

This diff makes mouse and keyboard behaviors similar.