### PR TITLE
Fix hover popup fallback position

### DIFF
--- a/autoload/lsp/internal/document_hover/under_cursor.vim
+++ b/autoload/lsp/internal/document_hover/under_cursor.vim
@@ -271,7 +271,11 @@ function! s:compute_position(size) abort
     let l:pos = screenpos(0, line('.'), col('.'))
     if l:pos.row == 0 && l:pos.col == 0
         " workaround for float position
-        let l:pos = {'curscol': wincol(), 'row': winline()}
+        let l:winpos = win_screenpos(win_getid())
+        let l:pos = {
+            \ 'curscol': l:winpos[1] + wincol() - 1,
+            \ 'row': l:winpos[0] + winline() - 1,
+            \ }
     endif
     let l:pos = [l:pos.row + 1, l:pos.curscol + 1]
     if l:pos[0] + a:size.height > &lines
@@ -282,4 +286,3 @@ function! s:compute_position(size) abort
     endif
     return l:pos
 endfunction
-


### PR DESCRIPTION
## Problem
screenpos() returns screen-relative coordinates, but the fallback logic used wincol() and winline(), which are relative to the current window. When multiple windows exist in the tab, this could place hover popups in incorrect locations when screenpos() returns zero and triggers the fallback logic.

## Solution
Convert the fallback coordinates to screen coordinates using win_screenpos().


| Before | After |
 |:---:|:---:|
|<img width="350" alt="faulty" src="https://github.com/user-attachments/assets/14628b91-1c61-4ea0-91d9-8a6d0406b146" /> | <img width="350" alt="fixed" src="https://github.com/user-attachments/assets/ca1ecd9a-bbfa-4317-bc7d-13ccb1553b88" /> |