### PR TITLE
Switch to the new Neovim health API

### DIFF
--- a/autoload/health/lsp.vim
+++ b/autoload/health/lsp.vim
@@ -8,7 +8,7 @@ endf
 
 
 function! health#lsp#check() abort
-    call health#report_start('server status')
+    call v:lua.vim.health.start('server status')
     let l:server_status = lsp#collect_server_status()
 
     let l:has_printed = v:false
@@ -17,21 +17,21 @@ function! health#lsp#check() abort
 
         let l:status_msg = printf('%s: %s', l:k, l:report.status)
         if l:report.status == 'running'
-            call health#report_ok(l:status_msg)
+            call v:lua.vim.health.ok(l:status_msg)
         elseif l:report.status == 'failed'
-            call health#report_error(l:status_msg, 'See :help g:lsp_log_verbose to debug server failure.')
+            call v:lua.vim.health.error(l:status_msg, 'See :help g:lsp_log_verbose to debug server failure.')
         else
-            call health#report_warn(l:status_msg)
+            call v:lua.vim.health.warn(l:status_msg)
         endif
         let l:has_printed = v:true
     endfor
 
     if !l:has_printed
-        call health#report_warn('no servers connected')
+        call v:lua.vim.health.warn('no servers connected')
     endif
 
     for l:k in sort(keys(l:server_status))
-        call health#report_start(printf('server configuration: %s', l:k))
+        call v:lua.vim.health.start(printf('server configuration: %s', l:k))
         let l:report = l:server_status[l:k]
 
         let l:msg = "\t\n"
@@ -51,14 +51,14 @@ function! health#lsp#check() abort
             endif
             let l:msg .= printf("### workspace_config\n```json\n%s\n```", l:cfg)
         endif
-        call health#report_info(l:msg)
+        call v:lua.vim.health.info(l:msg)
     endfor
 
-    call health#report_start('Performance')
+    call v:lua.vim.health.start('Performance')
     if lsp#utils#has_lua() && g:lsp_use_lua
-        call health#report_ok('Using lua for faster performance.')
+        call v:lua.vim.health.ok('Using lua for faster performance.')
     else
-        call health#report_warn('Missing requirements to enable lua for faster performance.')
+        call v:lua.vim.health.warn('Missing requirements to enable lua for faster performance.')
     endif
 
 endf


### PR DESCRIPTION
The old `report_(start|ok|info|warn|error)` functions are [deprecated](https://neovim.io/doc/user/deprecated.html#health%23report_start) and break :checkhealth in recent versions of neovim:
```
Error executing lua: function health#lsp#check, line 1: Vim(call):E117: Unknown function: health#report_start
stack traceback:                                                                                                                                                                             
        [C]: in function 'call'                                                                                                                                                              
        /usr/share/nvim/runtime/lua/vim/health.lua:366: in function '_check'                                                                                                                 
        [string "<nvim>"]:1: in main chunk                        
```
This PR updates to the new `vim.health` API and fixes the issue, although I guess it will break checkhealth for very old versions.