### PR TITLE
Fix trailing characters error when connecting via tcp

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -472,7 +472,7 @@ function! s:ensure_start(buf, server_name, cb) abort
     endif
 
     if has_key(l:server_info, 'tcp')
-        let l:tcp = l:server_info['tcp'](l:server_info)
+        let l:tcp = l:server_info['tcp']
         let l:lsp_id = lsp#client#start({
             \ 'tcp': l:tcp,
             \ 'on_stderr': function('s:on_stderr', [a:server_name]),


### PR DESCRIPTION
I normally avoid VimScript like fire so I don't really know what's going on. But I needed to remove it to make the TCP transport work for me. Otherwise I was getting a trailing characters error in `ensure_start`.

Vim version:
```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled May 24 2023 14:27:53)
Included patches: 1-3995, 4563, 4646, 4774, 4895, 4899, 4901, 4919
Modified by team+vim@tracker.debian.org
Compiled by team+vim@tracker.debian.org
Huge version without GUI.  Features included (+) or not (-):
+acl               +cursorshape       +job               +mouse_urxvt       +signs             +user_commands
+arabic            +dialog_con        +jumplist          +mouse_xterm       +smartindent       +vartabs
+autocmd           +diff              +keymap            +multi_byte        +sodium            +vertsplit
+autochdir         +digraphs          +lambda            +multi_lang        -sound             +vim9script
-autoservername    -dnd               +langmap           -mzscheme          +spell             +viminfo
-balloon_eval      -ebcdic            +libcall           +netbeans_intg     +startuptime       +virtualedit
+balloon_eval_term +emacs_tags        +linebreak         +num64             +statusline        +visual
-browse            +eval              +lispindent        +packages          -sun_workshop      +visualextra
++builtin_terms    +ex_extra          +listcmds          +path_extra        +syntax            +vreplace
+byte_offset       +extra_search      +localmap          -perl              +tag_binary        +wildignore
+channel           -farsi             -lua               +persistent_undo   -tag_old_static    +wildmenu
+cindent           +file_in_path      +menu              +popupwin          -tag_any_white     +windows
-clientserver      +find_in_path      +mksession         +postscript        -tcl               +writebackup
-clipboard         +float             +modify_fname      +printer           +termguicolors     -X11
+cmdline_compl     +folding           +mouse             +profile           +terminal          -xfontset
+cmdline_hist      -footer            -mouseshape        -python            +terminfo          -xim
+cmdline_info      +fork()            +mouse_dec         +python3           +termresponse      -xpm
+comments          +gettext           +mouse_gpm         +quickfix          +textobjects       -xsmp
+conceal           -hangul_input      -mouse_jsbterm     +reltime           +textprop          -xterm_clipboard
+cryptv            +iconv             +mouse_netterm     +rightleft         +timers            -xterm_save
+cscope            +insert_expand     +mouse_sgr         -ruby              +title
+cursorbind        +ipv6              -mouse_sysmouse    +scrollbind        -toolbar
```

My config:
```
au User lsp_setup call lsp#register_server({
    \ 'name': 'pylsp',
    \ 'tcp': "localhost:6001",
    \ 'allowlist': ['python'],
    \ })
```
the rest is standard, from the README.