### PR TITLE
Add string id support to native LSP channel

### DIFF
--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -453,7 +453,11 @@ function! lsp#client#send_response(client_id, opts) abort
             " see: https://github.com/vim/vim/issues/14091
             let l:request['jsonrpc'] = '2.0'
             let l:body = json_encode(l:request)
-            call ch_sendraw(l:ctx['channel'], 'Content-Length: ' . len(l:body) . "\r\n\r\n" . l:body)
+            try
+              call ch_sendraw(l:ctx['channel'], 'Content-Length: ' . len(l:body) . "\r\n\r\n" . l:body)
+            catch
+              call lsp#log('lsp#client#send_response error', v:exception, v:throwpoint)
+            endtry
             return 0
         endif
         try

--- a/autoload/lsp/client.vim
+++ b/autoload/lsp/client.vim
@@ -447,6 +447,15 @@ function! lsp#client#send_response(client_id, opts) abort
         if has_key(a:opts, 'id') | let l:request['id'] = a:opts['id'] | endif
         if has_key(a:opts, 'result') | let l:request['result'] = a:opts['result'] | endif
         if has_key(a:opts, 'error') | let l:request['error'] = a:opts['error'] | endif
+        if has_key(l:request, 'id') && type(l:request['id']) == v:t_string
+            " Vim's lsp channel mode only accepts number ids
+            " so build the frame manually and bypass ch_sendexpr.
+            " see: https://github.com/vim/vim/issues/14091
+            let l:request['jsonrpc'] = '2.0'
+            let l:body = json_encode(l:request)
+            call ch_sendraw(l:ctx['channel'], 'Content-Length: ' . len(l:body) . "\r\n\r\n" . l:body)
+            return 0
+        endif
         try
             call ch_sendexpr(l:ctx['channel'], l:request)
         catch


### PR DESCRIPTION
ref: https://github.com/prabirshrestha/vim-lsp/issues/1684

Native LSP channel currently only supports numeric ids ([vim/vim#14091](https://github.com/vim/vim/issues/14091)).

Vim's native LSP channel does not support string ids, 
so this PR works around it on the client side to allow sending responses with a string id.
