### PR TITLE
Add textDocument/documentLink support

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -567,6 +567,9 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'documentHighlight': {
     \           'dynamicRegistration': v:false,
     \       },
+    \       'documentLink': {
+    \           'dynamicRegistration': v:false,
+    \       },
     \       'documentSymbol': {
     \           'dynamicRegistration': v:false,
     \           'symbolKind': {

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -200,3 +200,7 @@ endfunction
 function! lsp#capabilities#has_inlay_hint_provider(server_name) abort
     return s:has_provider(a:server_name, 'inlayHintProvider')
 endfunction
+
+function! lsp#capabilities#has_document_link_provider(server_name) abort
+    return s:has_provider(a:server_name, 'documentLinkProvider')
+endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -433,6 +433,163 @@ function! s:handle_text_edit(server, last_command_id, type, data) abort
     redraw | echo 'Document formatted'
 endfunction
 
+function! lsp#ui#vim#document_link() abort
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_link_provider(v:val)')
+    let l:command_id = lsp#_new_command()
+
+    if len(l:servers) == 0
+        call s:not_supported('Retrieving document links')
+        return
+    endif
+
+    let l:ctx = { 'counter': len(l:servers), 'list': [], 'last_command_id': l:command_id }
+
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'textDocument/documentLink',
+            \ 'params': {
+            \   'textDocument': lsp#get_text_document_identifier(),
+            \ },
+            \ 'on_notification': function('s:handle_document_link', [l:ctx, l:server]),
+            \ })
+    endfor
+
+    echo 'Retrieving document links ...'
+endfunction
+
+function! s:handle_document_link(ctx, server, data) abort
+    if a:ctx['last_command_id'] != lsp#_last_command()
+        return
+    endif
+
+    let a:ctx['counter'] = a:ctx['counter'] - 1
+
+    if lsp#client#is_error(a:data['response']) || !has_key(a:data['response'], 'result')
+        call lsp#utils#error('Failed to retrieve document links for ' . a:server . ': ' . lsp#client#error_message(a:data['response']))
+    elseif a:data['response']['result'] isnot v:null
+        for l:link in a:data['response']['result']
+            let l:range = l:link['range']
+            let [l:start_line, l:start_col] = lsp#utils#position#lsp_to_vim('%', l:range['start'])
+            let l:target = get(l:link, 'target', '')
+            let l:text = l:target
+            if empty(l:text)
+                let l:text = get(l:link, 'tooltip', '(no target)')
+            endif
+            call add(a:ctx['list'], {
+                \ 'filename': expand('%:p'),
+                \ 'lnum': l:start_line,
+                \ 'col': l:start_col,
+                \ 'text': l:text,
+                \ })
+        endfor
+    endif
+
+    if a:ctx['counter'] == 0
+        if empty(a:ctx['list'])
+            call lsp#utils#error('No document links found')
+        else
+            call lsp#ui#vim#utils#setqflist(a:ctx['list'], 'documentLink')
+            echo 'Retrieved document links'
+            botright copen
+        endif
+    endif
+endfunction
+
+function! lsp#ui#vim#document_link_open() abort
+    let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_link_provider(v:val)')
+
+    if len(l:servers) == 0
+        call s:not_supported('Retrieving document links')
+        return
+    endif
+
+    let l:position = lsp#get_position()
+    let l:ctx = { 'counter': len(l:servers), 'position': l:position, 'done': 0 }
+
+    for l:server in l:servers
+        call lsp#send_request(l:server, {
+            \ 'method': 'textDocument/documentLink',
+            \ 'params': {
+            \   'textDocument': lsp#get_text_document_identifier(),
+            \ },
+            \ 'on_notification': function('s:handle_document_link_open', [l:ctx, l:server]),
+            \ })
+    endfor
+
+    echo 'Retrieving document link ...'
+endfunction
+
+function! s:handle_document_link_open(ctx, server, data) abort
+    let a:ctx['counter'] = a:ctx['counter'] - 1
+
+    if a:ctx['done']
+        return
+    endif
+
+    if lsp#client#is_error(a:data['response']) || !has_key(a:data['response'], 'result')
+                \ || a:data['response']['result'] is v:null || empty(a:data['response']['result'])
+        if a:ctx['counter'] == 0
+            call lsp#utils#error('No document link found at cursor position')
+        endif
+        return
+    endif
+
+    let l:cursor_line = a:ctx['position']['line']
+    let l:cursor_char = a:ctx['position']['character']
+
+    " First try exact match (cursor within link range)
+    for l:link in a:data['response']['result']
+        let l:range = l:link['range']
+        if l:range['start']['line'] <= l:cursor_line && l:cursor_line <= l:range['end']['line']
+            if l:cursor_line == l:range['start']['line'] && l:cursor_char < l:range['start']['character']
+                continue
+            endif
+            if l:cursor_line == l:range['end']['line'] && l:cursor_char > l:range['end']['character']
+                continue
+            endif
+            let l:target = get(l:link, 'target', '')
+            if !empty(l:target)
+                let a:ctx['done'] = 1
+                call s:open_document_link_target(l:target)
+                return
+            endif
+        endif
+    endfor
+
+    " Fallback: find link on the same line
+    for l:link in a:data['response']['result']
+        let l:range = l:link['range']
+        if l:range['start']['line'] <= l:cursor_line && l:cursor_line <= l:range['end']['line']
+            let l:target = get(l:link, 'target', '')
+            if !empty(l:target)
+                let a:ctx['done'] = 1
+                call s:open_document_link_target(l:target)
+                return
+            endif
+        endif
+    endfor
+
+    if a:ctx['counter'] == 0
+        call lsp#utils#error('No document link found at cursor position')
+    endif
+endfunction
+
+function! s:open_document_link_target(target) abort
+    if lsp#utils#is_file_uri(a:target)
+        let l:path = lsp#utils#uri_to_path(a:target)
+        execute 'edit' fnameescape(l:path)
+    else
+        if has('mac')
+            call system('open ' . shellescape(a:target) . ' &')
+        elseif has('win32') || has('win64')
+            call system('start "" ' . shellescape(a:target))
+        else
+            call system('xdg-open ' . shellescape(a:target) . ' &')
+        endif
+        echo 'Opened ' . a:target
+    endif
+endfunction
+
 function! lsp#ui#vim#code_action(opts) abort
     call lsp#ui#vim#code_action#do(extend({
         \   'sync': v:false,

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -126,6 +126,8 @@ CONTENTS                                                  *vim-lsp-contents*
       LspDocumentDiagnostics                |:LspDocumentDiagnostics|
       LspDeclaration                        |:LspDeclaration|
       LspDefinition                         |:LspDefinition|
