### PR TITLE
Add try..catch as id as string is not supported by vim.

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -453,7 +453,7 @@ function! lsp#client#send_response(client_id, opts) abort
         catch
             " vim only supports id as number and fails when string, hence add a try catch: https://github.com/vim/vim/issues/14091
             call lsp#log('lsp#client#send_response error', v:exception, v:throwpoint,
-                \  has_key(l:request, 'id') && type(l:request['id']) != 'number')
+                \  has_key(l:request, 'id') && type(l:request['id']) != type(1))
         endtry
         return 0
     else

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -448,7 +448,13 @@ function! lsp#client#send_response(client_id, opts) abort
         if has_key(a:opts, 'id') | let l:request['id'] = a:opts['id'] | endif
         if has_key(a:opts, 'result') | let l:request['result'] = a:opts['result'] | endif
         if has_key(a:opts, 'error') | let l:request['error'] = a:opts['error'] | endif
-        call ch_sendexpr(l:ctx['channel'], l:request)
+        try
+            call ch_sendexpr(l:ctx['channel'], l:request)
+        catch
+            " vim only supports id as number and fails when string, hence add a try catch: https://github.com/vim/vim/issues/14091
+            call lsp#log('lsp#client#send_response error', v:exception, v:throwpoint,
+                \  has_key(l:request, 'id') && type(l:request['id']) != 'number')
+        endtry
         return 0
     else
         return s:lsp_send(a:client_id, a:opts, s:send_type_response)


### PR DESCRIPTION
Partially solve native lsp in vim not supporting string for id when sending response.

Refer to following for more details:
https://github.com/prabirshrestha/vim-lsp/issues/1497
https://github.com/vim/vim/issues/14091