### PR TITLE
Improving multiple workspaces functionality

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -722,7 +722,7 @@ function! s:ensure_init(buf, server_name, cb) abort
         let l:root_uri = lsp#utils#get_default_root_uri()
     endif
     let l:server['server_info']['_root_uri_resolved'] = l:root_uri
-    let l:server['workspace_folders'][l:root_uri] = { 'name': l:root_uri, 'uri': l:root_uri }
+    let l:server['workspace_folders'][l:root_uri] = { 'name': lsp#utils#uri_to_path(l:root_uri), 'uri': l:root_uri }
 
     if has_key(l:server_info, 'capabilities')
         let l:capabilities = l:server_info['capabilities']
@@ -744,9 +744,8 @@ function! s:ensure_init(buf, server_name, cb) abort
     
     let l:workspace_capabilities = get(l:capabilities, 'workspace', {})
     if get(l:workspace_capabilities, 'workspaceFolders', v:false)
-        " TODO: extract folder name for l:root_uri
         let l:server_info['workspaceFolders'] = [
-            \ { 'uri': l:root_uri, 'name': l:root_uri }
+            \ { 'uri': l:root_uri, 'name': lsp#utils#uri_to_path(l:root_uri) }
             \ ]
         let l:request['params']['workspaceFolders'] = l:server_info['workspaceFolders']
     endif
@@ -911,7 +910,7 @@ function! s:workspace_add_folder(server_name) abort
     let l:server_info = l:server['server_info']
     let l:root_uri = has_key(l:server_info, 'root_uri') ?  l:server_info['root_uri'](l:server_info) : lsp#utils#get_default_root_uri()
     if !has_key(l:server['workspace_folders'], l:root_uri)
-        let l:workspace_folder = { 'name': l:root_uri, 'uri': l:root_uri }
+        let l:workspace_folder = { 'name': lsp#utils#uri_to_path(l:root_uri), 'uri': l:root_uri }
         call lsp#log('adding workspace folder', a:server_name, l:workspace_folder)
         call s:send_notification(a:server_name, {
             \ 'method': 'workspace/didChangeWorkspaceFolders',
@@ -1419,6 +1418,10 @@ function! lsp#update_workspace_config(server_name, workspace_config) abort
 endfunction
 
 function! lsp#add_workspace_folder(server_name, path_or_uri) abort
+    if !g:lsp_experimental_workspace_folders
+        call lsp#utils#error('workspace folders require g:lsp_experimental_workspace_folders to be enabled')
+        return
+    endif
     if !has_key(s:servers, a:server_name)
         call lsp#utils#error('Server not found: ' . a:server_name)
         return
@@ -1432,7 +1435,7 @@ function! lsp#add_workspace_folder(server_name, path_or_uri) abort
         return
     endif
 
-    let l:uri = a:path_or_uri =~# '^file://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
+    let l:uri = a:path_or_uri =~# '^\w\+://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
     let l:server = s:servers[a:server_name]
 
     if has_key(l:server['workspace_folders'], l:uri)
@@ -1460,6 +1463,10 @@ function! lsp#add_workspace_folder(server_name, path_or_uri) abort
 endfunction
 
 function! lsp#remove_workspace_folder(server_name, path_or_uri) abort
+    if !g:lsp_experimental_workspace_folders
+        call lsp#utils#error('workspace folders require g:lsp_experimental_workspace_folders to be enabled')
+        return
+    endif
     if !has_key(s:servers, a:server_name)
         call lsp#utils#error('Server not found: ' . a:server_name)
         return
@@ -1473,11 +1480,10 @@ function! lsp#remove_workspace_folder(server_name, path_or_uri) abort
         return
     endif
 
-    let l:uri = a:path_or_uri =~# '^file://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
+    let l:uri = a:path_or_uri =~# '^\w\+://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
     let l:server = s:servers[a:server_name]
 
     if !has_key(l:server['workspace_folders'], l:uri)
-        call lsp#utils#error('Workspace folder not found: ' . l:uri)
         return
     endif
 

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -916,7 +916,10 @@ function! s:workspace_add_folder(server_name) abort
         call s:send_notification(a:server_name, {
             \ 'method': 'workspace/didChangeWorkspaceFolders',
             \ 'params': {
-            \    'added': [l:workspace_folder],
+            \    'event': {
+            \        'added': [l:workspace_folder],
+            \        'removed': [],
+            \    },
             \  }
             \ })
         let l:server['workspace_folders'][l:root_uri] = l:workspace_folder

--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1418,6 +1418,104 @@ function! lsp#update_workspace_config(server_name, workspace_config) abort
     call s:ensure_conf(bufnr('%'), a:server_name, function('s:Noop'))
 endfunction
 
+function! lsp#add_workspace_folder(server_name, path_or_uri) abort
+    if !has_key(s:servers, a:server_name)
+        call lsp#utils#error('Server not found: ' . a:server_name)
+        return
+    endif
+    if !lsp#is_server_running(a:server_name)
+        call lsp#utils#error('Server is not running: ' . a:server_name)
+        return
+    endif
+    if !lsp#capabilities#has_workspace_folders_change_notifications(a:server_name)
+        call lsp#utils#error('Server does not support workspace folder notifications: ' . a:server_name)
+        return
+    endif
+
+    let l:uri = a:path_or_uri =~# '^file://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
+    let l:server = s:servers[a:server_name]
+
+    if has_key(l:server['workspace_folders'], l:uri)
+        return
+    endif
+
+    let l:workspace_folder = { 'name': lsp#utils#uri_to_path(l:uri), 'uri': l:uri }
+    call lsp#log('adding workspace folder', a:server_name, l:workspace_folder)
+    call s:send_notification(a:server_name, {
+        \ 'method': 'workspace/didChangeWorkspaceFolders',
+        \ 'params': {
+        \    'event': {
+        \        'added': [l:workspace_folder],
+        \        'removed': [],
+        \    },
+        \  }
+        \ })
+    let l:server['workspace_folders'][l:uri] = l:workspace_folder
+
+    let l:server_info = l:server['server_info']
+    if !has_key(l:server_info, 'workspaceFolders')
+        let l:server_info['workspaceFolders'] = []
+    endif
+    call add(l:server_info['workspaceFolders'], l:workspace_folder)
+endfunction
+
+function! lsp#remove_workspace_folder(server_name, path_or_uri) abort
+    if !has_key(s:servers, a:server_name)
+        call lsp#utils#error('Server not found: ' . a:server_name)
+        return
+    endif
+    if !lsp#is_server_running(a:server_name)
+        call lsp#utils#error('Server is not running: ' . a:server_name)
+        return
+    endif
+    if !lsp#capabilities#has_workspace_folders_change_notifications(a:server_name)
+        call lsp#utils#error('Server does not support workspace folder notifications: ' . a:server_name)
+        return
+    endif
+
+    let l:uri = a:path_or_uri =~# '^file://' ? a:path_or_uri : lsp#utils#path_to_uri(a:path_or_uri)
+    let l:server = s:servers[a:server_name]
+
+    if !has_key(l:server['workspace_folders'], l:uri)
+        call lsp#utils#error('Workspace folder not found: ' . l:uri)
+        return
+    endif
+
+    let l:workspace_folder = l:server['workspace_folders'][l:uri]
+    call lsp#log('removing workspace folder', a:server_name, l:workspace_folder)
+    call s:send_notification(a:server_name, {
+        \ 'method': 'workspace/didChangeWorkspaceFolders',
+        \ 'params': {
+        \    'event': {
+        \        'added': [],
+        \        'removed': [l:workspace_folder],
+        \    },
+        \  }
+        \ })
+    unlet l:server['workspace_folders'][l:uri]
+
+    let l:server_info = l:server['server_info']
+    if has_key(l:server_info, 'workspaceFolders')
+        call filter(l:server_info['workspaceFolders'], {idx, val -> val['uri'] !=# l:uri})
+    endif
+endfunction
+
+function! lsp#_add_workspace_folder_cmd(...) abort
+    if a:0 < 2
+        call lsp#utils#error('Usage: LspAddWorkspaceFolder {server_name} {path}')
+        return
+    endif
+    call lsp#add_workspace_folder(a:1, join(a:000[1:], ' '))
+endfunction
+
+function! lsp#_remove_workspace_folder_cmd(...) abort
+    if a:0 < 2
+        call lsp#utils#error('Usage: LspRemoveWorkspaceFolder {server_name} {path}')
+        return
+    endif
+    call lsp#remove_workspace_folder(a:1, join(a:000[1:], ' '))
+endfunction
+
 function! lsp#server_complete(lead, line, pos) abort
     return filter(sort(keys(s:servers)), 'stridx(v:val, a:lead)==0 && has_key(s:servers[v:val], "init_result")')
 endfunction

--- a/autoload/lsp/capabilities.vim
+++ b/autoload/lsp/capabilities.vim
@@ -40,7 +40,8 @@ function! lsp#capabilities#has_workspace_folders_change_notifications(server_nam
         if type(l:workspace) == type({}) && !empty(l:workspace)
             let l:workspace_folders = get(l:workspace, 'workspaceFolders', {})
             if type(l:workspace_folders) == type({}) && !empty(l:workspace_folders)
-                if get(l:workspace_folders, 'supported', v:false) && get(l:workspace_folders, 'changeNotifications', '') ==# 'workspace/didChangeWorkspaceFolders'
+                let l:change_notifications = get(l:workspace_folders, 'changeNotifications', '')
+                if get(l:workspace_folders, 'supported', v:false) && (l:change_notifications ==# 'workspace/didChangeWorkspaceFolders' || l:change_notifications is v:true)
                     return v:true
                 endif
             endif

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -107,6 +107,8 @@ CONTENTS                                                  *vim-lsp-contents*
       lsp#register_command                  |lsp#register_command()|
       lsp#stream			    |lsp#stream()|
       lsp#stop_server                       |lsp#stop_server()|
+      lsp#add_workspace_folder             |lsp#add_workspace_folder()|
+      lsp#remove_workspace_folder          |lsp#remove_workspace_folder()|
       lsp#utils#find_nearest_parent_file_directory()
                               |lsp#utils#find_nearest_parent_file_directory()|
       lsp#enable_diagnostics_for_buffer() |lsp#enable_diagnostics_for_buffer()|
@@ -155,6 +157,8 @@ CONTENTS                                                  *vim-lsp-contents*
       LspSemanticHighlightGroups            |:LspSemanticHighlightGroups|
       LspTypeDefinition                     |:LspTypeDefinition|
       LspTypeHierarchy                      |:LspTypeHierarchy|
+      LspAddWorkspaceFolder                 |:LspAddWorkspaceFolder|
+      LspRemoveWorkspaceFolder              |:LspRemoveWorkspaceFolder|
       LspWorkspaceSymbol                    |:LspWorkspaceSymbol|
       LspWorkspaceSymbolSearch              |:LspWorkspaceSymbolSearch|
       LspStatus                             |:LspStatus|
@@ -1601,6 +1605,42 @@ Used to stop the server.
 	* If the server is not running or is not registered it is a noop.
 	* The server is forcefully stopped without sending shutdown request.
 
+lsp#add_workspace_folder({server-name}, {path-or-uri})
+						    *lsp#add_workspace_folder()*
+
+Add a workspace folder to a running language server. The server must support
+workspace folder change notifications, and |g:lsp_experimental_workspace_folders|
+must be enabled.
+
+{path-or-uri} can be a filesystem path or a URI. Filesystem paths are
+automatically converted to URIs.
+
+If the folder is already registered, the call is a silent no-op.
+
+    Example: >
+	call lsp#add_workspace_folder('eclipse-jdt-ls', '/home/user/project')
+	call lsp#add_workspace_folder('eclipse-jdt-ls', 'file:///home/user/project')
+<
+    Note:
+	* The server must be running.
+	* |g:lsp_experimental_workspace_folders| must be set to 1.
+	* Sends workspace/didChangeWorkspaceFolders notification.
+
+lsp#remove_workspace_folder({server-name}, {path-or-uri})
+						 *lsp#remove_workspace_folder()*
+
+Remove a workspace folder from a running language server.
+
+If the folder is not registered, the call is a silent no-op.
+
+    Example: >
+	call lsp#remove_workspace_folder('eclipse-jdt-ls', '/home/user/project')
+<
+    Note:
+	* The server must be running.
+	* |g:lsp_experimental_workspace_folders| must be set to 1.
+	* Sends workspace/didChangeWorkspaceFolders notification.
+
 lsp#get_server_status({name-of-server})            *lsp#get_server_status()*
 
 Get the status of a server.
@@ -1968,6 +2008,25 @@ View type hierarchy for the symbol under cursor.
 
 Also see |:LspPeekTypeDefinition|.
 
+LspAddWorkspaceFolder {server-name} {path}        *:LspAddWorkspaceFolder*
+
+Add a workspace folder to a running language server. Requires
+|g:lsp_experimental_workspace_folders| to be enabled.
+
+    Example: >
+	:LspAddWorkspaceFolder eclipse-jdt-ls /home/user/project
+<
+    See |lsp#add_workspace_folder()| for details.
+
+LspRemoveWorkspaceFolder {server-name} {path}  *:LspRemoveWorkspaceFolder*
+
+Remove a workspace folder from a running language server.
+
+    Example: >
+	:LspRemoveWorkspaceFolder eclipse-jdt-ls /home/user/project
+<
+    See |lsp#remove_workspace_folder()| for details.
+
 LspWorkspaceSymbol                                     *:LspWorkspaceSymbol*
 
 Search and show workspace symbols in quickfix.
@@ -2326,6 +2385,10 @@ When a new buffer is opened, if the server supports workspace folder, it will
 call `root_uri` function to detect the workspace folder. If the folder is not
 part of workspace folder, it will automatically notify the server to add the
 workspace folder.
+
+Workspace folders can also be managed manually using
+|lsp#add_workspace_folder()| and |lsp#remove_workspace_folder()|, or with the
+|:LspAddWorkspaceFolder| and |:LspRemoveWorkspaceFolder| commands.
 
 =============================================================================
 License                                                    *vim-lsp-license*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -166,6 +166,8 @@ command! LspDocumentFold call lsp#ui#vim#folding#fold(0)
 command! LspDocumentFoldSync call lsp#ui#vim#folding#fold(1)
 command! -nargs=0 LspSemanticTokenTypes echo lsp#internal#semantic#get_token_types()
 command! -nargs=0 LspSemanticTokenModifiers echo lsp#internal#semantic#get_token_modifiers()
+command! -nargs=+ -complete=customlist,lsp#server_complete_running LspAddWorkspaceFolder call lsp#_add_workspace_folder_cmd(<f-args>)
+command! -nargs=+ -complete=customlist,lsp#server_complete_running LspRemoveWorkspaceFolder call lsp#_remove_workspace_folder_cmd(<f-args>)
 
 nnoremap <silent> <plug>(lsp-call-hierarchy-incoming) :<c-u>call lsp#ui#vim#call_hierarchy_incoming({})<cr>
 nnoremap <silent> <plug>(lsp-call-hierarchy-outgoing) :<c-u>call lsp#ui#vim#call_hierarchy_outgoing()<cr>


### PR DESCRIPTION
Appears the wrong schema is used in `send_notification` for when the workspace folder is changed? Fixed it.

Also added public methods for explicitly managing workspace folders. As a reason for inclusion: For me they were necessary for managing some tooling at my job. These methods were mentioned in #1265 but not implemented yet, maybe due to the lack of necessity?

I tested these changes with some basic work on java (jdtls) and rust (bacon-ls/rust-analyzer) projects with [mattn/vim-lsp-settings](https://github.com/mattn/vim-lsp-settings), both with multiple workspaces. Existing functionalities seem fine. 