+      LspDocumentLink                       |:LspDocumentLink|
+      LspDocumentLinkOpen                   |:LspDocumentLinkOpen|
       LspDocumentFold                       |:LspDocumentFold|
       LspDocumentFoldSync                   |:LspDocumentFoldSync|
       LspDocumentFormat                     |:LspDocumentFormat|
@@ -1798,6 +1800,18 @@ Go to definition.
 This accepts |<mods>|.
 
 Also see |:LspPeekDefinition|.
+
+LspDocumentLink                                           *:LspDocumentLink*
+
+List all document links in the current buffer in the quickfix list.
+Document links include URLs, file references, and import paths that the
+language server recognizes.
+
+LspDocumentLinkOpen                                   *:LspDocumentLinkOpen*
+
+Open the document link on the current cursor line. If the target is a URL,
+it opens in the default browser. If the target is a file URI, it opens the
+file in the current editor.
 
 LspDocumentFold                                           *:LspDocumentFold*
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -160,6 +160,8 @@ command! LspNextReference call lsp#internal#document_highlight#jump(+1)
 command! LspPreviousReference call lsp#internal#document_highlight#jump(-1)
 command! -nargs=? -bang -complete=customlist,lsp#server_complete_running LspStopServer call lsp#ui#vim#stop_server("<bang>", <f-args>)
 command! -nargs=? -complete=customlist,lsp#utils#empty_complete LspSignatureHelp call lsp#ui#vim#signature_help#get_signature_help_under_cursor()
+command! LspDocumentLink call lsp#ui#vim#document_link()
+command! LspDocumentLinkOpen call lsp#ui#vim#document_link_open()
 command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
 command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
 command! -nargs=0 LspSemanticTokenTypes echo lsp#internal#semantic#get_token_types()
@@ -211,6 +213,8 @@ nnoremap <silent> <plug>(lsp-peek-implementation) :<c-u>call lsp#ui#vim#implemen
 nnoremap <silent> <plug>(lsp-status) :<c-u>echo lsp#get_server_status()<cr>
 nnoremap <silent> <plug>(lsp-next-reference) :<c-u>call lsp#internal#document_highlight#jump(+1)<cr>
 nnoremap <silent> <plug>(lsp-previous-reference) :<c-u>call lsp#internal#document_highlight#jump(-1)<cr>
+nnoremap <silent> <plug>(lsp-document-link) :<c-u>call lsp#ui#vim#document_link()<cr>
+nnoremap <silent> <plug>(lsp-document-link-open) :<c-u>call lsp#ui#vim#document_link_open()<cr>
 nnoremap <silent> <plug>(lsp-signature-help) :<c-u>call lsp#ui#vim#signature_help#get_signature_help_under_cursor()<cr>
 
 if has('gui_running')


### PR DESCRIPTION
Add support for `textDocument/documentLink` LSP method.

- `:LspDocumentLink` lists all document links in the quickfix list
- `:LspDocumentLinkOpen` opens the document link on the current cursor line (URL in browser, file URI in editor)
- `<plug>(lsp-document-link)` and `<plug>(lsp-document-link-open)` mappings
- Registers `documentLink` client capability so language servers know the client supports it