### PR TITLE
feat: Just echo message without truncation

### DIFF
--- a/autoload/lsp/internal/diagnostics/echo.vim
+++ b/autoload/lsp/internal/diagnostics/echo.vim
@@ -32,10 +32,10 @@ endfunction
 
 function! s:echo(diagnostic) abort
     if !empty(a:diagnostic) && has_key(a:diagnostic, 'message')
-        call lsp#utils#echo_with_truncation('LSP: '. substitute(a:diagnostic['message'], '\n\+', ' ', 'g'))
+        call lsp#utils#echo('LSP: '. substitute(a:diagnostic['message'], '\n\+', ' ', 'g'))
         let s:displaying_message = 1
     elseif get(s:, 'displaying_message', 0)
-        call lsp#utils#echo_with_truncation('')
+        call lsp#utils#echo('')
         let s:displaying_message = 0
     endif
 endfunction

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -324,6 +324,11 @@ function! lsp#utils#echo_with_truncation(msg) abort
     exec 'echo l:msg'
 endfunction
 
+function! lsp#utils#echo(msg) abort
+    let l:msg = a:msg
+    exec 'echo l:msg'
+endfunction
+
 " Convert a byte-index (1-based) to a character-index (0-based)
 " This function requires a buffer specifier (expr, see :help bufname()),
 " a line number (lnum, 1-based), and a byte-index (char, 1-based).

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -1794,7 +1794,7 @@ LspNextReference                                         *:LspNextReference*
 
 Jump to the next reference of the symbol under cursor.
 
-LspNextWarning [-wrap=0]                              :LspNextWarning*
+LspNextWarning [-wrap=0]                              *:LspNextWarning*
 
 Jump to Next warning diagnostics
 With '-wrap=0', stop wrapping around the end of file.


### PR DESCRIPTION

The echo message should not be truncated, Just show the message.

When  truncated
![WX20231010-141635@2x](https://github.com/prabirshrestha/vim-lsp/assets/908026/6d322bab-580e-4181-9786-7665cdd30d80)

When show the full message
![WX20231010-142100@2x](https://github.com/prabirshrestha/vim-lsp/assets/908026/91aee432-74c8-426e-a883-0087af690264)
