### PR TITLE
Add manual way to display diagnostics under the cursor

### DIFF
--- a/autoload/lsp/internal/diagnostics/float.vim
+++ b/autoload/lsp/internal/diagnostics/float.vim
@@ -45,6 +45,13 @@ function! lsp#internal#diagnostics#float#_disable() abort
     let s:enabled = 0
 endfunction
 
+function! lsp#internal#diagnostics#float#open_under_cursor() abort
+    let l:diagnostic = lsp#internal#diagnostics#under_cursor#get_diagnostic()
+    if empty(l:diagnostic) | return | endif
+    call s:show_float(l:diagnostic)
+    call timer_start(0, {-> execute("au CursorMoved,InsertEnter * ++once :call s:hide_float()")})
+endfunction
+
 function! s:show_float(diagnostic) abort
     let l:doc_win = s:get_doc_win()
     if !empty(a:diagnostic) && has_key(a:diagnostic, 'message')
@@ -81,6 +88,7 @@ function! s:show_float(diagnostic) abort
         call s:hide_float()
     endif
 endfunction
+
 
 function! s:hide_float() abort
     let l:doc_win = s:get_doc_win()

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -207,6 +207,7 @@ nnoremap <silent> <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
 nnoremap <silent> <plug>(lsp-next-reference) :<c-u>call lsp#internal#document_highlight#jump(+1)<cr>
 nnoremap <silent> <plug>(lsp-previous-reference) :<c-u>call lsp#internal#document_highlight#jump(-1)<cr>
 nnoremap <silent> <plug>(lsp-signature-help) :<c-u>call lsp#ui#vim#signature_help#get_signature_help_under_cursor()<cr>
+nnoremap <silent> <plug>(lsp-diagnostic-open-float-under-cursor) :<c-u>call lsp#internal#diagnostics#float#open_under_cursor()<cr>
 
 if has('gui_running')
   anoremenu <silent> L&sp.Goto.Definition :LspDefinition<CR>


### PR DESCRIPTION
fixes #1519

As mentioned in the issue, I find the current automatic behavior not really good. So I think having the option to manually open diagnostic at cursor is a good improvement.