### PR TITLE
docs: Removed space in Registering servers in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ function! s:on_lsp_buffer_enabled() abort
 
     let g:lsp_format_sync_timeout = 1000
     autocmd! BufWritePre *.rs,*.go call execute('LspDocumentFormatSync')
-    
+
     " refer to doc to add more commands
 endfunction
 


### PR DESCRIPTION
## Description
Removed space in Registering servers in the documentation.
I fixed it because it was a nuisance when installing it several times.

If you don't mind, I'd like to apply the fix.

thank you
