### PR TITLE
Place multi-line highlights every lines

### DIFF
--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -186,7 +186,7 @@ function! s:place_highlights(server, diagnostics_response, bufnr) abort
                     if l:line == l:end_line
                         let l:highlight_end_col = l:end_col
                     else
-                        let l:highlight_end_col = strlen(getbufoneline(a:bufnr, l:line)) + 1
+                        let l:highlight_end_col = strlen(getbufline(a:bufnr, l:line, l:line)[0]) + 1
                     endif
 
                     try

--- a/autoload/lsp/internal/diagnostics/highlights.vim
+++ b/autoload/lsp/internal/diagnostics/highlights.vim
@@ -163,18 +163,45 @@ function! s:place_highlights(server, diagnostics_response, bufnr) abort
                    \ l:line - 1, l:highlight_start_col - 1, l:highlight_end_col == -1 ? -1 : l:highlight_end_col)
             endfor
         else
-            try
-                " TODO: need to check for valid range before calling prop_add
-                " See https://github.com/prabirshrestha/vim-lsp/pull/721
-                silent! call prop_add(l:start_line, l:start_col, {
-                    \ 'end_lnum': l:end_line,
-                    \ 'end_col': l:end_col,
-                    \ 'bufnr': a:bufnr,
-                    \ 'type': s:get_prop_type_name(l:severity),
-                    \ })
-            catch
-                call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
-            endtry
+            if l:start_line == l:end_line
+                try
+                     " TODO: need to check for valid range before calling prop_add
+                     " See https://github.com/prabirshrestha/vim-lsp/pull/721
+                     silent! call prop_add(l:start_line, l:start_col, {
+                     \ 'end_col': l:end_col,
+                     \ 'bufnr': a:bufnr,
+                     \ 'type': s:get_prop_type_name(l:severity),
+                     \ })
+                catch
+                     call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
+                endtry
+            else
+                for l:line in range(l:start_line, l:end_line)
+                    if l:line == l:start_line
+                        let l:highlight_start_col = l:start_col
+                    else
+                        let l:highlight_start_col = 1
+                    endif
+
+                    if l:line == l:end_line
+                        let l:highlight_end_col = l:end_col
+                    else
+                        let l:highlight_end_col = strlen(getbufoneline(a:bufnr, l:line)) + 1
+                    endif
+
+                    try
+                        " TODO: need to check for valid range before calling prop_add
+                        " See https://github.com/prabirshrestha/vim-lsp/pull/721
+                        silent! call prop_add(l:line, l:highlight_start_col, {
+                        \ 'end_col': l:highlight_end_col,
+                        \ 'bufnr': a:bufnr,
+                        \ 'type': s:get_prop_type_name(l:severity),
+                        \ })
+                    catch
+                        call lsp#log('diagnostics', 'place_highlights', 'prop_add', v:exception, v:throwpoint)
+                    endtry
+                endfor
+            endif
         endif
     endfor
 endfunction


### PR DESCRIPTION
Resolve: #1415 

Briefly, this change fixes a bug that the rows do not match the lines on the screen.

* master
<img width="417" alt="Screen Shot 2023-01-22 at 0 48 50" src="https://user-images.githubusercontent.com/121105839/213874959-5f87322d-6a6d-4577-bd3b-32dd2ebb6298.png">

* ryuichiroh:issue-1415-multiline-highlights
<img width="417" alt="Screen Shot 2023-01-22 at 0 49 03" src="https://user-images.githubusercontent.com/121105839/213874974-ac3532f5-d0dc-4017-9363-d6514cd10a55.png">


Vim has a problem with multi-line text_prop not working properly. https://github.com/vim/vim/issues/11846
Therefore, I changed the code to add text_prop one line at a time.

The idea is simple because it's based on the code for Neovim. (https://github.com/prabirshrestha/vim-lsp/blob/master/autoload/lsp/internal/diagnostics/highlights.vim#L137-L163)
