### PR TITLE
Add support for range diagnostics under cursor

### DIFF
--- a/test/lsp/internal/diagnostics/under_cursor.vimspec
+++ b/test/lsp/internal/diagnostics/under_cursor.vimspec
@@ -1,0 +1,88 @@
+Describe lsp#internal#diagnostics#under_cursor
+    " refer to lsp#test#projectdir('go') . '/documentdiagnostics.go'
+
+    It should not trigger diagnostics when cursor is outside diagnostic range
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 1, 1), {})
+    End
+
+    It should trigger diagnostic when cursor is exactly at start position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 7, 13), l:expected)
+    End
+
+    It should not trigger diagnostic when cursor is at line before start position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 6, 13), {})
+    End
+
+    It should not trigger diagnostic when cursor is one character before start position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 7, 12), {})
+    End
+
+    It should trigger diagnostic when cursor is at start column on an intermediate line within range
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 8, 1), l:expected)
+    End
+
+    It should trigger diagnostic when cursor is at end column on an intermediate line within range
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 8, 15), l:expected)
+    End
+
+    It should trigger diagnostic when cursor is exactly at end position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 9, 5), l:expected)
+    End
+
+    It should not trigger diagnostic when cursor is at line after end position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 10, 5), {})
+    End
+
+    It should not return diagnostic when cursor is one character after end position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 9, 6), {})
+    End
+
+    It should return the closest diagnostic when multiple diagnostics exist across different ranges
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 10, 'line': 4}, 'end': {'character': 7, 'line': 10}} },
+            \     { 'range': {'start': {'character': 12, 'line': 6}, 'end': {'character': 5, 'line': 8}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 10, 'line': 4}, 'end': {'character': 7, 'line': 10}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 7, 3), l:expected)
+    End
+
+    It should return the most specific diagnostic when multiple diagnostics overlap at cursor position
+        let l:diagnostics = [
+            \     { 'range': {'start': {'character': 10, 'line': 4}, 'end': {'character': 15, 'line': 4}} },
+            \     { 'range': {'start': {'character': 12, 'line': 4}, 'end': {'character': 14, 'line': 4}} }
+            \   ]
+        let l:expected = { 'range': {'start': {'character': 12, 'line': 4}, 'end': {'character': 14, 'line': 4}} }
+        Assert Equals(lsp#internal#diagnostics#under_cursor#_get_closest_diagnostic(l:diagnostics, 5, 13), l:expected)
+    End
+End

--- a/test/testproject-go/documentdiagnositcs.go
+++ b/test/testproject-go/documentdiagnositcs.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func documentdiagnostics() {
+	msg := "msg"
+	fmt.Printf(msg +
+		msg +
+		msg,
+	)
+}


### PR DESCRIPTION
Added support for range-based diagnostics, aligning with [the Language Server Protocol (LSP) Specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range). 
Previously, diagnostics were matched only to specific start positions, limiting usability for multi-line or range diagnostics.
This update ensures vim-lsp provides functionality consistent with VSCode, which already supports range-based diagnostics.

The highlighted codes represents the area where textDocument/codeAction can be triggered. 
Below is the corresponding diff for the changes.
## Before
<img width="382" alt="before" src="https://github.com/user-attachments/assets/51aa3990-a282-4d81-bb61-76c2cb36f874">

## After
<img width="382" alt="after" src="https://github.com/user-attachments/assets/9d37f7ae-7180-483e-96d2-820c5f6330f3">

## VSCode behavior
<img width="382" alt="vscode" src="https://github.com/user-attachments/assets/5df01276-fba2-48e7-bb97-c121739d66d0">
