### PR TITLE
Improve diagnostic virtual text rendering and controls

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1345,6 +1345,17 @@ function! lsp#disable_diagnostics_for_buffer(...) abort
     call lsp#internal#diagnostics#state#_disable_for_buffer(l:bufnr)
 endfunction
 
+function! lsp#enable_diagnostics_virtual_text() abort
+    let g:lsp_diagnostics_virtual_text_enabled = 1
+    call lsp#internal#diagnostics#virtual_text#_enable()
+    call lsp#internal#diagnostics#state#_force_notify_buffer(bufnr('%'))
+endfunction
+
+function! lsp#disable_diagnostics_virtual_text() abort
+    let g:lsp_diagnostics_virtual_text_enabled = 0
+    call lsp#internal#diagnostics#virtual_text#_disable()
+endfunction
+
 " Return dict with diagnostic counts for current buffer
 " { 'error': 1, 'warning': 0, 'information': 0, 'hint': 0 }
 function! lsp#get_buffer_diagnostics_counts() abort

--- a/autoload/lsp/internal/diagnostics/virtual_text.vim
+++ b/autoload/lsp/internal/diagnostics/virtual_text.vim
@@ -141,8 +141,9 @@ function! s:set_virtual_text(params) abort
         for l:bufnr in nvim_list_bufs()
             if lsp#internal#diagnostics#state#_is_enabled_for_buffer(l:bufnr) && bufexists(l:bufnr) && bufloaded(l:bufnr)
                 let l:uri = lsp#utils#get_buffer_uri(l:bufnr)
+                let l:line_props = {}
                 for [l:server, l:diagnostics_response] in items(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri))
-                    call s:place_virtual_text(l:server, l:diagnostics_response, l:bufnr)
+                    call s:place_virtual_text(l:server, l:diagnostics_response, l:bufnr, l:line_props)
                 endfor
             endif
         endfor
@@ -150,17 +151,16 @@ function! s:set_virtual_text(params) abort
         for l:bufnr in map(copy(getbufinfo()), 'v:val.bufnr')
             if lsp#internal#diagnostics#state#_is_enabled_for_buffer(l:bufnr) && bufexists(l:bufnr) && bufloaded(l:bufnr)
                 let l:uri = lsp#utils#get_buffer_uri(l:bufnr)
+                let l:line_props = {}
                 for [l:server, l:diagnostics_response] in items(lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(l:uri))
-                    call s:place_virtual_text(l:server, l:diagnostics_response, l:bufnr)
+                    call s:place_virtual_text(l:server, l:diagnostics_response, l:bufnr, l:line_props)
                 endfor
             endif
         endfor
     endif
 endfunction
 
-function! s:place_virtual_text(server, diagnostics_response, bufnr) abort
-    let l:line_props = {}
-
+function! s:place_virtual_text(server, diagnostics_response, bufnr, line_props) abort
     let l:linecount = s:Buffer.get_line_count(a:bufnr)
     for l:item in lsp#utils#iterable(a:diagnostics_response['params']['diagnostics'])
         let l:line = lsp#utils#position#lsp_line_to_vim(a:bufnr, l:item['range']['start'])
@@ -182,17 +182,19 @@ function! s:place_virtual_text(server, diagnostics_response, bufnr) abort
             " it's an error to add virtual text on lines that don't exist
             " anymore due to async processing, just skip such diagnostics
             if l:line <= l:linecount
-                if g:lsp_diagnostics_virtual_text_tidy && has_key(l:line_props, l:line)
+                if g:lsp_diagnostics_virtual_text_tidy && has_key(a:line_props, l:line)
                   " Replace the existing virtual text with the one that has higher severity
-                  if l:severity <= l:line_props[l:line]['severity']
-                    call prop_remove({'id': l:line_props[l:line]['prop_id']}, l:line)
+                  if l:severity <= a:line_props[l:line]['severity']
+                    call prop_remove({
+                        \ 'id': a:line_props[l:line]['prop_id'],
+                        \ 'bufnr': a:bufnr,
+                        \ }, l:line)
                   else
                     continue
                   endif
                 endif
 
                 let l:type = 'vim_lsp_' . l:name . '_virtual_text'
-                call prop_remove({'all': v:true, 'type': l:type, 'bufnr': a:bufnr}, l:line)
                 let l:prop_id = prop_add(
                 \ l:line, 0,
                 \ {
@@ -202,7 +204,7 @@ function! s:place_virtual_text(server, diagnostics_response, bufnr) abort
                 \   'text_wrap': g:lsp_diagnostics_virtual_text_wrap,
                 \ })
 
