### PR TITLE
Allow adjustable options of prop_add() for virtual text

### DIFF
--- a/autoload/lsp/internal/diagnostics/virtual_text.vim
+++ b/autoload/lsp/internal/diagnostics/virtual_text.vim
@@ -177,7 +177,14 @@ function! s:place_virtual_text(server, diagnostics_response, bufnr) abort
             if l:line <= getbufinfo(a:bufnr)[0].linecount
                 let l:type = 'vim_lsp_' . l:name . '_virtual_text'
                 call prop_remove({'all': v:true, 'type': l:type, 'bufnr': a:bufnr}, l:line)
-                call prop_add(l:line, 0, {'type': l:type, 'text': l:text, 'text_padding_left': 1, 'bufnr': a:bufnr, 'text_align': 'below', 'text_wrap': 'wrap'})
+                call prop_add(
+                \ l:line, 0,
+                \ {
+                \   'type': l:type, 'text': l:text, 'bufnr': a:bufnr,
+                \   'text_align': g:lsp_diagnostics_virtual_text_align,
+                \   'text_padding_left': g:lsp_diagnostics_virtual_text_padding_left,
+                \   'text_wrap': g:lsp_diagnostics_virtual_text_wrap,
+                \ })
             endif
         endif
     endfor

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -49,8 +49,12 @@ CONTENTS                                                  *vim-lsp-contents*
 			     |g:lsp_diagnostics_virtual_text_insert_mode_enabled|
       g:lsp_diagnostics_virtual_text_delay
 			     |g:lsp_diagnostics_virtual_text_delay|
-      g:lsp_diagnostics_virtual_text_prefix
-			     |g:lsp_diagnostics_virtual_text_prefix|
+      g:lsp_diagnostics_virtual_text_align
+			     |g:lsp_diagnostics_virtual_text_align|
+      g:lsp_diagnostics_virtual_text_padding_left
+			     |g:lsp_diagnostics_virtual_text_padding_left|
+      g:lsp_diagnostics_virtual_text_wrap
+			     |g:lsp_diagnostics_virtual_text_wrap|
       g:lsp_document_code_action_signs_enabled
 			     |g:lsp_document_code_actions_signs_enabled|
       g:lsp_document_code_action_signs_delay
@@ -719,6 +723,38 @@ g:lsp_diagnostics_virtual_text_prefix   *g:lsp_diagnostics_virtual_text_prefix*
     Example: >
 	let g:lsp_diagnostics_virtual_text_prefix = "> "
 	let g:lsp_diagnostics_virtual_text_prefix = " ‣ "
+
+g:lsp_diagnostics_virtual_text_align    *g:lsp_diagnostics_virtual_text_align*
+    Type: |String|
+    Default: `"below"`
+
+    Determines the align of the diagnostics virtual text. Requires
+    |g:lsp_diagnostics_virtual_text_enabled|.
+
+    Example: >
+	let g:lsp_diagnostics_virtual_text_align = "right"
+
+g:lsp_diagnostics_virtual_text_padding_left
+                                  *g:lsp_diagnostics_virtual_text_padding_left*
+    Type: |Number|
+    Default: `1`
+
+    Determines the left padding of the diagnostics virtual text. Requires
+    |g:lsp_diagnostics_virtual_text_enabled|.
+
+    Example: >
+	let g:lsp_diagnostics_virtual_text_padding_left = 2
+
+g:lsp_diagnostics_virtual_text_wrap       *g:lsp_diagnostics_virtual_text_wrap*
+    Type: |String|
+    Default: `"wrap"`
+
+    Determines whether or not to wrap the diagnostics virtual text. Possible
+    values are one of `'wrap'`, `'truncate'`. Requires
+    |g:lsp_diagnostics_virtual_text_enabled|.
+
+    Example: >
+	let g:lsp_diagnostics_virtual_text_wrap = "truncate"
 
 g:lsp_document_code_action_signs_enabled
 				      *g:lsp_document_code_action_signs_enabled*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -37,6 +37,9 @@ let g:lsp_diagnostics_virtual_text_enabled = get(g:, 'lsp_diagnostics_virtual_te
 let g:lsp_diagnostics_virtual_text_insert_mode_enabled = get(g:, 'lsp_diagnostics_virtual_text_insert_mode_enabled', 0)
 let g:lsp_diagnostics_virtual_text_delay = get(g:, 'lsp_diagnostics_virtual_text_delay', 500)
 let g:lsp_diagnostics_virtual_text_prefix = get(g:, 'lsp_diagnostics_virtual_text_prefix', '')
+let g:lsp_diagnostics_virtual_text_align = get(g:, 'lsp_diagnostics_virtual_text_align', 'below')
+let g:lsp_diagnostics_virtual_text_wrap = get(g:, 'lsp_diagnostics_virtual_text_wrap', 'wrap')
+let g:lsp_diagnostics_virtual_text_padding_left = get(g:, 'lsp_diagnostics_virtual_text_padding_left', 1)
 
 let g:lsp_document_code_action_signs_enabled = get(g:, 'lsp_document_code_action_signs_enabled', 1)
 let g:lsp_document_code_action_signs_delay = get(g:, 'lsp_document_code_action_signs_delay', 500)


### PR DESCRIPTION
Hi maintainers ✋

I faced to a problem of changing the height and wrapping of lines frequency as shown in the video below.
And I found out the cause is that a `text_align` of `prop_add()` option is `"below"`.

*Before*

https://user-images.githubusercontent.com/121105839/210579403-00aefdd8-c0db-4162-812e-47d0a6f9429c.mov

So I improved that the `prop_add()` option can be specified via global variables.
For example:

```vim
let g:lsp_diagnostics_virtual_text_enabled = 1
let g:lsp_diagnostics_virtual_text_align = 'after'
let g:lsp_diagnostics_virtual_text_padding_left = 2
let g:lsp_diagnostics_virtual_text_wrap = 'truncate'
```

*After*

https://user-images.githubusercontent.com/121105839/210579502-4d3b6f2a-9c38-4c22-ab9f-f082c7581046.mov

