### PR TITLE
adopt lsp#scroll bindings in readme which don't clobber normal <c-d> and <c-f>

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ function! s:on_lsp_buffer_enabled() abort
     nmap <buffer> [g <plug>(lsp-previous-diagnostic)
     nmap <buffer> ]g <plug>(lsp-next-diagnostic)
     nmap <buffer> K <plug>(lsp-hover)
-    nnoremap <buffer> <expr><c-f> lsp#scroll(+4)
-    nnoremap <buffer> <expr><c-d> lsp#scroll(-4)
+    nmap <expr><buffer> <c-d> popup_list()->empty() ? '<c-d>' : lsp#scroll(+4)
+    nmap <expr><buffer> <c-u> popup_list()->empty() ? '<c-u>' : lsp#scroll(-4)
 
     let g:lsp_format_sync_timeout = 1000
     autocmd! BufWritePre *.rs,*.go call execute('LspDocumentFormatSync')


### PR DESCRIPTION
Suggested by @cherryeclipseworks

https://github.com/prabirshrestha/vim-lsp/issues/1522#issuecomment-1867592487

For me it worked but took time to find, so it should probably go in the README.

@enemychrome maybe suggests that it didn’t work. Would need to check but I have a fairly minimal/clean vim setup so I would assume it should work generally and was some interference from something else in his setup (?)

https://github.com/prabirshrestha/vim-lsp/issues/1588#issuecomment-2525348618