### PR TITLE
fix eat of typing char after completion done

### DIFF
--- a/test/lsp/omni.vimspec
+++ b/test/lsp/omni.vimspec
@@ -84,6 +84,7 @@ Describe lsp#omni
                         \   'completion_item': item,
                         \   'complete_position': { 'line': 1, 'character': 1 },
                         \   'start_character': 0,
+                        \   'complete_word': 'yyy',
                         \ })
         End
 
@@ -187,6 +188,7 @@ Describe lsp#omni
                         \   'completion_item': item,
                         \   'complete_position': { 'line': 1, 'character': 1 },
                         \   'start_character': 0,
+                        \   'complete_word': 'System.out.println(${0});',
                         \ })
         End
 


### PR DESCRIPTION
When using typescript-language-server, in content `Math.ab|`, if you type `<C-X><C-o>` for omni completion, it will be completed with `s`. Then, the content will become `Math.abs|`. If you continue type `(`, the `(` will be removed. Also, if type `<CR>`, a new line will be added, resulting in `Math.abs|s\nMath.ab`. This patch attempts to fix this issue.