### PR TITLE
Add toggles for disabling auto open location/quickfix list

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,16 @@ You can get detailed status on your servers using `:CheckHealth` with a plugin o
 if !has('nvim') | Plug 'rhysd/vim-healthcheck' | endif
 CheckHealth
 ```
+## Toggle location and quickfix behaviour
 
+The default behaviour is to open the location or quickfix list automatically
+when triggering a command.
+
+You may use the the configuration parameters below to prevent this from happening:
+```vim
+let g:lsp_auto_open_loclist = 0
+let g:lsp_auto_open_qflist = 0
+```
 ## Tests
 
 [vim-themis](https://github.com/thinca/vim-themis) is used for testing. To run

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ CheckHealth
 The default behaviour is to open the location or quickfix list automatically
 when triggering a command.
 
-You may use the the configuration parameters below to prevent this from happening:
+You may use the configuration parameters below to prevent this from happening:
 ```vim
 let g:lsp_auto_open_loclist = 0
 let g:lsp_auto_open_qflist = 0

--- a/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
+++ b/autoload/lsp/internal/diagnostics/document_diagnostics_command.vim
@@ -35,6 +35,6 @@ function! lsp#internal#diagnostics#document_diagnostics_command#do(options) abor
     else
         call setloclist(0, l:result)
         echo 'Retrieved diagnostics results'
-        botright lopen
+        call lsp#utils#maybe_execute_list_command('location', 'botright lopen')
     endif
 endfunction

--- a/autoload/lsp/ui/vim.vim
+++ b/autoload/lsp/ui/vim.vim
@@ -288,7 +288,7 @@ function! s:handle_symbol(server, last_command_id, type, data) abort
         call lsp#utils#error('No ' . a:type .' found')
     else
         echo 'Retrieved ' . a:type
-        botright copen
+        call lsp#utils#maybe_execute_list_command('quickfix', 'botright copen')
     endif
 endfunction
 
@@ -327,7 +327,7 @@ function! s:handle_location(ctx, server, type, data) abort "ctx = {counter, list
                 endif
                 call lsp#ui#vim#utils#setqflist(a:ctx['list'], a:type)
                 echo 'Retrieved ' . a:type
-                botright copen
+                call lsp#utils#maybe_execute_list_command('quickfix', 'botright copen')
                 if get(a:ctx, 'add_tree', v:false)
                     " move the cursor to the newly added item
                     execute l:pos + 1
@@ -490,7 +490,7 @@ function! s:handle_document_link(ctx, server, data) abort
         else
             call lsp#ui#vim#utils#setqflist(a:ctx['list'], 'documentLink')
             echo 'Retrieved document links'
-            botright copen
+            call lsp#utils#maybe_execute_list_command('quickfix', 'botright copen')
         endif
     endif
 endfunction
@@ -704,7 +704,7 @@ function! s:handle_call_hierarchy(ctx, server, type, data) abort
             endif
             call lsp#ui#vim#utils#setqflist(a:ctx['list'], a:type)
             echo 'Retrieved ' . a:type
-            botright copen
+            call lsp#utils#maybe_execute_list_command('quickfix', 'botright copen')
             if get(a:ctx, 'add_tree', v:false)
                 " move the cursor to the newly added item
                 execute l:pos + 1

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -195,6 +195,20 @@ function! lsp#utils#get_buffer_uri(...) abort
     return lsp#utils#path_to_uri(fnamemodify(l:name, ':p'))
 endfunction
 
+function! lsp#utils#maybe_execute_list_command(kind, cmd) abort
+  if a:kind ==# 'location'
+    if !get(g:, 'lsp_auto_open_loclist', 1)
+      return
+    endif
+  elseif a:kind ==# 'quickfix'
+    if !get(g:, 'lsp_auto_open_qflist', 1)
+      return
+    endif
+  endif
+
+  execute a:cmd
+endfunction
+
 " Find a nearest to a `path` parent directory `directoryname` by traversing the filesystem upwards
 function! lsp#utils#find_nearest_parent_directory(path, directoryname) abort
     let l:relative_path = finddir(a:directoryname, fnameescape(a:path) . ';')

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -196,17 +196,17 @@ function! lsp#utils#get_buffer_uri(...) abort
 endfunction
 
 function! lsp#utils#maybe_execute_list_command(kind, cmd) abort
-  if a:kind ==# 'location'
-    if !get(g:, 'lsp_auto_open_loclist', 1)
-      return
+    if a:kind ==# 'location'
+        if !get(g:, 'lsp_auto_open_loclist', 1)
+            return
+        endif
+    elseif a:kind ==# 'quickfix'
+        if !get(g:, 'lsp_auto_open_qflist', 1)
+            return
+        endif
     endif
-  elseif a:kind ==# 'quickfix'
-    if !get(g:, 'lsp_auto_open_qflist', 1)
-      return
-    endif
-  endif
 
-  execute a:cmd
+    execute a:cmd
 endfunction
 
 " Find a nearest to a `path` parent directory `directoryname` by traversing the filesystem upwards

--- a/autoload/lsp/utils/workspace_edit.vim
+++ b/autoload/lsp/utils/workspace_edit.vim
@@ -14,7 +14,7 @@ function! lsp#utils#workspace_edit#apply_workspace_edit(workspace_edit) abort
 
     if g:lsp_show_workspace_edits
         call setloclist(0, l:loclist_items, 'r')
-        execute 'lopen'
+        call lsp#utils#maybe_execute_list_command('location', 'lopen')
     endif
 endfunction
 

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -5,6 +5,8 @@ let g:lsp_loaded = 1
 
 let g:lsp_use_lua = get(g:, 'lsp_use_lua', has('nvim-0.4.0') || (has('lua') && has('patch-8.2.0775')))
 let g:lsp_use_native_client = get(g:, 'lsp_use_native_client', 0)
+let g:lsp_auto_open_loclist = get(g:, 'lsp_auto_open_loclist', 1)
+let g:lsp_auto_open_qflist = get(g:, 'lsp_auto_open_qflist', 1)
 let g:lsp_auto_enable = get(g:, 'lsp_auto_enable', 1)
 let g:lsp_async_completion = get(g:, 'lsp_async_completion', 0)
 let g:lsp_log_file = get(g:, 'lsp_log_file', '')


### PR DESCRIPTION
Hi all,

First of all, Thank you for the great plugin. I use your plugin everyday and am very grateful. 

I am submitting this change set to get an idea from you if you think it would be a useful addition to your ecosystem. 

Just because you trigger a gd or gr, etc, shouldn't always move focus away from the window you're working on. I didn't want this and applied some hacks to prevent this from happening. I've now been using this for a couple of months and find it quite nice. 

The change needs the addition of a couple of global options to maintain compatibility with the current behaviour. 

This is actually my first ever PR on an open source project. Vimscript isn't even something that I would list as something I'm great at. Any feedback would be highly appreciate. You can also say this isn't a useful feature to add. That's fine. 

I haven't added any tests for this (I actually don't know how to do that - but hey, if this is something that's interesting to add to vim-lsp, I can dig further into the tests/ directory)

I'm just sharing this because I thought that maybe this is something useful for others too.

Rohail