### PR TITLE
Support `lsp_document_symbol_detail` option

### DIFF
--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -72,7 +72,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name'],
                         \ })
                 endif
             else
@@ -84,7 +84,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['name'],
+                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['detail'],
                         \ })
                     if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
                         call s:symbols_to_loc_list_children(a:server, l:path, l:list, l:symbol['children'], 1)

--- a/autoload/lsp/ui/vim/utils.vim
+++ b/autoload/lsp/ui/vim/utils.vim
@@ -84,7 +84,7 @@ function! lsp#ui#vim#utils#symbols_to_loc_list(server, result) abort
                         \ 'filename': l:path,
                         \ 'lnum': l:line,
                         \ 'col': l:col,
-                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . l:symbol['detail'],
+                        \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name'],
                         \ })
                     if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
                         call s:symbols_to_loc_list_children(a:server, l:path, l:list, l:symbol['children'], 1)

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -74,6 +74,7 @@ CONTENTS                                                  *vim-lsp-contents*
       g:lsp_document_highlight_enabled      |g:lsp_document_highlight_enabled|
       g:lsp_document_highlight_delay        |g:lsp_document_highlight_delay|
       g:lsp_get_supported_capabilities      |g:lsp_get_supported_capabilities|
+      g:lsp_document_symbol_detail          |g:lsp_document_symbol_detail|
       g:lsp_peek_alignment                  |g:lsp_peek_alignment|
       g:lsp_preview_max_width               |g:lsp_preview_max_width|
       g:lsp_preview_max_height              |g:lsp_preview_max_height|
@@ -950,6 +951,22 @@ g:lsp_get_supported_capabilities         *g:lsp_get_supported_capabilities*
     Note: You can obtain the default supported capabilities of vim-lsp by
     calling `lsp#default_get_supported_capabilities` from within your
     function.
+
+g:lsp_document_symbol_detail                 *g:lsp_document_symbol_detail*
+    Type: |Number|
+    Default: `0`
+
+    Determines whether document symbol shows details or not. Set to `1` to
+    show details.
+
+    Note: showing details needs to turn on setting below: >
+      \ 'capabilities': {
+      \     'textDocument': {
+      \         'documentSymbol': {
+      \             'hierarchicalDocumentSymbolSupport': v:true,
+      \         },
+      \     },
+      \ },
 
 g:lsp_peek_alignment                                 *g:lsp_peek_alignment*
     Type: |String|

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -85,6 +85,8 @@ let g:lsp_code_action_ui = get(g:, 'lsp_code_action_ui', 'preview')
 
 let g:lsp_get_supported_capabilities = get(g:, 'lsp_get_supported_capabilities', [function('lsp#default_get_supported_capabilities')])
 
+let g:lsp_document_symbol_detail = get(g:, 'lsp_document_symbol_detail', 0)
+
 let g:lsp_experimental_workspace_folders = get(g:, 'lsp_experimental_workspace_folders', 0)
 
 if g:lsp_auto_enable


### PR DESCRIPTION
to show details

`g:lsp_document_symbol_detail=0`(default):
```
internal/lsp/cmd/symbols.go|20 col 6| struct : symbols
internal/lsp/cmd/symbols.go|21 col 2| field :   app
internal/lsp/cmd/symbols.go|24 col 1| method : (*symbols).Name
internal/lsp/cmd/symbols.go|25 col 1| method : (*symbols).Parent
internal/lsp/cmd/symbols.go|26 col 1| method : (*symbols).Usage
internal/lsp/cmd/symbols.go|27 col 1| method : (*symbols).ShortHelp
internal/lsp/cmd/symbols.go|28 col 1| method : (*symbols).DetailedHelp
internal/lsp/cmd/symbols.go|35 col 1| method : (*symbols).Run
internal/lsp/cmd/symbols.go|73 col 1| function : mapToSymbol
internal/lsp/cmd/symbols.go|94 col 1| function : printDocumentSymbol
internal/lsp/cmd/symbols.go|105 col 1| function : printSymbolInformation
internal/lsp/cmd/symbols.go|109 col 1| function : positionToString
```

`g:lsp_document_symbol_detail=1`:
```
internal/lsp/cmd/symbols.go|20 col 6| struct : symbolsstruct{...}                                               
internal/lsp/cmd/symbols.go|21 col 2| field :   app                                                             
internal/lsp/cmd/symbols.go|24 col 1| method : (*symbols).Namefunc() string                                     
internal/lsp/cmd/symbols.go|25 col 1| method : (*symbols).Parentfunc() string                                   
internal/lsp/cmd/symbols.go|26 col 1| method : (*symbols).Usagefunc() string                                    
internal/lsp/cmd/symbols.go|27 col 1| method : (*symbols).ShortHelpfunc() string                                
internal/lsp/cmd/symbols.go|28 col 1| method : (*symbols).DetailedHelpfunc(f *flag.FlagSet)                     
internal/lsp/cmd/symbols.go|35 col 1| method : (*symbols).Runfunc(ctx context.Context, args ...string) error    
internal/lsp/cmd/symbols.go|73 col 1| function : mapToSymbolfunc(m map[string]interface{}) (interface{}, error) 
internal/lsp/cmd/symbols.go|94 col 1| function : printDocumentSymbolfunc(s protocol.DocumentSymbol)             
internal/lsp/cmd/symbols.go|105 col 1| function : printSymbolInformationfunc(s protocol.SymbolInformation)      
internal/lsp/cmd/symbols.go|109 col 1| function : positionToStringfunc(r protocol.Range) string                 
```