### PR TITLE
Handle create/rename/delete TextDocumentEdits

### DIFF
--- a/autoload/lsp/utils/text_edit.vim
+++ b/autoload/lsp/utils/text_edit.vim
@@ -25,6 +25,40 @@ function! lsp#utils#text_edit#apply_text_edits(uri, text_edits) abort
     endif
 endfunction
 
+function! lsp#utils#text_edit#apply_text_document_edits(text_document_edit) abort
+    let l:kind = get(a:text_document_edit, 'kind')
+
+    if l:kind == 'create'
+        let l:uri = lsp#utils#uri_to_path(a:text_document_edit['uri'])
+        let l:options = get(a:text_document_edit, 'options', {})
+
+        if !filereadable(l:uri) || !get(l:options, 'overwrite', v:false)
+            call writefile([], l:uri, "s")
+        endif
+        call s:_switch(l:uri)
+    elseif l:kind == 'rename'
+        let l:oldUri = lsp#utils#uri_to_path(a:text_document_edit['oldUri'])
+        let l:newUri = lsp#utils#uri_to_path(a:text_document_edit['newUri'])
+        let l:options = get(a:text_document_edit, 'options', {})
+
+        if !filereadable(l:uri) || !get(l:options, 'overwrite', v:false)
+            call rename(l:oldUri, l:newUri)
+        endif
+        call s:_switch(l:uri)
+    elseif l:kind == 'delete'
+        let l:uri = lsp#utils#uri_to_path(a:text_document_edit['uri'])
+        let l:options = get(a:text_document_edit, 'options', {})
+        let l:flags = ""
+
+        if isdirectory(l:uri) && get(l:options, "recursive")
+            let l:flags += "r"
+        endif
+        if filereadable(l:uri) || isdirectory(l:uri)
+            call delete(l:uri, l:flags)
+        endif
+    endif
+endfunction
+
 " @summary Use this to convert textedit to vim list that is compatible with
 " quickfix and locllist items
 " @param uri = DocumentUri

--- a/autoload/lsp/utils/workspace_edit.vim
+++ b/autoload/lsp/utils/workspace_edit.vim
@@ -4,7 +4,11 @@ function! lsp#utils#workspace_edit#apply_workspace_edit(workspace_edit) abort
 
     if has_key(a:workspace_edit, 'documentChanges')
         for l:text_document_edit in a:workspace_edit['documentChanges']
-            let l:loclist_items += s:_apply(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
+            if has_key(l:text_document_edit, 'textDocument')
+                let l:loclist_items += s:_apply(l:text_document_edit['textDocument']['uri'], l:text_document_edit['edits'])
+            elseif has_key(l:text_document_edit, 'kind')
+                let l:loclist_items += s:_apply_document(l:text_document_edit)
+            endif
         endfor
     elseif has_key(a:workspace_edit, 'changes')
         for [l:uri, l:text_edits] in items(a:workspace_edit['changes'])
@@ -24,4 +28,29 @@ endfunction
 function! s:_apply(uri, text_edits) abort
     call lsp#utils#text_edit#apply_text_edits(a:uri, a:text_edits)
     return lsp#utils#text_edit#_lsp_to_vim_list(a:uri, a:text_edits)
+endfunction
+
+"
+" _apply_document
+"
+function! s:_apply_document(text_document_edits) abort
+    call lsp#utils#text_edit#apply_text_document_edits(a:text_document_edits)
+    if a:text_document_edits['kind'] == 'create'
+        let l:uri = lsp#utils#uri_to_path(a:text_document_edits['uri'])
+        return [{
+            \ '  filename': l:uri,
+            \   'lnum': 1,
+            \   'col': 1,
+            \   'text': l:uri,
+            \  }]
+    elseif a:text_document_edits['kind'] == 'rename'
+        let l:uri = lsp#utils#uri_to_path(a:text_document_edits['newUri'])
+        return [{
+            \   'filename': l:uri,
+            \   'lnum': 1,
+            \   'col': 1,
+            \   'text': l:uri,
+            \  }]
+    endif
+    return []
 endfunction


### PR DESCRIPTION
Not all [WorkspaceEdits](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit) are text document changes. Add support for create/rename/delete edits.