### PR TITLE
Support pull diagnostics and add state tests

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -854,6 +854,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
         \   'contentChanges': l:content_changes,
         \ }
         \ })
+    call s:send_document_diagnostic_request(a:buf, a:server_name)
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/didChange sent', { 'server_name': a:server_name, 'path': l:path })
@@ -898,6 +899,7 @@ function! s:ensure_open(buf, server_name, cb) abort
         \ },
         \ })
 
+    call s:send_document_diagnostic_request(a:buf, a:server_name)
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/open sent', { 'server_name': a:server_name, 'path': l:path, 'filetype': getbufvar(a:buf, '&filetype') })
@@ -1305,6 +1307,41 @@ endfunction
 
 let s:didchange_queue = []
 let s:didchange_timer = -1
+
+function! s:on_document_diagnostic_response(server_name, client_id, data, event) abort
+    call lsp#internal#diagnostics#state#_handle_text_document_diagnostic(a:server_name, a:data['request'], a:data['response'])
+endfunction
+
+function! s:send_document_diagnostic_request(buf, server_name) abort
+    if !g:lsp_diagnostics_enabled || !lsp#capabilities#has_diagnostic_provider(a:server_name)
+        return
+    endif
+
+    let l:uri = lsp#utils#get_buffer_uri(a:buf)
+    if empty(l:uri)
+        return
+    endif
+
+    let l:provider = lsp#capabilities#get_diagnostic_provider(a:server_name)
+    let l:identifier = get(l:provider, 'identifier', '')
+    let l:params = {
+        \ 'textDocument': s:get_text_document_identifier(a:buf),
+        \ }
+    if !empty(l:identifier)
+        let l:params['identifier'] = l:identifier
+    endif
+
+    let l:previous_result_id = lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, a:server_name, l:identifier)
+    if !empty(l:previous_result_id)
+        let l:params['previousResultId'] = l:previous_result_id
+    endif
+
+    call s:send_request(a:server_name, {
+        \ 'method': 'textDocument/diagnostic',
+        \ 'params': l:params,
+        \ 'on_notification': function('s:on_document_diagnostic_response', [a:server_name]),
+        \ })
+endfunction
 
 function! s:add_didchange_queue(buf) abort
     if g:lsp_use_event_queue == 0

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -854,6 +854,7 @@ function! s:ensure_changed(buf, server_name, cb) abort
         \   'contentChanges': l:content_changes,
         \ }
         \ })
+    call s:send_document_diagnostic_request(a:buf, a:server_name)
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/didChange sent', { 'server_name': a:server_name, 'path': l:path })
@@ -898,6 +899,7 @@ function! s:ensure_open(buf, server_name, cb) abort
         \ },
         \ })
 
+    call s:send_document_diagnostic_request(a:buf, a:server_name)
     call lsp#ui#vim#folding#send_request(a:server_name, a:buf, 0)
 
     let l:msg = s:new_rpc_success('textDocument/open sent', { 'server_name': a:server_name, 'path': l:path, 'filetype': getbufvar(a:buf, '&filetype') })
@@ -1309,6 +1311,41 @@ endfunction
 
 let s:didchange_queue = []
 let s:didchange_timer = -1
+
+function! s:on_document_diagnostic_response(server_name, client_id, data, event) abort
+    call lsp#internal#diagnostics#state#_handle_text_document_diagnostic(a:server_name, a:data['request'], a:data['response'])
+endfunction
+
+function! s:send_document_diagnostic_request(buf, server_name) abort
+    if !g:lsp_diagnostics_enabled || !lsp#capabilities#has_diagnostic_provider(a:server_name)
+        return
+    endif
+
+    let l:uri = lsp#utils#get_buffer_uri(a:buf)
+    if empty(l:uri)
+        return
+    endif
+
+    let l:provider = lsp#capabilities#get_diagnostic_provider(a:server_name)
+    let l:identifier = get(l:provider, 'identifier', '')
+    let l:params = {
+        \ 'textDocument': s:get_text_document_identifier(a:buf),
+        \ }
+    if !empty(l:identifier)
+        let l:params['identifier'] = l:identifier
+    endif
+
+    let l:previous_result_id = lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, a:server_name, l:identifier)
+    if !empty(l:previous_result_id)
+        let l:params['previousResultId'] = l:previous_result_id
+    endif
+
+    call s:send_request(a:server_name, {
+        \ 'method': 'textDocument/diagnostic',
+        \ 'params': l:params,
+        \ 'on_notification': function('s:on_document_diagnostic_response', [a:server_name]),
+        \ })
+endfunction
 
 function! s:add_didchange_queue(buf) abort
     if g:lsp_use_event_queue == 0

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -109,6 +109,19 @@ function! lsp#capabilities#has_call_hierarchy_provider(server_name) abort
     return s:has_provider(a:server_name, 'callHierarchyProvider')
 endfunction
 
