### PR TITLE
Fix invalid LSP buffer state after buffer delete or wipeout

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -253,15 +253,14 @@ function! s:register_events() abort
         autocmd BufNewFile * call s:on_text_document_did_open()
         autocmd BufReadPost * call s:on_text_document_did_open()
         autocmd BufWritePost * call s:on_text_document_did_save()
-        autocmd BufWinLeave * call s:on_text_document_did_close()
-        autocmd BufWipeout * call s:on_buf_wipeout(expand('<afile>'))
+        autocmd BufDelete,BufWipeout * call s:on_text_document_did_close(str2nr(expand('<abuf>')))
         autocmd InsertLeave * call s:on_text_document_did_change()
         autocmd TextChanged * call s:on_text_document_did_change()
         if exists('##TextChangedP')
             autocmd TextChangedP * call s:on_text_document_did_change()
         endif
         if g:lsp_untitled_buffer_enabled
-            autocmd FileType * call s:on_filetype_changed(bufnr(expand('<afile>')))
+            autocmd FileType * call s:on_filetype_changed(str2nr(expand('<abuf>')))
         endif
     augroup END
 
@@ -280,9 +279,15 @@ function! s:unregister_events() abort
 endfunction
 
 function! s:on_filetype_changed(buf) abort
-  call s:on_buf_wipeout(a:buf)
+  if a:buf <= 0
+    return
+  endif
+  if !empty(bufname(a:buf))
+    return
+  endif
+  call s:on_buf_wipeout(a:buf, v:false)
   " TODO: stop unused servers
-  call s:on_text_document_did_open()
+  call s:on_text_document_did_open(a:buf)
 endfunction
 
 function! s:on_text_document_did_open(...) abort
@@ -366,10 +371,42 @@ function! s:call_did_save(buf, server_name, result, cb) abort
     call a:cb(l:msg)
 endfunction
 
-function! s:on_text_document_did_close() abort
-    let l:buf = bufnr('%')
+function! s:on_buf_wipeout(buf, send_did_close) abort
+    if a:buf <= 0
+        return
+    endif
+
+    let l:path = lsp#utils#get_buffer_uri(a:buf)
+    if !empty(l:path)
+        for [l:server_name, l:server] in items(s:servers)
+            if !has_key(l:server, 'buffers') || !has_key(l:server['buffers'], l:path)
+                continue
+            endif
+
+            if a:send_did_close && get(l:server, 'lsp_id', 0) > 0
+                call s:send_notification(l:server_name, {
+                    \ 'method': 'textDocument/didClose',
+                    \ 'params': {
+                    \   'textDocument': { 'uri': l:path },
+                    \ }
+                    \ })
+            endif
+
+            call remove(l:server['buffers'], l:path)
+        endfor
+    endif
+
+    if has_key(s:file_content, a:buf)
+        call remove(s:file_content, a:buf)
+    endif
+    call lsp#internal#listener#stop(a:buf)
+endfunction
+
+function! s:on_text_document_did_close(...) abort
+    let l:buf = a:0 > 0 ? a:1 : bufnr('%')
     if getbufvar(l:buf, '&buftype') ==# 'terminal' | return | endif
     call lsp#log('s:on_text_document_did_close()', l:buf)
+    call s:on_buf_wipeout(l:buf, v:true)
 endfunction
 
 function! s:get_last_file_content(buf, server_name) abort
@@ -385,13 +422,6 @@ function! s:update_file_content(buf, server_name, new) abort
     endif
     call lsp#log('s:update_file_content()', a:buf)
     let s:file_content[a:buf][a:server_name] = a:new
-endfunction
-
-function! s:on_buf_wipeout(buf) abort
-    if has_key(s:file_content, a:buf)
-        call remove(s:file_content, a:buf)
-    endif
-    call lsp#internal#listener#stop(a:buf)
 endfunction
 
 function! lsp#ensure_flush_all(buf, server_names) abort
@@ -802,6 +832,15 @@ function! s:ensure_changed(buf, server_name, cb) abort
         return
     endif
 
+    let l:content_changes = s:text_changes(a:buf, a:server_name)
+    if type(l:content_changes) == type([]) && empty(l:content_changes)
+        let l:buffer_info['changed_tick'] = l:changed_tick
+        let l:msg = s:new_rpc_success('not dirty', { 'server_name': a:server_name, 'path': l:path })
+        call lsp#log_verbose(l:msg)
+        call a:cb(l:msg)
+        return
+    endif
+
     let l:buffer_info['changed_tick'] = l:changed_tick
     let l:buffer_info['version'] = l:buffer_info['version'] + 1
 
