### PR TITLE
Add `options` to `lsp#ui#vim#rename()` to specify `server`

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -99,7 +99,10 @@ function! s:rename(server, new_name, pos) abort
     echo ' ... Renaming ...'
 endfunction
 
-function! lsp#ui#vim#rename() abort
+" options - {
+"   server - 'server_name'		" optional
+" }
+function! lsp#ui#vim#rename(options) abort
     let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_rename_prepare_provider(v:val)')
     let l:prepare_support = 1
     if len(l:servers) == 0
@@ -115,7 +118,16 @@ function! lsp#ui#vim#rename() abort
     endif
 
     " TODO: ask the user which server it should use to rename if there are multiple
-    let l:server = l:servers[0]
+    if has_key(a:options, 'server')
+        if index(l:servers, a:options['server']) >= 0
+            let l:server = a:options['server']
+        else
+            call s:not_supported('Renaming by ' .. a:options['server'])
+            return
+        endif
+    else
+        let l:server = l:servers[0]
+    endif
 
     if l:prepare_support
         call lsp#send_request(l:server, {

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -130,7 +130,8 @@ command! -nargs=* LspNextDiagnostic call lsp#internal#diagnostics#movement#_next
 command! -nargs=* LspPreviousDiagnostic call lsp#internal#diagnostics#movement#_previous_diagnostics(<f-args>)
 command! LspReferences call lsp#ui#vim#references({})
 command! LspAddTreeReferences call lsp#ui#vim#add_tree_references()
-command! LspRename call lsp#ui#vim#rename()
+command! LspRename call lsp#ui#vim#rename(
+            \ extend({}, lsp#utils#args#_parse(<q-args>, {}, v:null)))
 command! LspTypeDefinition call lsp#ui#vim#type_definition(0, <q-mods>)
 command! LspTypeHierarchy call lsp#internal#type_hierarchy#show()
 command! LspPeekTypeDefinition call lsp#ui#vim#type_definition(1)
@@ -191,7 +192,7 @@ nnoremap <silent> <plug>(lsp-next-diagnostic-nowrap) :<c-u>call lsp#internal#dia
 nnoremap <silent> <plug>(lsp-previous-diagnostic) :<c-u>call lsp#internal#diagnostics#movement#_previous_diagnostics()<cr>
 nnoremap <silent> <plug>(lsp-previous-diagnostic-nowrap) :<c-u>call lsp#internal#diagnostics#movement#_previous_diagnostics("-wrap=0")<cr>
 nnoremap <silent> <plug>(lsp-references) :<c-u>call lsp#ui#vim#references({})<cr>
-nnoremap <silent> <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename()<cr>
+nnoremap <silent> <plug>(lsp-rename) :<c-u>call lsp#ui#vim#rename({})<cr>
 nnoremap <silent> <plug>(lsp-type-definition) :<c-u>call lsp#ui#vim#type_definition(0)<cr>
 nnoremap <silent> <plug>(lsp-type-hierarchy) :<c-u>call lsp#internal#type_hierarchy#show()<cr>
 nnoremap <silent> <plug>(lsp-peek-type-definition) :<c-u>call lsp#ui#vim#type_definition(1)<cr>


### PR DESCRIPTION
This PR adds `options` to `lsp#ui#vim#rename()` to specify `server`.

My use case is following:
Recently, I added the setting for the latest Vue Language Tools to vim-lsp-settings ( https://github.com/mattn/vim-lsp-settings/pull/728 ). We need to run both typescript-language-server and volar-server to use it but only typescript-language-server supports the renaming feature. Here, `l:servers[0]` is `volar-server` by accident in my environment so I cannot use the renaming feature. So, I'd like to specify typescript-langeuage-server for renaming in explicit way.