### PR TITLE
fix parsing header's Content-Length without carriage-return

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -139,7 +139,7 @@ function! s:on_stdout(id, data, event) abort
 endfunction
 
 function! s:get_content_length(headers) abort
-    for l:header in split(a:headers, "\r\n")
+    for l:header in split(a:headers, '\r\n\|\n')
         let l:kvp = split(l:header, ':')
         if len(l:kvp) == 2
             if l:kvp[0] =~? '^Content-Length'


### PR DESCRIPTION
Lsp client failed to read `Content-Length` from header. The server implementation was https://github.com/NomicFoundation/hardhat-vscode

Turns out the header response separator was `\n` instead of `\r\n`
<img width="953" alt="image" src="https://github.com/user-attachments/assets/94a6348a-6dc7-4481-b8d1-f208eacaddc0" />

Neovim lsp client doesn't have this issue, so I just apply this simple fix