### PR TITLE
Enable scrollbar in popup window

### DIFF
--- a/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
+++ b/autoload/vital/_lsp/VS/Vim/Window/FloatingWindow.vim
@@ -401,7 +401,7 @@ else
     \   'pos': 'topleft',
     \   'wrap': v:false,
     \   'moved': [0, 0, 0],
-    \   'scrollbar': 0,
+    \   'scrollbar': 1,
     \   'maxwidth': l:style.width,
     \   'maxheight': l:style.height,
     \   'minwidth': l:style.width,


### PR DESCRIPTION
@prabirshrestha LspHover can show a lot of text sometimes. Enabling the scrollbar ensures it can be scrolled via mouse, for example.

Tested locally.

<img width="705" alt="image" src="https://user-images.githubusercontent.com/940/234903622-6757ebaf-3f90-4576-95c8-3fd29b82a119.png">


https://user-images.githubusercontent.com/940/234905176-c956af34-17aa-4cb9-831c-5aeed34ff210.mov



Closes https://github.com/prabirshrestha/vim-lsp/issues/1457