### PR TITLE
Add g:lsp_diagnostics_pull_enabled to advertise pull diagnostics capability

### DIFF
--- a/autoload/lsp.vim
+++ b/autoload/lsp.vim
@@ -554,7 +554,7 @@ endfunction
 
 function! lsp#default_get_supported_capabilities(server_info) abort
     " Sorted alphabetically
-    return {
+    let l:capabilities = {
     \   'textDocument': {
     \       'callHierarchy': {
     \           'dynamicRegistration': v:false,
@@ -692,6 +692,10 @@ function! lsp#default_get_supported_capabilities(server_info) abort
     \       'workspaceFolders': g:lsp_experimental_workspace_folders ? v:true : v:false,
     \   },
     \ }
+    if g:lsp_diagnostics_pull_enabled
+        let l:capabilities['textDocument']['diagnostic'] = { 'dynamicRegistration': v:false }
+    endif
+    return l:capabilities
 endfunction
 
 function! s:ensure_init(buf, server_name, cb) abort

--- a/doc/vim-lsp.txt
+++ b/doc/vim-lsp.txt
@@ -39,6 +39,7 @@ CONTENTS                                                  *vim-lsp-contents*
 			     |g:lsp_diagnostics_highlights_insert_mode_enabled|
       g:lsp_diagnostics_highlights_delay
 			     |g:lsp_diagnostics_highlights_delay|
+      g:lsp_diagnostics_pull_enabled        |g:lsp_diagnostics_pull_enabled|
       g:lsp_diagnostics_signs_enabled       |g:lsp_diagnostics_signs_enabled|
       g:lsp_diagnostics_signs_insert_mode_enabled
 			     |g:lsp_diagnostics_signs_insert_mode_enabled|
@@ -625,6 +626,21 @@ g:lsp_diagnostics_highlights_delay	   *g:lsp_diagnostics_highlights_delay*
     Example: >
 	let g:lsp_diagnostics_highlights_delay = 200
 	let g:lsp_diagnostics_highlights_delay = 1000
+
+g:lsp_diagnostics_pull_enabled		       *g:lsp_diagnostics_pull_enabled*
+    Type: |Number|
+    Default: `0`
+
+    Advertise the `textDocument.diagnostic` client capability so that servers
+    supporting pull diagnostics (`textDocument/diagnostic`) enable it. Some
+    servers such as vscode-eslint-language-server deliver diagnostics only via
+    pull when the client declares this capability. vim-lsp sends pull requests
+    automatically whenever a server advertises `diagnosticProvider`,
+    regardless of this option. Requires |g:lsp_diagnostics_enabled| set to 1.
+
+    Example: >
+	let g:lsp_diagnostics_pull_enabled = 1
+	let g:lsp_diagnostics_pull_enabled = 0
 
 g:lsp_diagnostics_signs_enabled
 					      *g:lsp_diagnostics_signs_enabled*

--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -25,6 +25,7 @@ let g:lsp_diagnostics_float_insert_mode_enabled = get(g:, 'lsp_diagnostics_float
 let g:lsp_diagnostics_highlights_enabled = get(g:, 'lsp_diagnostics_highlights_enabled', lsp#utils#_has_highlights())
 let g:lsp_diagnostics_highlights_insert_mode_enabled = get(g:, 'lsp_diagnostics_highlights_insert_mode_enabled', 1)
 let g:lsp_diagnostics_highlights_delay = get(g:, 'lsp_diagnostics_highlights_delay', 500)
+let g:lsp_diagnostics_pull_enabled = get(g:, 'lsp_diagnostics_pull_enabled', 0)
 let g:lsp_diagnostics_signs_enabled = get(g:, 'lsp_diagnostics_signs_enabled', lsp#utils#_has_signs())
 let g:lsp_diagnostics_signs_insert_mode_enabled = get(g:, 'lsp_diagnostics_signs_insert_mode_enabled', 1)
 let g:lsp_diagnostics_signs_delay = get(g:, 'lsp_diagnostics_signs_delay', 500)

--- a/test/lsp.vimspec
+++ b/test/lsp.vimspec
@@ -1,0 +1,17 @@
+Describe lsp#default_get_supported_capabilities
+    After each
+        let g:lsp_diagnostics_pull_enabled = 0
+    End
+
+    It should not declare textDocument.diagnostic capability by default
+        let g:lsp_diagnostics_pull_enabled = 0
+        let l:caps = lsp#default_get_supported_capabilities({})
+        Assert False(has_key(l:caps['textDocument'], 'diagnostic'))
+    End
+
+    It should declare textDocument.diagnostic capability when pull diagnostics is enabled
+        let g:lsp_diagnostics_pull_enabled = 1
+        let l:caps = lsp#default_get_supported_capabilities({})
+        Assert Equals(l:caps['textDocument']['diagnostic'], { 'dynamicRegistration': v:false })
+    End
+End


### PR DESCRIPTION
Follow-up to #1674. Spec-compliant servers such as vscode-eslint-language-server advertise `diagnosticProvider` (and switch to pull diagnostics) only when the client declares the `textDocument.diagnostic` capability, which vim-lsp never sent. This adds `g:lsp_diagnostics_pull_enabled` (default off for backward compatibility) to include the capability in the default client capabilities.

Verified with a mock server that advertises `diagnosticProvider` only when the client declares the capability: with the option on, diagnostics are pulled and displayed; with it off, behavior is unchanged.

Closes #1532