### PR TITLE
Handle workspace/diagnostic/refresh server request

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -1022,6 +1022,14 @@ function! s:on_request(server_name, id, request) abort
         call s:send_response(a:server_name, { 'id': a:request['id'], 'result': v:null})
     elseif a:request['method'] ==# 'client/unregisterCapability'
         call s:send_response(a:server_name, { 'id': a:request['id'], 'result': v:null})
+    elseif a:request['method'] ==# 'workspace/diagnostic/refresh'
+        call s:send_response(a:server_name, { 'id': a:request['id'], 'result': v:null})
+        for l:uri in keys(s:servers[a:server_name]['buffers'])
+            let l:refresh_buf = bufnr(lsp#utils#uri_to_path(l:uri))
+            if l:refresh_buf >= 0 && bufloaded(l:refresh_buf)
+                call s:send_document_diagnostic_request(l:refresh_buf, a:server_name)
+            endif
+        endfor
     else
         " TODO: for now comment this out until we figure out a better solution.
         " We need to comment this out so that others outside of vim-lsp can


### PR DESCRIPTION
Follow-up to #1674. Respond to the `workspace/diagnostic/refresh` server-to-client request and re-send `textDocument/diagnostic` pull requests for all buffers open on that server, so servers can invalidate diagnostics across files (e.g. after configuration changes or inter-file dependencies). Verified with a mock server that switches diagnostics after sending the refresh request.