+function! lsp#capabilities#has_diagnostic_provider(server_name) abort
+    return s:has_provider(a:server_name, 'diagnosticProvider')
+endfunction
+
+function! lsp#capabilities#get_diagnostic_provider(server_name) abort
+    let l:capabilities = lsp#get_server_capabilities(a:server_name)
+    if !empty(l:capabilities) && has_key(l:capabilities, 'diagnosticProvider')
+        let l:provider = l:capabilities['diagnosticProvider']
+        return type(l:provider) == type({}) ? l:provider : {}
+    endif
+    return {}
+endfunction
+
 function! lsp#capabilities#has_semantic_tokens(server_name) abort
     return s:has_provider(a:server_name, 'semanticTokensProvider')
 endfunction

--- a/autoload/lsp/internal/diagnostics/state.vim
+++ b/autoload/lsp/internal/diagnostics/state.vim
@@ -19,6 +19,7 @@
 " buffer state is removed when server exits.
 " TODO: reset buffer state when server initializes. ignoring for now for perf.
 let s:diagnostics_state = {}
+let s:diagnostic_result_ids = {}
 
 " internal state for whether it is enabled or not to avoid multiple subscriptions
 let s:enabled = 0
@@ -73,6 +74,7 @@ endfunction
 
 function! lsp#internal#diagnostics#state#_reset() abort
     let s:diagnostics_state = {}
+    let s:diagnostic_result_ids = {}
     let s:diagnostics_disabled_buffers = {}
 endfunction
 
@@ -105,12 +107,62 @@ function! s:on_text_documentation_publish_diagnostics(server, response) abort
     call s:notify_diagnostics_update(a:server, l:normalized_uri)
 endfunction
 
+function! lsp#internal#diagnostics#state#_get_previous_result_id(uri, server, identifier) abort
+    let l:normalized_uri = lsp#utils#normalize_uri(a:uri)
+    let l:server_result_ids = get(get(s:diagnostic_result_ids, l:normalized_uri, {}), a:server, {})
+    return get(l:server_result_ids, a:identifier, '')
+endfunction
+
+function! lsp#internal#diagnostics#state#_handle_text_document_diagnostic(server, request, response) abort
+    if lsp#client#is_error(a:response) | return | endif
+    if !has_key(a:request, 'params') || !has_key(a:request['params'], 'textDocument')
+        return
+    endif
+    if !has_key(a:response, 'result') || type(a:response['result']) != type({})
+        return
+    endif
+
+    let l:uri = a:request['params']['textDocument']['uri']
+    let l:normalized_uri = lsp#utils#normalize_uri(l:uri)
+    let l:identifier = get(a:request['params'], 'identifier', '')
+    let l:result = a:response['result']
+
+    if !has_key(s:diagnostic_result_ids, l:normalized_uri)
+        let s:diagnostic_result_ids[l:normalized_uri] = {}
+    endif
+    if !has_key(s:diagnostic_result_ids[l:normalized_uri], a:server)
+        let s:diagnostic_result_ids[l:normalized_uri][a:server] = {}
+    endif
+    let s:diagnostic_result_ids[l:normalized_uri][a:server][l:identifier] = get(l:result, 'resultId', '')
+
+    if get(l:result, 'kind', 'full') ==# 'unchanged'
+        return
+    endif
+
+    if !has_key(s:diagnostics_state, l:normalized_uri)
+        let s:diagnostics_state[l:normalized_uri] = {}
+    endif
+    let s:diagnostics_state[l:normalized_uri][a:server] = {
+        \ 'method': 'textDocument/publishDiagnostics',
+        \ 'params': {
+        \   'uri': l:uri,
+        \   'diagnostics': get(l:result, 'items', []),
+        \ },
+        \ }
+    call s:notify_diagnostics_update(a:server, l:normalized_uri)
+endfunction
+
 function! s:on_exit(response) abort
     let l:server = a:response['params']['server']
     let l:notify = 0
     for l:value in values(s:diagnostics_state)
         if has_key(l:value, l:server)
             let l:notify = 1
