### PR TITLE
Use native diff() builtin for incremental sync fallback diff

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -796,15 +796,15 @@ function! s:text_changes(buf, server_name) abort
             return l:listener_changes
         endif
 
-        " Fallback: compute diff (O(total lines))
+        " Fallback: compute diff (native diff() when available, else O(total lines))
         let l:old_content = s:get_last_file_content(a:buf, a:server_name)
         let l:new_content = lsp#internal#listener#get_lines_cached(a:buf)
         let l:changes = lsp#internal#listener#get_diff_cached(a:buf, l:old_content)
-        if empty(l:changes.text) && l:changes.rangeLength ==# 0
+        if empty(l:changes)
             return []
         endif
         call s:update_file_content(a:buf, a:server_name, l:new_content)
-        return [l:changes]
+        return l:changes
     endif
 
     let l:new_content = lsp#internal#listener#get_lines_cached(a:buf)

--- a/autoload/lsp/internal/listener.vim
+++ b/autoload/lsp/internal/listener.vim
@@ -1,4 +1,5 @@
 let s:has_listener = exists('*listener_add')
+let s:has_native_diff = exists('*diff')
 let s:buf_state = {}
 
 function! lsp#internal#listener#is_enabled() abort
@@ -86,6 +87,9 @@ function! lsp#internal#listener#get_lines_cached(buf) abort
     return l:lines
 endfunction
 
+" Always returns a list of LSP TextDocumentContentChangeEvent dicts.
+" Prefers Vim 9.1's native diff() builtin (O(n) in C) and falls back to the
+" vim-lsc-derived prefix/suffix scan when unavailable.
 function! lsp#internal#listener#get_diff_cached(buf, old_content) abort
     let l:tick = getbufvar(a:buf, 'changedtick')
     if has_key(s:buf_state, a:buf)
@@ -95,7 +99,16 @@ function! lsp#internal#listener#get_diff_cached(buf, old_content) abort
         endif
     endif
     let l:new_content = lsp#internal#listener#get_lines_cached(a:buf)
-    let l:changes = lsp#utils#diff#compute(a:old_content, l:new_content)
+    if s:has_native_diff
+        let l:changes = lsp#utils#diff#compute_native(a:old_content, l:new_content)
+    else
+        let l:change = lsp#utils#diff#compute(a:old_content, l:new_content)
+        if empty(l:change.text) && l:change.rangeLength ==# 0
+            let l:changes = []
+        else
+            let l:changes = [l:change]
+        endif
+    endif
     if has_key(s:buf_state, a:buf)
         let s:buf_state[a:buf].diff_cache = {'tick': l:tick, 'old': a:old_content, 'changes': l:changes}
     endif

--- a/autoload/lsp/utils/diff.vim
+++ b/autoload/lsp/utils/diff.vim
@@ -43,6 +43,34 @@ if s:has_lua && !exists('s:lua')
   call s:init_lua()
 endif
 
+" Compute LSP-style content changes using Vim 9.1's native diff() builtin.
+" Returns a list of TextDocumentContentChangeEvent dicts (line-granular hunks),
+" or an empty list when the buffers are identical.
+" Hunks are emitted in reverse document order so applying them sequentially
+" against the original state stays correct without offset bookkeeping.
+function! lsp#utils#diff#compute_native(old, new) abort
+  let l:hunks = diff(a:old, a:new, {'output': 'indices'})
+  if empty(l:hunks)
+    return []
+  endif
+  let l:changes = []
+  for l:h in reverse(l:hunks)
+    if l:h.to_count > 0
+      let l:text = join(a:new[l:h.to_idx : l:h.to_idx + l:h.to_count - 1], "\n") . "\n"
+    else
+      let l:text = ''
+    endif
+    call add(l:changes, {
+        \ 'range': {
+        \   'start': {'line': l:h.from_idx, 'character': 0},
+        \   'end': {'line': l:h.from_idx + l:h.from_count, 'character': 0},
+        \ },
+        \ 'text': l:text,
+        \ })
+  endfor
+  return l:changes
+endfunction
+
 function! lsp#utils#diff#compute(old, new) abort
   let [l:start_line, l:start_char] = s:FirstDifference(a:old, a:new)
   let [l:end_line, l:end_char] =

--- a/test/lsp/utils/diff.vimspec
+++ b/test/lsp/utils/diff.vimspec
@@ -83,4 +83,96 @@ Describe lsp#utils#diff
             Assert Equals(got, want)
         End
     End
