### PR TITLE
Add missing borders to Neovim's floating windows

### DIFF
--- a/autoload/lsp/ui/vim/output.vim
+++ b/autoload/lsp/ui/vim/output.vim
@@ -102,6 +102,7 @@ function! s:get_float_positioning(height, width) abort
     let l:height = min([l:height, max([&lines - &cmdheight - l:row, &previewheight])])
 
     let l:style = 'minimal'
+    let l:border = 'double'
     " Positioning is not window but screen relative
     let l:opts = {
         \ 'relative': 'editor',
@@ -110,6 +111,7 @@ function! s:get_float_positioning(height, width) abort
         \ 'width': l:width,
         \ 'height': l:height,
         \ 'style': l:style,
+        \ 'border': l:border,
         \ }
     return l:opts
 endfunction


### PR DESCRIPTION
Related to issue #1207 

In Vim, when e.g. peeking at type definition, the popup windows have a border drawn around them:
![screenshot-20240709_222924](https://github.com/prabirshrestha/vim-lsp/assets/22616434/998db940-8883-4357-9a3a-dc9837ed7844)

While in Neovim such border is missing:
![screenshot-20240709_223010](https://github.com/prabirshrestha/vim-lsp/assets/22616434/d7561bb5-a3d4-4ce7-8ad4-e536d782bc9e)

With the small fix from this PR:
![screenshot-20240709_223146](https://github.com/prabirshrestha/vim-lsp/assets/22616434/5b6ef084-1fcc-401b-bbb4-a9600969e8f7)

The readability is quite improved.