@@ -809,7 +848,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
         \ 'method': 'textDocument/didChange',
         \ 'params': {
         \   'textDocument': s:get_versioned_text_document_identifier(a:buf, l:buffer_info),
-        \   'contentChanges': s:text_changes(a:buf, a:server_name),
+        \   'contentChanges': l:content_changes,
         \ }
         \ })
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)


### PR DESCRIPTION
Hi, I found that repeatedly jumping to a definition target buffer and deleting it can eventually break LSP operations in vim-lsp.

In my case, repeating `:LspDefinition` on a TypeScript(vtsls) symbol and then deleting the opened definition buffer eventually caused definition requests to stop working, and the language server became unusable for further LSP operations.

## Steps to reproduce

1. create a.ts and add `console.log('foo');`
2. set cursor to console and type `:LspDefeinition`
3. jump to lib.dom.d.ts
4. type `:bdelete` and move to a.ts automatically
5. repeate 2 - 4
6. Display `Retrieving definition not supported for filetype 'typescript'`

minimam vimrc
```vim
set nocompatible

let s:vim_lsp_dir = expand('~/.vim/pack/bundle/opt/vim-lsp')
execute 'set runtimepath^=' .. fnameescape(s:vim_lsp_dir)
if isdirectory(s:vim_lsp_dir . '/after')
  execute 'set runtimepath+=' .. fnameescape(s:vim_lsp_dir . '/after')
endif

filetype plugin on
syntax on
set hidden
set updatetime=1000

language message C
language time C

" path to vtsls
let s:vtsls = expand('/tmp/servers/vtsls/vtsls')

augroup minimal_vim_lsp
  autocmd!
  autocmd User lsp_setup call lsp#register_server({
    \ 'name': 'vtsls',
    \ 'cmd': {server_info -> [s:vtsls, '--stdio']},
    \ 'allowlist': ['typescript'],
    \ })
  autocmd BufEnter lib.dom.d.ts sleep 1500m
augroup END

function! s:wait_for_buffer(name, timeout_ms) abort
  let l:start = reltime()
  while reltimefloat(reltime(l:start)) * 1000 < a:timeout_ms
    if expand('%:t') ==# a:name
      return 1
    endif
    sleep 100m
  endwhile
  return 0
endfunction

function! s:repro() abort
  let l:src = bufnr('%')

  for l:i in range(10)
    execute 'buffer' l:src
    call search('\<console\>', 'W')
    call lsp#ui#vim#definition(0)

    if !s:wait_for_buffer('lib.dom.d.ts', 10000)
      echoerr printf('definition jump timeout at iteration %d', l:i + 1)
      return
    endif

    bdelete!
  endfor

  execute 'buffer' l:src
  call search('\<console\>', 'W')
  call lsp#ui#vim#definition(0)

  if !s:wait_for_buffer('lib.dom.d.ts', 10000)
    echoerr 'final definition jump timeout'
    return
  endif

  echo 'ok'
endfunction

command! Repro call s:repro()
```
open a.ts and `:Repro` shows `Retrieving definition not supported for filetype 'typescript'`

When vim-lsp started showing `Retrieving definition not supported for filetype 'typescript'`,
the actual problem was that vtsls had already crashed and logged an exception.

Part of the log when the server crashed

