### PR TITLE
Fix call hierarchy handler; use extend() instead of exend()

### DIFF
--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -569,7 +569,7 @@ function! s:hierarchy_item_to_vim(item, server) abort
         let l:text .= ": " . a:item['detail']
     endif
 
-    return exend({
+    return extend({
         \ 'filename': l:path,
         \ 'text': l:text,
         \ }, l:loc_range)


### PR DESCRIPTION
## Summary
Running `:LspCallHierarchyIncoming` can get stuck showing `Preparing call hierarchy ...`. With vim-lsp logging enabled, Vim reports `E117: Unknown function: exend` in the call hierarchy handler, even though the LSP server returns valid results.

## Fix
Replace the typo `exend()` with Vim’s builtin `extend()`.

## Steps to reproduce
1. Open a Python file with the basedpyright language server attached.
2. Place the cursor on a function name that is called at least once somewhere and run `:LspCallHierarchyIncoming`.
3. It stays on `Preparing call hierarchy ...`.
4. Enable logging (`let g:lsp_log_verbose = 1`) and repeat; the log shows `E117: Unknown function: exend`.

## Result after this change
`:LspCallHierarchyIncoming` completes normally and shows the incoming calls.
