### PR TITLE
Clear document highlight when call lsp#disable()

### DIFF
--- a/autoload/lsp/internal/document_highlight.vim
+++ b/autoload/lsp/internal/document_highlight.vim
@@ -46,6 +46,8 @@ function! lsp#internal#document_highlight#_enable() abort
 endfunction
 
 function! lsp#internal#document_highlight#_disable() abort
+    call s:clear_highlights()
+
     if exists('s:Dispose')
         call s:Dispose()
         unlet s:Dispose


### PR DESCRIPTION
When call lsp#disable(), the highlights remained:
![image](https://github.com/user-attachments/assets/3acad630-9a7c-4981-a8e1-14160d4d8cad)
