### PR TITLE
Bugfix: Correctly identify the type of content update notification to use for each LSP server

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -750,7 +750,7 @@ function! s:text_changes(buf, server_name) abort
     endif
 
     " When syncKind is Incremental and previous content is saved.
-    if l:sync_kind == 2 && has_key(s:file_content, a:buf)
+    if l:sync_kind == 2 && has_key(s:file_content, a:buf) && has_key(s:file_content[a:buf], a:server_name)
         " compute diff
         let l:old_content = s:get_last_file_content(a:buf, a:server_name)
         let l:new_content = lsp#utils#buffer#_get_lines(a:buf)


### PR DESCRIPTION
Fixes #1547

The `s:file_content` object has an entry for each buffer, and each buffer entry has an entry for each LSP server it has been synced with:
https://github.com/prabirshrestha/vim-lsp/blob/f7ccf006df1aefd327c0e2c55cc8632a2db577c1/autoload/lsp.vim#L9-L20

When deciding whether an LSP has been sent a copy of the buffer or not, the current code only inspects whether the buffer entry exists. It should, instead, additionally verify whether the entry for the corresponding LSP server exists.

This PR adds such a check.