### PR TITLE
Revert "Switch to the new Neovim health API"

### DIFF
--- a/autoload/health/lsp.vim
+++ b/autoload/health/lsp.vim
@@ -8,7 +8,7 @@ endf
 
 
 function! health#lsp#check() abort
-    call v:lua.vim.health.start('server status')
+    call health#report_start('server status')
     let l:server_status = lsp#collect_server_status()
 
     let l:has_printed = v:false
@@ -17,21 +17,21 @@ function! health#lsp#check() abort
 
         let l:status_msg = printf('%s: %s', l:k, l:report.status)
         if l:report.status == 'running'
-            call v:lua.vim.health.ok(l:status_msg)
+            call health#report_ok(l:status_msg)
         elseif l:report.status == 'failed'
-            call v:lua.vim.health.error(l:status_msg, 'See :help g:lsp_log_verbose to debug server failure.')
+            call health#report_error(l:status_msg, 'See :help g:lsp_log_verbose to debug server failure.')
         else
-            call v:lua.vim.health.warn(l:status_msg)
+            call health#report_warn(l:status_msg)
         endif
         let l:has_printed = v:true
     endfor
 
     if !l:has_printed
-        call v:lua.vim.health.warn('no servers connected')
+        call health#report_warn('no servers connected')
     endif
 
     for l:k in sort(keys(l:server_status))
-        call v:lua.vim.health.start(printf('server configuration: %s', l:k))
+        call health#report_start(printf('server configuration: %s', l:k))
         let l:report = l:server_status[l:k]
 
         let l:msg = "\t\n"
@@ -51,14 +51,14 @@ function! health#lsp#check() abort
             endif
             let l:msg .= printf("### workspace_config\n```json\n%s\n```", l:cfg)
         endif
-        call v:lua.vim.health.info(l:msg)
+        call health#report_info(l:msg)
     endfor
 
-    call v:lua.vim.health.start('Performance')
+    call health#report_start('Performance')
     if lsp#utils#has_lua() && g:lsp_use_lua
-        call v:lua.vim.health.ok('Using lua for faster performance.')
+        call health#report_ok('Using lua for faster performance.')
     else
-        call v:lua.vim.health.warn('Missing requirements to enable lua for faster performance.')
+        call health#report_warn('Missing requirements to enable lua for faster performance.')
     endif
 
 endf


### PR DESCRIPTION
Reverts prabirshrestha/vim-lsp#1567 as vim is broken. will use https://github.com/prabirshrestha/vim-lsp/pull/1562 instead.