### PR TITLE
fix(text_edit): discarded change from the initial buffer

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -200,18 +200,17 @@ function! s:_compare(text_edit1, text_edit2) abort
     return a:text_edit1.range.start.character - a:text_edit2.range.start.character
   endif
   return l:diff
-endfunction
+endfunction 
 
 "
 " _switch
 "
 function! s:_switch(path) abort
-  if bufnr(a:path) >= 0
-    execute printf('keepalt keepjumps %sbuffer!', bufnr(a:path))
-  else
-    execute printf('keepalt keepjumps edit! %s', fnameescape(a:path))
+  if bufnr(a:path) == -1
+    execute printf('badd %s', fnameescape(a:path))
   endif
-endfunction
+  execute printf('keepalt keepjumps %sbuffer!', bufnr(a:path))
+endfunction 
 
 "
 " delete

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -2,6 +2,7 @@ function! s:set_text(lines)
     % delete _
     put =a:lines
     execute 'normal ggdd'
+    execute 'write! /tmp/xyz'
 endfunction
 
 function! s:get_text()
@@ -641,6 +642,45 @@ Describe lsp#utils#text_edit
             \ }])
 
             Assert Equals(getbufline(l:target, 1), ['aiueo'])
+        End
+
+        It should apply edits to buffer and unloaded file
+            let l:text = ['plop']
+            call s:set_text(l:text)
+            let l:buffer_text = s:get_text()
+            Assert Equals(l:buffer_text, ['plop', ''])
+            let l:target = globpath(&runtimepath, 'test/lsp/utils/text_edit.vimspec')
+            call lsp#utils#text_edit#apply_text_edits(
+              \ lsp#utils#path_to_uri(expand('%')),
+              \  [{
+              \   'range': {
+              \     'start': {
+              \       'line': 0,
+              \       'character': 0,
+              \     },
+              \     'end': {
+              \       'line': 1,
+              \       'character': 0,
+              \     }
+              \   },
+              \   'newText': "buffer\n"
+              \ }])
+            call lsp#utils#text_edit#apply_text_edits(lsp#utils#path_to_uri(l:target), [{
+              \   'range': {
+              \     'start': {
+              \       'line': 0,
+              \       'character': 0,
+              \     },
+              \     'end': {
+              \       'line': 1,
+              \       'character': 0,
+              \     }
+              \   },
+              \   'newText': "unloaded\n"
+              \ }])
+
+            Assert Equals(getbufline(l:target, 1), ['unloaded'])
+            Assert Equals(getbufline(expand('%'), 1), ['buffer'])
         End
     End
 End

--- a/test/lsp/utils/text_edit.vimspec
+++ b/test/lsp/utils/text_edit.vimspec
@@ -2,7 +2,7 @@ function! s:set_text(lines)
     % delete _
     put =a:lines
     execute 'normal ggdd'
-    execute 'write! /tmp/xyz'
+    execute 'file my-file'
 endfunction
 
 function! s:get_text()


### PR DESCRIPTION
When multiple calls to the `apply_text_edits()` function are made, the changes made to the current buffer are discarded if the following `text_edit` targets a file that is not in the buffer list.

The problem comes from the `_switch` function, which executes `edit!` when it detects that the target is not in the buffer list. If a change has already been made to the current buffer before that, that change is discarded (definition of `edit!`).

The fix uses of a different logic: if `_switch` detects that the target is not in the buffer list, it calls `badd` before switching to the buffer that has just been added. No more `edit!`, no more discarded changes.

The added test will fail without the patch in the `_switch` function.