### PR TITLE
Add 'detail' to completionItem resolveSupport properties

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -549,7 +549,7 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \              'insertReplaceSupport': v:true,
     \              'snippetSupport': v:false,
     \              'resolveSupport': {
-    \                  'properties': ['additionalTextEdits']
+    \                  'properties': ['additionalTextEdits', 'detail']
     \              }
     \           },
     \           'completionItemKind': {


### PR DESCRIPTION
Add `'detail'` to `completionItem.resolveSupport.properties` in `default_get_supported_capabilities`.

Fixes auto import for rust-analyzer >= 1.85.x, which requires the client to advertise `detail` in `resolveSupport` for `additionalTextEdits` (auto imports) to work.

Fixes #1595