+
+    Describe lsp#utils#diff#compute_native
+        Before
+            if !exists('*diff')
+                Skip diff() builtin (Vim 9.1.0099+) not available
+            endif
+        End
+
+        It should return empty list when identical
+            let lines = ['foo', 'bar', 'baz']
+            Assert Equals(lsp#utils#diff#compute_native(lines, lines), [])
+        End
+
+        It should diff a single line change
+            let lines1 = ['foo', 'bar', 'baz']
+            let lines2 = ['foo', 'baR', 'baz']
+            let got = lsp#utils#diff#compute_native(lines1, lines2)
+            let want = [{
+            \  'range': {
+            \    'start': { 'line': 1, 'character': 0 },
+            \    'end': { 'line': 2, 'character': 0 },
+            \  },
+            \  'text': "baR\n",
+            \}]
+            Assert Equals(got, want)
+        End
+
+        It should emit multiple hunks in reverse document order
+            let lines1 = ['a', 'b', 'c', 'd', 'e']
+            let lines2 = ['A', 'b', 'c', 'D', 'e']
+            let got = lsp#utils#diff#compute_native(lines1, lines2)
+            " Later hunk must come first so earlier line numbers stay valid
+            " when the server applies changes sequentially.
+            Assert Equals(len(got), 2)
+            Assert Equals(got[0].range.start.line, 3)
+            Assert Equals(got[0].text, "D\n")
+            Assert Equals(got[1].range.start.line, 0)
+            Assert Equals(got[1].text, "A\n")
+        End
+
+        It should represent pure insertion as a zero-width range
+            let lines1 = ['foo', 'baz']
+            let lines2 = ['foo', 'bar', 'baz']
+            let got = lsp#utils#diff#compute_native(lines1, lines2)
+            let want = [{
+            \  'range': {
+            \    'start': { 'line': 1, 'character': 0 },
+            \    'end': { 'line': 1, 'character': 0 },
+            \  },
+            \  'text': "bar\n",
+            \}]
+            Assert Equals(got, want)
+        End
+
+        It should represent pure deletion with empty text
+            let lines1 = ['foo', 'bar', 'baz']
+            let lines2 = ['foo', 'baz']
+            let got = lsp#utils#diff#compute_native(lines1, lines2)
+            let want = [{
+            \  'range': {
+            \    'start': { 'line': 1, 'character': 0 },
+            \    'end': { 'line': 2, 'character': 0 },
+            \  },
+            \  'text': '',
+            \}]
+            Assert Equals(got, want)
+        End
+
+        It should handle empty old list
+            let got = lsp#utils#diff#compute_native([], ['foo', 'bar', 'baz'])
+            let want = [{
+            \  'range': {
+            \    'start': { 'line': 0, 'character': 0 },
+            \    'end': { 'line': 0, 'character': 0 },
+            \  },
+            \  'text': "foo\nbar\nbaz\n",
+            \}]
+            Assert Equals(got, want)
+        End
+
+        It should handle empty new list
+            let got = lsp#utils#diff#compute_native(['foo', 'bar', 'baz'], [])
+            let want = [{
+            \  'range': {
+            \    'start': { 'line': 0, 'character': 0 },
+            \    'end': { 'line': 3, 'character': 0 },
+            \  },
+            \  'text': '',
+            \}]
+            Assert Equals(got, want)
+        End
+    End
 End


### PR DESCRIPTION
When the listener-based change tracking cannot provide changes, the fallback path computes a diff between the old and new buffer content using the vim-lsc-derived prefix/suffix scan, which is O(total lines) in Vim script and always emits a single change spanning the first to last difference. This PR switches the fallback to Vim 9.1's native `diff()` builtin (`patch-9.1.0099`) when available, which runs in C and emits one change per hunk, keeping payloads small when edits are far apart. The previous implementation is kept as a fallback for Vim/Neovim without `diff()`.

Benchmark (Vim 9.2 without lua, 200 iterations each):

| scenario | before | after |
|---|---|---|
| 10k lines, 1-line edit | 57.2ms/iter | 3.7ms/iter |
| 10k lines, 2 distant hunks | 297.7ms/iter | 2.8ms/iter |
| 1k lines, 10-line insert | 6.2ms/iter | 0.12ms/iter |

For the 2-distant-hunks case the didChange payload also shrinks from 449,991 bytes (single change spanning both hunks) to 210 bytes (two hunks).