### PR TITLE
Check for valid range before place diagnostic highlights

### DIFF
--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -163,18 +163,19 @@ function! s:place_highlights(server, diagnostics_response, bufnr) abort
                    \ l:line - 1, l:highlight_start_col - 1, l:highlight_end_col == -1 ? -1 : l:highlight_end_col)
             endfor
         else
-            try
-                " TODO: need to check for valid range before calling prop_add
-                " See https://github.com/prabirshrestha/vim-lsp/pull/721
-                silent! call prop_add(l:start_line, l:start_col, {
-                    \ 'end_lnum': l:end_line,
-                    \ 'end_col': l:end_col,
-                    \ 'bufnr': a:bufnr,
-                    \ 'type': s:get_prop_type_name(l:severity),
-                    \ })
-            catch
-                call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
-            endtry
+            if lsp#utils#position#is_valid_for_buffer(a:bufnr, l:start_line, l:start_col) &&
+             \ lsp#utils#position#is_valid_for_buffer(a:bufnr, l:end_line, l:end_col)
+                try
+                    silent! call prop_add(l:start_line, l:start_col, {
+                        \ 'end_lnum': l:end_line,
+                        \ 'end_col': l:end_col,
+                        \ 'bufnr': a:bufnr,
+                        \ 'type': s:get_prop_type_name(l:severity),
+                        \ })
+                catch
+                    call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
+                endtry
+            endif
         endif
     endfor
 endfunction

--- a/autoload/lsp/utils/position.vim
+++ b/autoload/lsp/utils/position.vim
@@ -89,3 +89,15 @@ function! lsp#utils#position#vim_to_lsp(expr, pos) abort
          \ }
 endfunction
 
+function! lsp#utils#position#is_valid_for_buffer(bufnr, line, col) abort
+    if a:col < 0
+        return 0
+    endif
+
+    let l:line_str = get(getbufline(a:bufnr, a:line, '$'), 0, '')
+    if a:col > strlen(l:line_str)
+        return 0
+    endif
+
+    return 1
+endfunction


### PR DESCRIPTION
Close: #1415 

https://github.com/prabirshrestha/vim-lsp/pull/721#issuecomment-753279052

https://github.com/prabirshrestha/vim-lsp/blob/500987604d356738068ee3bf320a82dfa9fbfc1f/autoload/lsp/internal/diagnostics/highlights.vim#L167-L175

> f someone wants to create lsp#utils#range#is_valid_for_buffer(range, buffer) before calling prop_add feel free to send a PR.

I read this comment and I tried to add `lsp#utils#range#is_valid_for_buffer(range, buffer)`. But we have to check both start_line/start_col and end_line/end_col not range.

So I decided to add function `lsp#utils#position#is_valid_for_buffer(bufnr, line, col)`.