### PR TITLE
Specify that Vim9 is needed for semantic highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Also see `:h vim-lsp-folding`.
 
 ## Semantic highlighting
 vim-lsp supports the unofficial extension to the LSP protocol for semantic highlighting (https://github.com/microsoft/vscode-languageserver-node/pull/367).
-This feature requires Neovim highlights, or Vim with the `textprop` feature enabled.
+This feature requires Neovim highlights, or Vim9 with the `textprop` feature enabled.
 You will also need to link language server semantic scopes to Vim highlight groups.
 Refer to `:h vim-lsp-semantic` for more info.
 


### PR DESCRIPTION
Semantic highlighting uses reduce() and prop_type_add() which are introduced in Vim9.