```log
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","node:internal/process/promises:394"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    triggerUncaughtException(err, true /* fromPromise */);"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    ^"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls",""]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","_TypeScriptServerError: <syntax> TypeScript Server Error (5.9.3)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","Error: Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at computePositionOfLineAndCharacter (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:11689:13)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at TextStorage.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186656:59)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at ScriptInfo.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186964:29)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194119:38"]
Mon Mar 30 16:48:20 2026:["s:on_exit",1,"vtsls","exited",1]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at mapDefinedIterator (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:2616:19)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at mapDefinedIterator.next (<anonymous>)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at _ProjectService.applyChangesToFile (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192901:16)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at _ProjectService.applyChangesInOpenFiles (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192858:14)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at updateOpen (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194107:29)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196832:15"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at IpcIOSession.executeWithRequestId (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196821:14)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at IpcIOSession.executeCommand (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196830:29)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at IpcIOSession.onMessage (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196878:68)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at process.<anonymous> (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/_tsserver.js:519:14)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at process.emit (node:events:508:28)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at emit (node:internal/child_process:948:14)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at process.processTicksAndRejections (node:internal/process/task_queues:91:21)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at _TypeScriptServerError.create (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/@vtsls/language-service/dist/index.js:6253:16)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at _SingleTsServer.dispatchResponse (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/@vtsls/language-service/dist/index.js:6447:50)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at _SingleTsServer.dispatchMessage (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/@vtsls/language-service/dist/index.js:6379:22)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at ChildProcess.<anonymous> (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/@vtsls/language-service/dist/index.js:6340:16)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at ChildProcess.emit (node:events:508:28)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at emit (node:internal/child_process:948:14)"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    at process.processTicksAndRejections (node:internal/process/task_queues:91:21) {"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","  serverId: 'syntax',"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","  version: TypeScriptVersion {"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    source: 'ts-nightly-extension',"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    path: '/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/tsserver.js',"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    apiVersion: _API {"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","      displayName: '5.9.3',"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","      version: '5.9.3',"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","      fullVersionString: '5.9.3'"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    },"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    _pathLabel: ''"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","  },"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","  response: {"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    seq: 0,"]
Mon Mar 30 16:48:20 2026:["<---(stderr)",1,"vtsls","    type: 'response',"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    command: 'updateOpen',"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    request_seq: 9,"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    success: false,"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    message: 'Error processing request. Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      'Error: Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at computePositionOfLineAndCharacter (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:11689:13)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at TextStorage.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186656:59)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at ScriptInfo.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186964:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194119:38\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at mapDefinedIterator (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:2616:19)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at mapDefinedIterator.next (<anonymous>)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at _ProjectService.applyChangesToFile (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192901:16)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at _ProjectService.applyChangesInOpenFiles (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192858:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at updateOpen (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194107:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196832:15\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at IpcIOSession.executeWithRequestId (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196821:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at IpcIOSession.executeCommand (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196830:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at IpcIOSession.onMessage (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196878:68)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at process.<anonymous> (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/_tsserver.js:519:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at process.emit (node:events:508:28)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at emit (node:internal/child_process:948:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","      '    at process.processTicksAndRejections (node:internal/process/task_queues:91:21)',"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    _serverType: 'syntax'"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","  },"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","  serverMessage: 'Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true',"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","  serverStack: 'Error: Debug Failure. Bad line number. Line: 39430, lineStarts.length: 39430 , line map is correct? true\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at computePositionOfLineAndCharacter (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:11689:13)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at TextStorage.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186656:59)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at ScriptInfo.lineOffsetToPosition (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:186964:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194119:38\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at mapDefinedIterator (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:2616:19)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at mapDefinedIterator.next (<anonymous>)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at _ProjectService.applyChangesToFile (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192901:16)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at _ProjectService.applyChangesInOpenFiles (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:192858:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at updateOpen (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:194107:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at /tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196832:15\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at IpcIOSession.executeWithRequestId (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196821:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at IpcIOSession.executeCommand (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196830:29)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at IpcIOSession.onMessage (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/typescript.js:196878:68)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at process.<anonymous> (/tmp/.local/share/vim-lsp-settings/servers/vtsls/node_modules/typescript/lib/_tsserver.js:519:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at process.emit (node:events:508:28)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at emit (node:internal/child_process:948:14)\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    '    at process.processTicksAndRejections (node:internal/process/task_queues:91:21)',"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","  sanitizedStack: 'suppressed.js:11689:13\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:186656:59\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:186964:29\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:194119:38\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:2616:19\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:192901:16\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:192858:14\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:194107:29\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:196832:15\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:196821:14\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:196830:29\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:196878:68\\n' +"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","    'suppressed.js:519:14\\n'"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","}"]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls",""]
Mon Mar 30 16:48:21 2026:["<---(stderr)",1,"vtsls","Node.js v24.14.0"]
```

## Cause

Buffer deletion did not consistently perform didClose handling and internal cleanup, and related buffer lifecycle paths had additional state management issues.                                                          

## Solution

Run close/cleanup logic on actual buffer deletion events, clean up internal buffer state consistently, and skip empty didChange notifications.


## before

https://github.com/user-attachments/assets/bcdba813-8103-419a-8984-e0fc90235e5f

## after

https://github.com/user-attachments/assets/87cc5fb0-bd55-491d-b165-464f8e79ca29