### PR TITLE
Make the CompleteDone backspace check more robust

### DIFF
--- a/autoload/lsp/ui/vim/completion.vim
+++ b/autoload/lsp/ui/vim/completion.vim
@@ -49,6 +49,7 @@ function! s:on_complete_done() abort
   endif
 
   let s:context['done_line'] = getline('.')
+  let s:context['done_line_nr'] = line('.')
   let s:context['completed_item'] = copy(v:completed_item)
   let s:context['done_position'] = lsp#utils#position#vim_to_lsp('%', getpos('.')[1 : 2])
   let s:context['complete_position'] = l:managed_user_data['complete_position']
@@ -71,6 +72,7 @@ function! s:on_complete_done_after() abort
   endif
 
   let l:done_line = s:context['done_line']
+  let l:done_line_nr = s:context['done_line_nr']
   let l:completed_item = s:context['completed_item']
   let l:done_position = s:context['done_position']
   let l:complete_position = s:context['complete_position']
@@ -79,7 +81,7 @@ function! s:on_complete_done_after() abort
   let l:start_character = s:context['start_character']
 
   " check the commit characters are <BS> or <C-w>.
-  if strlen(getline('.')) < strlen(l:done_line)
+  if line('.') ==# l:done_line_nr && strlen(getline('.')) < strlen(l:done_line)
     doautocmd <nomodeline> User lsp_complete_done
     return ''
   endif


### PR DESCRIPTION
When checking for backspace in `CompleteDone` event, also look at the line number. If the line number changed, the user probably pressed something like `<CR>` and not backspace.