-                let l:line_props[l:line] = {
+                let a:line_props[l:line] = {
                 \ 'prop_id': l:prop_id,
                 \ 'severity': l:severity,
                 \ }

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -111,6 +111,10 @@ CONTENTS                                                  *vim-lsp-contents*
                               |lsp#utils#find_nearest_parent_file_directory()|
       lsp#enable_diagnostics_for_buffer() |lsp#enable_diagnostics_for_buffer()|
       lsp#disable_diagnostics_for_buffer()|lsp#disable_diagnostics_for_buffer()|
+      lsp#enable_diagnostics_virtual_text()
+                               |lsp#enable_diagnostics_virtual_text()|
+      lsp#disable_diagnostics_virtual_text()
+                               |lsp#disable_diagnostics_virtual_text()|
       lsp#get_buffer_diagnostics_counts() |lsp#get_buffer_diagnostics_counts()|
       lsp#get_buffer_first_error_line()   |lsp#get_buffer_first_error_line()|
       lsp#get_progress()                  |lsp#get_progress()|
@@ -1686,6 +1690,23 @@ other plugins.
 	    autocmd User EasyMotionPromptBegin call lsp#disable_diagnostics_for_buffer()<CR>
 	    autocmd User EasyMotionPromptEnd call lsp#enable_diagnostics_for_buffer()<CR>
 	augroup END
+
+lsp#enable_diagnostics_virtual_text()    *lsp#enable_diagnostics_virtual_text()*
+
+Enable diagnostic virtual text and display any diagnostics that have already
+been received. Requires |g:lsp_diagnostics_enabled| set to `1` and Vim or
+NeoVim virtual text support.
+
+    Example: >
+	:call lsp#enable_diagnostics_virtual_text()
+
+lsp#disable_diagnostics_virtual_text()  *lsp#disable_diagnostics_virtual_text()*
+
+Disable diagnostic virtual text and remove all diagnostic virtual text
+currently displayed.
+
+    Example: >
+	:call lsp#disable_diagnostics_virtual_text()
 
 lsp#get_buffer_diagnostics_counts()    *lsp#get_buffer_diagnostics_counts()*
 


### PR DESCRIPTION
## Problem

When `g:lsp_diagnostics_virtual_text_tidy` is disabled, diagnostics of the same severity on the same line replace one another instead of all being displayed.

After allowing multiple diagnostics, tidy state must also be shared across LSP servers so that enabling tidy mode continues to display only one highest-severity diagnostic per line.

Additionally, diagnostic virtual text can be configured at startup, but there is no public API for enabling or disabling it afterward. Calling `lsp#internal#diagnostics#virtual_text#_enable()` subscribes to diagnostic updates, but does not immediately display diagnostics that were received earlier. Those diagnostics only appear after another event such as `InsertLeave` triggers a refresh.


## Changes

- Display all diagnostic virtual text across all severity levels and across all LSP servers when tidy mode is disabled.
- Display one highest-severity diagnostic per line across all LSP servers when tidy mode is enabled.
- Remove replaced virtual text from the correct buffer.
- Add `lsp#enable_diagnostics_virtual_text()`.
- Add `lsp#disable_diagnostics_virtual_text()`.
- Refresh cached diagnostics when virtual text is enabled.
- Document the new public functions.

## Testing

Manually verified that:

- Multiple same-line diagnostics are displayed with tidy mode disabled.
- Tidy mode displays only the highest-severity diagnostic per line.
- Tidy mode works across multiple LSP servers.
- Disabling virtual text removes displayed messages.
- Enabling virtual text displays cached diagnostics without requiring an
  `InsertLeave` event.

With `g:lsp_diagnostics_virtual_text_tidy=0` we get:
| Before | After |
 |:---:|:---:|
|<img width="350" alt="tidy0_before" src="https://github.com/user-attachments/assets/57723ae2-417d-431d-9afb-a0759039e78e" /> | <img width="350" alt="tidy0_after" src="https://github.com/user-attachments/assets/68ffc5aa-dcda-4874-8cc8-a03d4d42268e" /> |

With `g:lsp_diagnostics_virtual_text_tidy=1` we get:
| Before | After |
 |:---:|:---:|
|<img width="350" alt="tidy1_before" src="https://github.com/user-attachments/assets/bb121b37-17bb-4561-94ba-753a98f48d1f" /> | <img width="350" alt="tidy1_after" src="https://github.com/user-attachments/assets/434546df-8c4f-4e99-a4c2-510984f60e18" /> |

