### PR TITLE
Use prop_remove before adding virtual text

### DIFF
--- a/autoload/lsp/internal/diagnostics/virtual_text.vim
+++ b/autoload/lsp/internal/diagnostics/virtual_text.vim
@@ -176,7 +176,8 @@ function! s:place_virtual_text(server, diagnostics_response, bufnr) abort
             " anymore due to async processing, just skip such diagnostics
             if l:line <= getbufinfo(a:bufnr)[0].linecount
                 let l:type = 'vim_lsp_' . l:name . '_virtual_text'
-                call prop_add(l:line, 0, {'type': l:type, 'text': l:text, 'text_padding_left': 1, 'bufnr': a:bufnr})
+                call prop_remove({'all': v:true, 'type': l:type, 'bufnr': a:bufnr}, l:line)
+                call prop_add(l:line, 0, {'type': l:type, 'text': l:text, 'text_padding_left': 1, 'bufnr': a:bufnr, 'text_align': 'below', 'text_wrap': 'wrap'})
             endif
         endif
     endfor


### PR DESCRIPTION
Otherwise vim rendering gets messy when navigating through the file.

Also pass `text_align: 'below'` and `text_wrap: 'wrap'` to `prop_add`
which is nicer when a server provides multiline errors.

fixes #1410