### PR TITLE
Add option to show the most severe diagnostics per line

### DIFF
--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -57,6 +57,8 @@ CONTENTS                                                  *vim-lsp-contents*
 			     |g:lsp_diagnostics_virtual_text_padding_left|
       g:lsp_diagnostics_virtual_text_wrap
 			     |g:lsp_diagnostics_virtual_text_wrap|
+      g:lsp_diagnostics_virtual_text_tidy
+			     |g:lsp_diagnostics_virtual_text_tidy|
       g:lsp_document_code_action_signs_enabled
 			     |g:lsp_document_code_action_signs_enabled|
       g:lsp_document_code_action_signs_delay
@@ -784,6 +786,20 @@ g:lsp_diagnostics_virtual_text_wrap       *g:lsp_diagnostics_virtual_text_wrap*
 
     Example: >
 	let g:lsp_diagnostics_virtual_text_wrap = "truncate"
+
+g:lsp_diagnostics_virtual_text_tidy
+		  *g:lsp_diagnostics_virtual_text_tidy*
+    Type: |Boolean|
+    Default: `0`
+
+    Determines whether or not to show only the diagnostic virtual text
+    with the highest severity per line. Requires
+    |g:lsp_diagnostics_virtual_text_enabled|.
+    This prevents unintentional newlines in the view inserted by diagnostics
+    messages.
+
+    Example: >
+	let g:lsp_diagnostics_virtual_text_tidy = 0
 
 g:lsp_document_code_action_signs_enabled
 				      *g:lsp_document_code_action_signs_enabled*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -41,6 +41,7 @@ let g:lsp_diagnostics_virtual_text_prefix = get(g:, 'lsp_diagnostics_virtual_tex
 let g:lsp_diagnostics_virtual_text_align = get(g:, 'lsp_diagnostics_virtual_text_align', 'below')
 let g:lsp_diagnostics_virtual_text_wrap = get(g:, 'lsp_diagnostics_virtual_text_wrap', 'wrap')
 let g:lsp_diagnostics_virtual_text_padding_left = get(g:, 'lsp_diagnostics_virtual_text_padding_left', 1)
+let g:lsp_diagnostics_virtual_text_tidy = get(g:, 'lsp_diagnostics_virtual_text_tidy', 0)
 
 let g:lsp_document_code_action_signs_enabled = get(g:, 'lsp_document_code_action_signs_enabled', 1)
 let g:lsp_document_code_action_signs_delay = get(g:, 'lsp_document_code_action_signs_delay', 500)


### PR DESCRIPTION
I'm unsure why the original author of #1420 closed the issue, but I believe this option is still necessary. Without it, the new lines inserted by the virtual texts of diagnostics make the view messy and difficult to track at a glance.

Additionally, I'm unclear on how the option `let g:lsp_diagnostics_virtual_text_severities = [1,2,3...]`, as mentioned in the [comment](https://github.com/prabirshrestha/vim-lsp/pull/1420#issuecomment-1401823950) , would work with this feature. I'd like to continue the discussion on this.