### PR TITLE
Improve interoperability under win32unix

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -733,15 +733,17 @@ function! s:ensure_init(buf, server_name, cb) abort
     let l:request = {
     \   'method': 'initialize',
     \   'params': {
-    \     'processId': getpid(),
+    \     'processId': has('win32unix') ? v:null : getpid(),
     \     'clientInfo': { 'name': 'vim-lsp' },
     \     'capabilities': l:capabilities,
     \     'rootUri': l:root_uri,
-    \     'rootPath': lsp#utils#uri_to_path(l:root_uri),
     \     'trace': 'off',
     \   },
     \ }
-    
+    if !has('win32unix')
+        let l:request.params.rootPath = lsp#utils#uri_to_path(l:root_uri)
+    endif
+
     let l:workspace_capabilities = get(l:capabilities, 'workspace', {})
     if get(l:workspace_capabilities, 'workspaceFolders', v:false)
         " TODO: extract folder name for l:root_uri

--- a/autoload/lsp/utils.vim
+++ b/autoload/lsp/utils.vim
@@ -165,12 +165,12 @@ else
     endfunction
 endif
 
-if has('win32') || has('win64')
+if has('win32') || has('win64') || has('win32unix')
     function! lsp#utils#normalize_uri(uri) abort
         " Refer to https://github.com/microsoft/language-server-protocol/pull/1019 on normalization of urls.
         " TODO: after the discussion is settled, modify this function.
         let l:ret = substitute(a:uri, '^file:///[a-zA-Z]\zs%3[aA]', ':', '')
-        return substitute(l:ret, '^file:///\zs\([A-Z]\)', "\\=tolower(submatch(1))", '')
+        return substitute(l:ret, '^file:///\zs\([A-Z]\)\ze:', "\\=tolower(submatch(1))", '')
     endfunction
 else
     function! lsp#utils#normalize_uri(uri) abort

--- a/test/lsp/utils.vimspec
+++ b/test/lsp/utils.vimspec
@@ -10,7 +10,7 @@ Describe lsp#utils
 
     Describe lsp#utils#uri_to_path
         It should return path from uri (Windows)
-            if !has('win32')
+            if !(has('win32') || has('win64'))
               Skip This tests is not for UNIX
             endif
             let tests = [
@@ -28,7 +28,7 @@ Describe lsp#utils
         End
 
         It should return path from uri (UNIX)
-            if has('win32')
+            if has('win32') || has('win64') || has('win32unix')
               Skip This tests is not for Windows
             endif
             let tests = [
@@ -48,7 +48,7 @@ Describe lsp#utils
 
     Describe lsp#utils#path_to_uri
         It should return uri from path (Windows)
-            if !has('win32')
+            if !(has('win32') || has('win64'))
               Skip This tests is not for UNIX
             endif
             let tests = [
@@ -64,7 +64,7 @@ Describe lsp#utils
         End
 
         It should return uri from path (UNIX)
-            if has('win32')
+            if has('win32') || has('win64') || has('win32unix')
               Skip This tests is not for Windows
             endif
             let tests = [
@@ -82,7 +82,7 @@ Describe lsp#utils
 
     Describe lsp#utils#normalize_uri
         It should return normalized uri (Windows)
-            if !has('win32')
+            if !(has('win32') || has('win64') || has('win32unix'))
               Skip This tests is not for UNIX
             endif
             let tests = [
@@ -91,6 +91,7 @@ Describe lsp#utils
             \  {'path': 'file:///C%3A\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
             \  {'path': 'file:///c%3a\path\to\the\file.txt', 'uri': 'file:///c:\path\to\the\file.txt'},
             \  {'path': 'http://foo/bar.txt', 'uri': 'http://foo/bar.txt'},
+            \  {'path': 'file:///Home/project', 'uri': 'file:///Home/project'},
             \]
             for test in tests
                 let uri = lsp#utils#normalize_uri(test.path)
@@ -99,7 +100,7 @@ Describe lsp#utils
         End
 
         It should return normalized uri (UNIX)
-            if has('win32')
+            if has('win32') || has('win64') || has('win32unix')
               Skip This tests is not for Windows
             endif
             let tests = [


### PR DESCRIPTION
  ## Problem

  Under `win32unix` (Cygwin/MSYS), vim and a language server may use
  different path and PID namespaces. This caused problems with native
  Windows language servers such as [basedpyright](https://github.com/detachhead/basedpyright):

  - vim-lsp generates Windows-style file URIs under `win32unix`, but `normalize_uri()` did not normalize them. 
    URI differences such as drive-letter casing or an encoded drive colon could therefore prevent
    responses from matching the corresponding vim buffer.
  - `getpid()` returns a Cygwin/MSYS PID that may not identify vim to a native Windows server. 
    A server using it for parent-process monitoring may incorrectly conclude that vim has exited.
  - `rootPath` uses a platform-dependent filesystem path and may contradict the Windows-style `rootUri`.

  ## Changes

  - Apply `normalize_uri()` under `win32unix`.
  - Only lowercase a drive letter when it is followed by a colon, avoiding
    changes to paths such as `file:///Home/project`.
  - Send `processId: null` under `win32unix`, where the server's PID
    namespace cannot be determined reliably.
  - Omit the deprecated `rootPath` under `win32unix` and rely on
    `rootUri`. It remains present on other platforms for compatibility.
  - Run URI normalization tests under `win32unix` and skip native Windows
    and Unix path-conversion fixtures that do not apply there.