### PR TITLE
Fix completion item text selection priority

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -85,8 +85,27 @@ function! s:get_filter_label(item) abort
     return lsp#utils#_trim(a:item['word'])
 endfunction
 
+function! s:get_filter_text(item) abort
+    let l:completed_item = lsp#omni#get_managed_user_data_from_completed_item(a:item)
+    if !has_key(l:completed_item, 'completion_item')
+      return ''
+    endif
+
+    if !has_key(l:completed_item['completion_item'], 'filterText')
+      return ''
+    endif
+
+    let l:filter_text = l:completed_item['completion_item']['filterText']
+    if empty(l:filter_text)
+      return ''
+    endif
+
+    return l:filter_text
+endfunction
+
 function! s:prefix_filter(item, last_typed_word) abort
-    let l:label = s:get_filter_label(a:item)
+    let l:filter_text = s:get_filter_text(a:item)
+    let l:label = empty(l:filter_text) ? s:get_filter_label(a:item) : l:filter_text
 
     if g:lsp_ignorecase
         return stridx(tolower(l:label), tolower(a:last_typed_word)) == 0
@@ -96,7 +115,8 @@ function! s:prefix_filter(item, last_typed_word) abort
 endfunction
 
 function! s:contains_filter(item, last_typed_word) abort
-    let l:label = s:get_filter_label(a:item)
+    let l:filter_text = s:get_filter_text(a:item)
+    let l:label = empty(l:filter_text) ? s:get_filter_label(a:item) : l:filter_text
 
     if g:lsp_ignorecase
         return stridx(tolower(l:label), tolower(a:last_typed_word)) >= 0

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -95,12 +95,7 @@ function! s:get_filter_text(item) abort
       return ''
     endif
 
-    let l:filter_text = l:completed_item['completion_item']['filterText']
-    if empty(l:filter_text)
-      return ''
-    endif
-
-    return l:filter_text
+    return l:completed_item['completion_item']['filterText']
 endfunction
 
 function! s:prefix_filter(item, last_typed_word) abort

--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -312,15 +312,7 @@ function! lsp#omni#get_vim_completion_items(options) abort
         let l:range = lsp#utils#text_edit#get_range(get(l:completion_item, 'textEdit', {}))
         let l:complete_word = ''
         if has_key(l:completion_item, 'textEdit') && type(l:completion_item['textEdit']) == s:t_dict && !empty(l:range) && has_key(l:completion_item['textEdit'], 'newText')
-            let l:text_edit_new_text = l:completion_item['textEdit']['newText']
-            if has_key(l:completion_item, 'filterText') && !empty(l:completion_item['filterText']) && matchstr(l:text_edit_new_text, '^' . l:refresh_pattern) ==# ''
-                " Use filterText as word.
-                let l:complete_word = l:completion_item['filterText']
-            else
-                " Use textEdit.newText as word.
-                let l:complete_word = l:text_edit_new_text
-            endif
-
+            let l:complete_word = l:completion_item['textEdit']['newText']
             let l:item_start_character = l:range['start']['character']
             let l:start_character = min([l:item_start_character, l:start_character])
             let l:start_characters += [l:item_start_character]


### PR DESCRIPTION
Hi,

I found vtslp and typescript-language-server complete invalid item.

Steps to reproduce
```typescript
type Address = {
  state?: string
  town?: string
}

type Person = {
  name?: string
  age?: number
  address?: Address
}

const foo: Person = {
  name: 'foo',
  age: 20,                 
}
```

When I type like following

```typescript
foo.address.<c-x><c-o>
            +--------------+
            | state? field |
            | town?  field |
            +--------------+
```
and select `state?`, text insert like following

```typescript
foo.address.?.state
```

expected behavior is

```typescript
foo.address?.state
```

This occurs when filterText exists.
According to the [Language Server Protocol 3.17 specification:](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)

- filterText is only used for filtering and sorting completion items
- filtering should be performed to `filterText`
- When textEdit is provided, insertText must be ignored

In vim-lsp completion context, l:completion_item['filterText'] was set.
I think this is unnecessary.

I would appreciate it if someone could review this.

Before

https://github.com/user-attachments/assets/21ce9284-78d9-4c99-aa88-6585f238d974

After

https://github.com/user-attachments/assets/33b02887-df46-4dcd-9d46-d7d51028ba0a