+            call remove(l:value, l:server)
+        endif
+    endfor
+    for l:value in values(s:diagnostic_result_ids)
+        if has_key(l:value, l:server)
             call remove(l:value, l:server)
         endif
     endfor

--- a/test/lsp/internal/diagnostics/state.vimspec
+++ b/test/lsp/internal/diagnostics/state.vimspec
@@ -53,6 +53,81 @@ Describe lsp#internal#diagnostics#state
         Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
     End
 
+    It should be able to handle textDocument/diagnostic response and update state correctly
+        let l:uri = 'file://some/uri'
+
+        let l:server1_request1 = {'params': {'textDocument': {'uri': l:uri}, 'identifier': 'server1'}}
+        let l:server1_response1 = {'result': {'kind': 'full', 'resultId': 'server1-result-1', 'items': [
+            \ {'severity': 1, 'message': 'm1', 'range': { 'start': { 'line': 1, 'character': 1 }, 'end': { 'line': 1, 'character': 1 } }},
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2 }, 'end': { 'line': 1, 'character': 3 } }},
+            \ ]}}
+        let l:server2_request1 = {'params': {'textDocument': {'uri': l:uri}, 'identifier': 'server2'}}
+        let l:server2_response1 = {'result': {'kind': 'full', 'resultId': 'server2-result-1', 'items': [
+            \ {'severity': 1, 'message': 's2', 'range': { 'start': { 'line': 2, 'character': 3 }, 'end': { 'line': 4, 'character': 5 } }},
+            \ ]}}
+        let l:server1_request2 = {'params': {'textDocument': {'uri': l:uri}, 'identifier': 'server1', 'previousResultId': 'server1-result-1'}}
+        let l:server1_response2 = {'result': {'kind': 'full', 'resultId': 'server1-result-2', 'items': [
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2 }, 'end': { 'line': 1, 'character': 3 } }},
+            \ ]}}
+
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), {})
+
+        call lsp#internal#diagnostics#state#_handle_text_document_diagnostic('server1', l:server1_request1, l:server1_response1)
+        let l:server1_want1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': l:server1_response1['result']['items']}}
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_want1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_want1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server1', 'server1'), 'server1-result-1')
+
+        call lsp#internal#diagnostics#state#_handle_text_document_diagnostic('server2', l:server2_request1, l:server2_response1)
+        let l:server2_want1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': l:server2_response1['result']['items']}}
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_want1, 'server2': l:server2_want1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_want1, 'server2': l:server2_want1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server2', 'server2'), 'server2-result-1')
+
+        call lsp#internal#diagnostics#state#_handle_text_document_diagnostic('server1', l:server1_request2, l:server1_response2)
+        let l:server1_want2 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': l:server1_response2['result']['items']}}
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_want2, 'server2': l:server2_want1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_want2, 'server2': l:server2_want1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server1', 'server1'), 'server1-result-2')
+
+        call lsp#stream(1, { 'server': '$vimlsp',
+            \ 'response': { 'method': '$/vimlsp/lsp_server_exit', 'params': { 'server': 'server1' } } })
+        let l:want = {}
+        let l:want[l:uri] = { 'server2': l:server2_want1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server1', 'server1'), '')
+    End
+
+    It should keep existing diagnostics when textDocument/diagnostic response kind is unchanged
+        let l:uri = 'file://some/uri'
+
+        let l:server1_request1 = {'params': {'textDocument': {'uri': l:uri}, 'identifier': 'server1'}}
+        let l:server1_response1 = {'result': {'kind': 'full', 'resultId': 'server1-result-1', 'items': [
+            \ {'severity': 1, 'message': 'm1', 'range': { 'start': { 'line': 1, 'character': 1 }, 'end': { 'line': 1, 'character': 1 } }},
+            \ {'severity': 1, 'message': 'm2', 'range': { 'start': { 'line': 1, 'character': 2 }, 'end': { 'line': 1, 'character': 3 } }},
+            \ ]}}
+        let l:server1_request2 = {'params': {'textDocument': {'uri': l:uri}, 'identifier': 'server1', 'previousResultId': 'server1-result-1'}}
+        let l:server1_response2 = {'result': {'kind': 'unchanged', 'resultId': 'server1-result-2'}}
+
+        call lsp#internal#diagnostics#state#_handle_text_document_diagnostic('server1', l:server1_request1, l:server1_response1)
+        let l:server1_want1 = {'method': 'textDocument/publishDiagnostics', 'params': {'uri': l:uri, 'diagnostics': l:server1_response1['result']['items']}}
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_want1 })
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server1', 'server1'), 'server1-result-1')
+
+        call lsp#internal#diagnostics#state#_handle_text_document_diagnostic('server1', l:server1_request2, l:server1_response2)
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri), { 'server1': l:server1_want1 })
+        let l:want = {}
+        let l:want[l:uri] = { 'server1': l:server1_want1 }
+        Assert Equals(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_uri_and_server(), l:want)
+        Assert Equals(lsp#internal#diagnostics#state#_get_previous_result_id(l:uri, 'server1', 'server1'), 'server1-result-2')
+    End
+
 
     It should correctly return the state of buffer
         call lsp#internal#diagnostics#state#_disable()


### PR DESCRIPTION
ref: https://github.com/prabirshrestha/vim-lsp/issues/1532

Hi, this PR adds support for [pull diagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_pullDiagnostics) in vim-lsp.

I found that `vscode-eslint-language-server` does not work with the current vim-lsp
because it relies on pull diagnostics rather than `textDocument/publishDiagnostics`.
To support it, vim-lsp needs to support `textDocument/diagnostic`.

Reference: https://github.com/microsoft/vscode-eslint/blob/main/CHANGELOG.md#version-301---pre-release

 > Version 3.0.1 - pre-release
 >
 >     converted the server to use diagnostic pull instead of push.

Note:

To avoid breaking backward compatibility, pull diagnostics client capability and related configuration are not enabled globally in vim-lsp and should be configured per server as needed.

For example, `vscode-eslint-language-server` can be configured like this:

```vim
autocmd User lsp_setup call lsp#register_server({
      \ 'name': 'vscode-eslint-language-server',
      \ 'cmd': {server_info->['vscode-eslint-language-server', '--stdio']},
      \ 'allowlist': ['javascript', 'javascriptreact', 'typescript', 'typescriptreact'],
      \ 'initialization_options': {'diagnostics': 'true'},
      \ 'workspace_config': {
      \   'validate': 'probe',
      \   'packageManager': 'npm',
      \   'useESLintClass': v:false,
      \   'experimental': { 'useFlatConfig': v:false },
      \   'quiet': v:false,
      \   'onIgnoredFiles': 'off',
      \   'options': {},
      \   'rulesCustomizations': [],
      \   'run': 'onType',
      \   'problems': { 'shortenToSingleLine': v:true },
      \   'nodePath': v:null,
      \ },
      \ 'capabilities': extend(
      \   lsp#default_get_supported_capabilities({}),
      \   {'textDocument': extend(
      \     lsp#default_get_supported_capabilities({})['textDocument'],
      \     {'diagnostic': {
      \       'dynamicRegistration': v:false,
      \       'relatedDocumentSupport': v:false,
      \     }}
      \   )}
      \ ),
      \ })
```

Before:

<img width="740" height="380" alt="スクリーンショット 2026-05-16 1 56 30" src="https://github.com/user-attachments/assets/0e0e4850-b191-4751-9e05-42d943b603fc" />

After:

<img width="740" height="382" alt="スクリーンショット 2026-05-16 1 55 40" src="https://github.com/user-attachments/assets/8fa0b6e0-0324-4f9a-a74f-ccb868367c3e" />

Thank you