### PR TITLE
Fix various bugs when loading many buffers

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -211,6 +211,7 @@ function! lsp#register_server(server_info) abort
     let l:server_name = a:server_info['name']
     if has_key(s:servers, l:server_name)
         call lsp#log('lsp#register_server', 'server already registered', l:server_name)
+        return
     endif
     " NOTE: workspace_folders is dict for faster lookup instead of array
     let s:servers[l:server_name] = {

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1069,7 +1069,7 @@ endfunction
 function! s:get_text_document(buf, server_name, buffer_info) abort
     let l:server = s:servers[a:server_name]
     let l:server_info = l:server['server_info']
-    let l:language_id = has_key(l:server_info, 'languageId') ?  l:server_info['languageId'](l:server_info) : &filetype
+    let l:language_id = has_key(l:server_info, 'languageId') ?  l:server_info['languageId'](l:server_info) : getbufvar(a:buf, '&filetype')
     return {
         \ 'uri': lsp#utils#get_buffer_uri(a:buf),
         \ 'languageId': l:language_id,

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -210,10 +210,6 @@ endfunction
 function! lsp#register_server(server_info) abort
     let l:server_name = a:server_info['name']
     if has_key(s:servers, l:server_name)
-        if s:servers[l:server_name]['server_info'] ==# a:server_info
-            call lsp#log('lsp#register_server', 'server already registered and server_info matches', l:server_name)
-            return
-        endif
         call lsp#log('lsp#register_server', 'server already registered', l:server_name)
     endif
     " NOTE: workspace_folders is dict for faster lookup instead of array

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -210,8 +210,11 @@ endfunction
 function! lsp#register_server(server_info) abort
     let l:server_name = a:server_info['name']
     if has_key(s:servers, l:server_name)
+        if s:servers[l:server_name]['server_info'] ==# a:server_info
+            call lsp#log('lsp#register_server', 'server already registered and server_info matches', l:server_name)
+            return
+        endif
         call lsp#log('lsp#register_server', 'server already registered', l:server_name)
-        return
     endif
     " NOTE: workspace_folders is dict for faster lookup instead of array
     let s:servers[l:server_name] = {

--- a/autoload/lsp/ui/vim/folding.vim
+++ b/autoload/lsp/ui/vim/folding.vim
@@ -1,6 +1,9 @@
 let s:folding_ranges = {}
 let s:textprop_name = 'vim-lsp-folding-linenr'
 
+" imports
+let s:Buffer = vital#lsp#import('VS.Vim.Buffer')
+
 function! s:find_servers() abort
     return filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_folding_range_provider(v:val)')
 endfunction
@@ -30,7 +33,7 @@ function! s:set_textprops(buf) abort
     " Create text property, if not already defined
     silent! call prop_type_add(s:textprop_name, {'bufnr': a:buf, 'priority': lsp#internal#textprop#priority('folding')})
 
-    let l:line_count = s:get_line_count_buf(a:buf)
+    let l:line_count = s:Buffer.get_line_count(a:buf)
 
     " First, clear all markers from the previous run
     call prop_remove({'type': s:textprop_name, 'bufnr': a:buf}, 1, l:line_count)
@@ -41,14 +44,6 @@ function! s:set_textprops(buf) abort
         call prop_add(l:i, 1, {'bufnr': a:buf, 'type': s:textprop_name, 'id': l:i})
         let l:i += 1
     endwhile
-endfunction
-
-function! s:get_line_count_buf(buf) abort
-    if !has('patch-8.1.1967')
-        return line('$')
-    endif
-    let l:winids = win_findbuf(a:buf)
-    return empty(l:winids) ? line('$') : line('$', l:winids[0])
 endfunction
 
 function! lsp#ui#vim#folding#send_request(server_name, buf, sync) abort


### PR DESCRIPTION
I've hit a few bugs when trying to use vim-lsp and https://github.com/vim-ctrlspace/vim-ctrlspace. This happened when starting vim without any file (language server not started yet) and then loading a workspace with many buffers.
* languageId in a request was incorrectly set to "ctrlspace" because `filetype` option was not obtained by `getbufvar`. As a result `lsp_buffer_enabled` autocommand was not fired.
* An issue with an exception thrown in a folding request. The problem was invalid line count (greater than actual count) of a buffer. As a result LSP was not enabled for the buffer.