### PR TITLE
Improve workspace symbol search performance

### DIFF
--- a/autoload/lsp/internal/workspace_symbol/search.vim
+++ b/autoload/lsp/internal/workspace_symbol/search.vim
@@ -8,7 +8,7 @@ function! lsp#internal#workspace_symbol#search#do(options) abort
     if has_key(a:options, 'server')
         let l:servers = [a:options['server']]
     else
-        let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_document_symbol_provider(v:val)')
+        let l:servers = filter(lsp#get_allowed_servers(), 'lsp#capabilities#has_workspace_symbol_provider(v:val)')
     endif
 
     if len(l:servers) == 0
@@ -71,14 +71,45 @@ endfunction
 function! s:update_ui_items(x) abort
     let l:items = []
     for l:i in a:x
-        let l:items += lsp#ui#vim#utils#symbols_to_loc_list(l:i['server'], l:i)
+        let l:items += s:workspace_symbols_to_ui_list(l:i['server'], l:i)
     endfor
     call lsp#internal#ui#quickpick#items(l:items)
 endfunction
 
+function! s:workspace_symbols_to_ui_list(server, result) abort
+    if !has_key(a:result['response'], 'result')
+        return []
+    endif
+
+    let l:list = []
+
+    let l:entries = type(a:result['response']['result']) == type({}) ? [a:result['response']['result']] : a:result['response']['result']
+
+    if !empty(l:entries) " some servers also return null so check to make sure it isn't empty
+        for l:symbol in a:result['response']['result']
+            let l:location = l:symbol['location']
+            call add(l:list, {
+              \ 'uri': l:location['uri'],
+              \ 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . (g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name']),
+              \ 'range': l:location['range']
+              \ })
+        endfor
+    endif
+
+    return l:list
+endfunction
+
+
 function! s:on_accept(data, name) abort
     call lsp#internal#ui#quickpick#close()
-    call lsp#utils#location#_open_vim_list_item(a:data['items'][0], '')
+    let l:data = a:data['items'][0]
+    let l:path = lsp#utils#uri_to_path(l:data['uri'])
+    let [l:line, l:col] = lsp#utils#position#lsp_to_vim(l:path, l:data['range']['start'])
+    call lsp#utils#location#_open_vim_list_item({
+      \ 'filename': l:path,
+      \ 'lnum': l:line,
+      \ 'col': l:col,
+      \ }, '')
 endfunction
 
 function! s:on_close(...) abort


### PR DESCRIPTION
Workspace symbol search is slow with many symbols because vim locations for all symbols are calculated when generating the quickpick list, even though they are only required when selecting a symbol to open a location. Fix by delaying calculating the vim location until a symbol is selected.

I may be an unusual case, but there are over 75,000 symbols in the js monorepo I'm currently working with.

**before**
```
FUNCTION  lsp#ui#vim#utils#symbols_to_loc_list()
    Defined: ~/dotfiles/vim/pack/bundle/opt/vim-lsp/autoload/lsp/ui/vim/utils.vim:55
Called 1 time
Total time:  91.883434000
 Self time:   2.045618000

count     total (s)      self (s)
    1                 0.000001000     if !has_key(a:result['response'], 'result')
                                          return []
    1                 0.000001000     endif
                                  
    1                 0.000001000     let l:list = []
                                  
    1                 0.000004000     let l:locations = type(a:result['response']['result']) == type({}) ? [a:result['response']['result']] : a:result['response']['result']
                                  
    1                 0.000001000     if !empty(l:locations) " some servers also return null so check to make sure it isn't empty
76656                 0.046242000         for l:symbol in a:result['response']['result']
76655                 0.088684000             if has_key(l:symbol, 'location')
76655                 0.077596000                 let l:location = l:symbol['location']
76655   0.228495000   0.120610000                 if lsp#utils#is_file_uri(l:location['uri'])
76655   0.395069000   0.133293000                     let l:path = lsp#utils#uri_to_path(l:location['uri'])
76655  88.939279000   0.194759000                     let l:loc_range = lsp#utils#range#lsp_to_vim_loc(l:path, l:location['range'])
76655   1.162058000   0.438423000                     call add(l:list, extend({ 'filename': l:path, 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . (g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name']), }, l:loc_range))
76655                 0.024961000                 endif
                                              else
                                                  let l:location = a:result['request']['params']['textDocument']['uri']
                                                  if lsp#utils#is_file_uri(l:location)
                                                      let l:path = lsp#utils#uri_to_path(l:location)
                                                      let l:loc_range = lsp#utils#range#lsp_to_vim_loc(l:path, l:symbol['range'])
                                                      call add(l:list, extend({ 'filename': l:path, 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . (g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name']), }, l:loc_range))
                                                      if has_key(l:symbol, 'children') && !empty(l:symbol['children'])
                                                          call s:symbols_to_loc_list_children(a:server, l:path, l:list, l:symbol['children'], 1)
                                                      endif
                                                  endif
76655                 0.021519000             endif
76656                 0.024853000         endfor
    1                 0.000000000     endif
                                  
    1                 0.000001000     return l:list
```

**after**
```
FUNCTION  <SNR>272_workspace_symbols_to_ui_list()
    Defined: ~/dotfiles/vim/pack/bundle/opt/vim-lsp/autoload/lsp/internal/workspace_symbol/search.vim:79
Called 1 time
Total time:   1.158300000
 Self time:   0.527611000

count     total (s)      self (s)
    1                 0.000001000     if !has_key(a:result['response'], 'result')
                                          return []
    1                 0.000001000     endif
                                  
    1                 0.000001000     let l:list = []
                                  
    1                 0.000005000     let l:entries = type(a:result['response']['result']) == type({}) ? [a:result['response']['result']] : a:result['response']['result']
                                  
    1                 0.000002000     if !empty(l:entries) " some servers also return null so check to make sure it isn't empty
76656                 0.042634000         for l:symbol in a:result['response']['result']
76655                 0.071670000             let l:location = l:symbol['location']
76655   1.007334000   0.376645000             call add(l:list, { 'uri': l:location['uri'], 'text': lsp#ui#vim#utils#_get_symbol_text_from_kind(a:server, l:symbol['kind']) . ' : ' . (g:lsp_document_symbol_detail ? l:symbol['detail'] : l:symbol['name']), 'range': l:location['range'] })
76656                 0.024115000         endfor
    1                 0.000001000     endif
                                  
    1                 0.000001000     return l:list
```