### PR TITLE
Skip calling complete() in omnifunc when there are no matches

### DIFF
--- a/autoload/lsp/omni.vim
+++ b/autoload/lsp/omni.vim
@@ -154,7 +154,7 @@ function! s:display_completions(timer, info) abort
 
     let s:completion['status'] = ''
 
-    if mode() is# 'i'
+    if mode() is# 'i' && !empty(s:completion['matches'])
         call complete(s:completion['startcol'], s:completion['matches'])
     endif
 endfunction


### PR DESCRIPTION
I want to use items from 'complete' sources when LSP has no completion items (for example, inside string literals or comments).
Before this change, the empty completion items from LSP closed the completion menu triggered by i_CTRL-N or 'autocomplete', and discarded those items.
 
After this change, the items from 'complete' sources stay visible when LSP returns no completion items.